### PR TITLE
feat(resp): add AUTH command with --require-pass server password

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -41,6 +41,7 @@ type Config struct {
 	tlsCert           string
 	tlsKey            string
 	tlsCA             string
+	requirePass       string
 }
 
 func getEnv[T any](key string, fallback T) T {
@@ -116,6 +117,7 @@ func getEnv[T any](key string, fallback T) T {
 //		TSD_TLS_CERT         – path to TLS certificate file (PEM; empty = TLS disabled)
 //		TSD_TLS_KEY          – path to TLS private key file (PEM)
 //		TSD_TLS_CA           – path to CA certificate for client verification (enables mTLS)
+//		TSD_REQUIRE_PASS     – server password required by AUTH (empty = no authentication)
 //
 // args are the command-line arguments to parse (typically os.Args[1:]); pass nil for an
 // environment-only / default configuration. A fresh flag.FlagSet is used so LoadConfig is
@@ -270,6 +272,13 @@ func LoadConfig(args []string) *Config {
 		getEnv("TSD_TLS_CA", ""),
 		"Path to CA certificate for client verification (PEM); enables mTLS when set",
 	)
+	// Optional server password enforced via the RESP AUTH command.
+	fs.StringVar(
+		&cfg.requirePass,
+		"require-pass",
+		getEnv("TSD_REQUIRE_PASS", ""),
+		"Password clients must supply via AUTH; empty disables authentication (default: none)",
+	)
 	// Custom usage output to guide operators.
 	fs.Usage = func() {
 		println("Tellstone server – high-performance in-memory database")
@@ -319,6 +328,7 @@ func (cfg *Config) TLSEnabled() bool                  { return cfg.tlsCert != ""
 func (cfg *Config) GetTLSCert() string                { return cfg.tlsCert }
 func (cfg *Config) GetTLSKey() string                 { return cfg.tlsKey }
 func (cfg *Config) GetTLSCA() string                  { return cfg.tlsCA }
+func (cfg *Config) GetRequirePass() string            { return cfg.requirePass }
 func (cfg *Config) MTLSEnabled() bool {
 	return cfg.tlsCert != "" && cfg.tlsKey != "" && cfg.tlsCA != ""
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -317,3 +317,25 @@ func TestTLSFlagsOverrideEnvVars(t *testing.T) {
 		t.Fatalf("flag should override env for key: %s", cfg.GetTLSKey())
 	}
 }
+
+func TestRequirePassDefaultEmpty(t *testing.T) {
+	cfg := LoadConfig(nil)
+	if cfg.GetRequirePass() != "" {
+		t.Fatalf("require-pass should default to empty, got %q", cfg.GetRequirePass())
+	}
+}
+
+func TestRequirePassFlag(t *testing.T) {
+	cfg := LoadConfig([]string{"--require-pass", "hunter2"})
+	if cfg.GetRequirePass() != "hunter2" {
+		t.Fatalf("require-pass flag mismatch: %q", cfg.GetRequirePass())
+	}
+}
+
+func TestRequirePassEnvVar(t *testing.T) {
+	t.Setenv("TSD_REQUIRE_PASS", "envpass")
+	cfg := LoadConfig(nil)
+	if cfg.GetRequirePass() != "envpass" {
+		t.Fatalf("require-pass env mismatch: %q", cfg.GetRequirePass())
+	}
+}

--- a/internal/resp/benchmark_test.go
+++ b/internal/resp/benchmark_test.go
@@ -64,11 +64,12 @@ func BenchmarkDispatchGetHit(b *testing.B) {
 	store := newFakeStore()
 	_ = store.Set("k", []byte("benchmark_value"), 0)
 	srv := &Server{store: store, logger: log.NewNoOpLogger()}
+	st := &connState{authenticated: true}
 	args := [][]byte{[]byte("GET"), []byte("k")}
 	out := make([]byte, 0, 128)
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		out = srv.dispatch(args, out[:0])
+		out = srv.dispatch(st, args, out[:0])
 	}
 }
 
@@ -76,11 +77,12 @@ func BenchmarkDispatchGetHit(b *testing.B) {
 func BenchmarkDispatchSet(b *testing.B) {
 	store := newFakeStore()
 	srv := &Server{store: store, logger: log.NewNoOpLogger()}
+	st := &connState{authenticated: true}
 	args := [][]byte{[]byte("SET"), []byte("k"), []byte("benchmark_value")}
 	out := make([]byte, 0, 128)
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		out = srv.dispatch(args, out[:0])
+		out = srv.dispatch(st, args, out[:0])
 	}
 }
 
@@ -91,10 +93,11 @@ func BenchmarkDispatchSetParallel(b *testing.B) {
 	srv := &Server{store: store, logger: log.NewNoOpLogger()}
 	b.ReportAllocs()
 	b.RunParallel(func(pb *testing.PB) {
+		st := &connState{authenticated: true}
 		args := [][]byte{[]byte("SET"), []byte("k"), []byte("benchmark_value")}
 		out := make([]byte, 0, 128)
 		for pb.Next() {
-			out = srv.dispatch(args, out[:0])
+			out = srv.dispatch(st, args, out[:0])
 		}
 	})
 }

--- a/internal/resp/server.go
+++ b/internal/resp/server.go
@@ -50,6 +50,9 @@ type connState struct {
 	handshakeDeadline time.Time
 	authenticated     bool
 	remoteAddr        string
+	// closeAfterReply is set by dispatch (QUIT) so the traffic loop flushes the pending
+	// replies and then returns gnet.Close instead of keeping the connection open.
+	closeAfterReply bool
 }
 
 // Server is an edge-triggered RESP2 listener backed by gnet.
@@ -249,6 +252,10 @@ func (s *Server) handleDecryptedResp(st *connState, c gnet.Conn) gnet.Action {
 		st.args = args[:0]
 		consumed += n
 		st.out = s.dispatch(st, args, st.out)
+		if st.closeAfterReply {
+			// QUIT: stop parsing pipelined commands; flush replies, then close below.
+			break
+		}
 	}
 	if consumed == 0 {
 		return gnet.None
@@ -270,6 +277,9 @@ func (s *Server) handleDecryptedResp(st *connState, c gnet.Conn) gnet.Action {
 	}
 	remaining := copy(st.readBuf, st.readBuf[consumed:])
 	st.readBuf = st.readBuf[:remaining]
+	if st.closeAfterReply {
+		return gnet.Close
+	}
 	return gnet.None
 }
 
@@ -298,6 +308,10 @@ func (s *Server) onTrafficPlaintext(c gnet.Conn, st *connState) gnet.Action {
 		st.args = args[:0]
 		consumed += n
 		st.out = s.dispatch(st, args, st.out)
+		if st.closeAfterReply {
+			// QUIT: stop parsing pipelined commands; flush replies, then close below.
+			break
+		}
 	}
 	if consumed == 0 {
 		return gnet.None
@@ -319,6 +333,9 @@ func (s *Server) onTrafficPlaintext(c gnet.Conn, st *connState) gnet.Action {
 	atomic.AddUint64(&s.bytesRead, n)
 	if st.shardID >= 0 && st.shardID < len(s.shards) {
 		s.shards[st.shardID].AddBytesRead(n)
+	}
+	if st.closeAfterReply {
+		return gnet.Close
 	}
 	return gnet.None
 }
@@ -390,6 +407,10 @@ func (s *Server) dispatch(st *connState, args [][]byte, out []byte) []byte {
 		// redis-cli / some tools probe COMMAND DOCS|COUNT at startup; an empty array keeps
 		// the session alive without implementing the introspection surface.
 		return append(out, "*0\r\n"...)
+
+	case EqualFold(cmd, "QUIT"):
+		st.closeAfterReply = true
+		return append(out, respOK...)
 
 	default:
 		return AppendError(out, "ERR unknown command '"+string(cmd)+"'")

--- a/internal/resp/server.go
+++ b/internal/resp/server.go
@@ -3,10 +3,12 @@ Package resp
 Tellstone Redis-Compatible Wire Protocol
 File: server.go
 Description: Optional gnet event-loop server speaking RESP2, reusing the shared storage engine
-via a small Store interface. Supports PING, GET, SET (with optional EX/PX), and DEL; unknown
-commands return an error without dropping the connection. Exists so Tellstone can be driven by
-standard Redis tooling (redis-benchmark, memtier_benchmark) for cross-system comparison.
-Supports optional TLS 1.3 transport encryption via the internal TLS library.
+via a small Store interface. Supports PING, GET, SET (with optional EX/PX), DEL, and AUTH;
+unknown commands return an error without dropping the connection. Exists so Tellstone can be
+driven by standard Redis tooling (redis-benchmark, memtier_benchmark) for cross-system
+comparison. Supports optional TLS 1.3 transport encryption via the internal TLS library.
+When a server password is configured (--require-pass / TSD_REQUIRE_PASS), connections must
+authenticate via AUTH before issuing commands other than PING and QUIT.
 
 Authors:
 
@@ -26,6 +28,7 @@ import (
 	"github.com/Saxy/Tellstone/internal/shard"
 	tlslib "github.com/Saxy/Tellstone/internal/tls"
 	"github.com/panjf2000/gnet/v2"
+	"golang.org/x/crypto/bcrypt"
 )
 
 // Store is the subset of the storage engine the RESP server needs. *storage.Engine satisfies
@@ -45,6 +48,8 @@ type connState struct {
 	tlsConn           *tlslib.Conn
 	readBuf           []byte
 	handshakeDeadline time.Time
+	authenticated     bool
+	remoteAddr        string
 }
 
 // Server is an edge-triggered RESP2 listener backed by gnet.
@@ -66,22 +71,38 @@ type Server struct {
 	protocolErrors   uint64
 	shards           []*shard.Shard
 	nextConn         uint64
+	// requirePassHash is the bcrypt hash of the server password. nil means AUTH is not
+	// required and every connection starts authenticated (zero-overhead no-op path).
+	requirePassHash []byte
 }
 
 // NewServer creates a RESP server bound to addr that dispatches commands to store.
 // shards is optional — if nil, per-shard metrics are not tracked.
 // tlsCfg is optional — if nil, plaintext TCP is used.
-func NewServer(addr string, store Store, shards []*shard.Shard, logger log.Logger, tlsCfg *tlslib.Config) *Server {
+// requirePass is optional — if empty, AUTH is a no-op and connections start authenticated;
+// otherwise it is hashed once at startup and clients must AUTH before issuing commands.
+func NewServer(addr string, store Store, shards []*shard.Shard, logger log.Logger, tlsCfg *tlslib.Config, requirePass string) *Server {
 	if logger == nil {
 		logger = log.NewNoOpLogger()
 	}
+	var passHash []byte
+	if requirePass != "" {
+		var err error
+		passHash, err = bcrypt.GenerateFromPassword([]byte(requirePass), bcrypt.DefaultCost)
+		if err != nil {
+			// bcrypt only fails on invalid cost or a password over 72 bytes — a
+			// misconfiguration that must surface at startup, not at first AUTH.
+			panic("resp: invalid --require-pass value: " + err.Error())
+		}
+	}
 	return &Server{
-		addr:      addr,
-		store:     store,
-		shards:    shards,
-		logger:    logger,
-		tlsConfig: tlsCfg,
-		ready:     make(chan struct{}),
+		addr:            addr,
+		store:           store,
+		shards:          shards,
+		logger:          logger,
+		tlsConfig:       tlsCfg,
+		requirePassHash: passHash,
+		ready:           make(chan struct{}),
 	}
 }
 
@@ -123,9 +144,11 @@ func (s *Server) OnOpen(c gnet.Conn) (out []byte, action gnet.Action) {
 		s.shards[sid].IncTotalConnections()
 	}
 	st := &connState{
-		out:     make([]byte, 0, 4096),
-		args:    make([][]byte, 0, 8),
-		shardID: shardID,
+		out:           make([]byte, 0, 4096),
+		args:          make([][]byte, 0, 8),
+		shardID:       shardID,
+		authenticated: s.requirePassHash == nil,
+		remoteAddr:    c.RemoteAddr().String(),
 	}
 	if s.tlsConfig != nil {
 		adapter := tlslib.NewGnetConnAdapter(c)
@@ -151,7 +174,12 @@ func (s *Server) OnClose(c gnet.Conn, err error) (action gnet.Action) {
 func (s *Server) OnTraffic(c gnet.Conn) gnet.Action {
 	st, _ := c.Context().(*connState)
 	if st == nil {
-		st = &connState{out: make([]byte, 0, 4096), args: make([][]byte, 0, 8)}
+		st = &connState{
+			out:           make([]byte, 0, 4096),
+			args:          make([][]byte, 0, 8),
+			authenticated: s.requirePassHash == nil,
+			remoteAddr:    c.RemoteAddr().String(),
+		}
 		c.SetContext(st)
 	}
 
@@ -220,7 +248,7 @@ func (s *Server) handleDecryptedResp(st *connState, c gnet.Conn) gnet.Action {
 		}
 		st.args = args[:0]
 		consumed += n
-		st.out = s.dispatch(args, st.out)
+		st.out = s.dispatch(st, args, st.out)
 	}
 	if consumed == 0 {
 		return gnet.None
@@ -269,7 +297,7 @@ func (s *Server) onTrafficPlaintext(c gnet.Conn, st *connState) gnet.Action {
 		}
 		st.args = args[:0]
 		consumed += n
-		st.out = s.dispatch(args, st.out)
+		st.out = s.dispatch(st, args, st.out)
 	}
 	if consumed == 0 {
 		return gnet.None
@@ -300,11 +328,18 @@ func (s *Server) onTrafficPlaintext(c gnet.Conn, st *connState) gnet.Action {
 // Lookup keys use a zero-copy unsafe string over the argument bytes (which alias the gnet read
 // buffer): this is safe because Get does not retain the key, and Set clones the key and copies
 // the value before storing them.
-func (s *Server) dispatch(args [][]byte, out []byte) []byte {
+func (s *Server) dispatch(st *connState, args [][]byte, out []byte) []byte {
 	if len(args) == 0 {
 		return AppendError(out, "ERR empty command")
 	}
 	cmd := args[0]
+	if EqualFold(cmd, shard.CmdAuth) {
+		return s.auth(st, args, out)
+	}
+	// Unauthenticated connections may only issue AUTH, PING, and QUIT (Redis semantics).
+	if !st.authenticated && !EqualFold(cmd, shard.CmdPing) && !EqualFold(cmd, "QUIT") {
+		return AppendError(out, "NOAUTH Authentication required")
+	}
 	switch {
 	case EqualFold(cmd, shard.CmdGet):
 		if len(args) != 2 {
@@ -359,6 +394,38 @@ func (s *Server) dispatch(args [][]byte, out []byte) []byte {
 	default:
 		return AppendError(out, "ERR unknown command '"+string(cmd)+"'")
 	}
+}
+
+// auth handles the AUTH command in both single-password (AUTH <password>) and ACL
+// (AUTH <username> <password>) forms. When no server password is configured, AUTH is a
+// backward-compatible no-op that replies +OK. bcrypt comparison happens only here, never
+// on the hot path.
+func (s *Server) auth(st *connState, args [][]byte, out []byte) []byte {
+	if len(args) != 2 && len(args) != 3 {
+		return AppendError(out, "ERR wrong number of arguments for 'auth' command")
+	}
+	if s.requirePassHash == nil {
+		return append(out, respOK...)
+	}
+	// Only the implicit "default" user exists until an ACL system lands (issue #9).
+	if len(args) == 3 && string(args[1]) != "default" {
+		return s.authFailed(st, out)
+	}
+	if bcrypt.CompareHashAndPassword(s.requirePassHash, args[len(args)-1]) != nil {
+		return s.authFailed(st, out)
+	}
+	st.authenticated = true
+	return append(out, respOK...)
+}
+
+// authFailed logs a rejected AUTH attempt and appends the RESP error reply.
+func (s *Server) authFailed(st *connState, out []byte) []byte {
+	if s.logger.Enabled(log.LevelWarn) {
+		s.logger.Log(log.LevelWarn, "resp: failed AUTH attempt",
+			log.String("remote_addr", st.remoteAddr),
+		)
+	}
+	return AppendError(out, "ERR invalid password")
 }
 
 // parseSetTTL extracts the TTL from a SET command. Returns (0, true) for a plain 3-arg SET,

--- a/internal/resp/server_test.go
+++ b/internal/resp/server_test.go
@@ -54,7 +54,7 @@ func freeAddr(t *testing.T) string {
 
 func TestRESPServer_GetSetPingPipeline(t *testing.T) {
 	addr := freeAddr(t)
-	srv := NewServer(addr, newFakeStore(), nil, log.NewNoOpLogger(), nil)
+	srv := NewServer(addr, newFakeStore(), nil, log.NewNoOpLogger(), nil, "")
 	go func() { _ = srv.ListenAndServe() }()
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -88,6 +88,105 @@ func TestRESPServer_GetSetPingPipeline(t *testing.T) {
 	expect("pipeline",
 		"*3\r\n$3\r\nSET\r\n$1\r\np\r\n$2\r\nhi\r\n*2\r\n$3\r\nGET\r\n$1\r\np\r\n",
 		"+OK\r\n$2\r\nhi\r\n")
+}
+
+// expectReply writes send on conn and asserts the exact reply bytes.
+func expectReply(t *testing.T, conn net.Conn, name, send, want string) {
+	t.Helper()
+	if _, err := conn.Write([]byte(send)); err != nil {
+		t.Fatalf("%s write: %v", name, err)
+	}
+	got := make([]byte, len(want))
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, err := io.ReadFull(conn, got); err != nil {
+		t.Fatalf("%s read: %v", name, err)
+	}
+	if string(got) != want {
+		t.Fatalf("%s: got %q want %q", name, got, want)
+	}
+}
+
+func startServer(t *testing.T, requirePass string) (addr string) {
+	t.Helper()
+	addr = freeAddr(t)
+	srv := NewServer(addr, newFakeStore(), nil, log.NewNoOpLogger(), nil, requirePass)
+	go func() { _ = srv.ListenAndServe() }()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = gnet.Stop(ctx, "tcp://"+addr)
+	})
+	return addr
+}
+
+func TestRESPServer_AuthRequired(t *testing.T) {
+	addr := startServer(t, "sekret")
+
+	conn := dialWithRetry(t, addr)
+	defer conn.Close()
+
+	expectReply(t, conn, "GET before auth",
+		"*2\r\n$3\r\nGET\r\n$1\r\nk\r\n", "-NOAUTH Authentication required\r\n")
+	expectReply(t, conn, "SET before auth",
+		"*3\r\n$3\r\nSET\r\n$1\r\nk\r\n$1\r\nv\r\n", "-NOAUTH Authentication required\r\n")
+	expectReply(t, conn, "PING before auth",
+		"*1\r\n$4\r\nPING\r\n", "+PONG\r\n")
+	expectReply(t, conn, "AUTH wrong password",
+		"*2\r\n$4\r\nAUTH\r\n$5\r\nwrong\r\n", "-ERR invalid password\r\n")
+	expectReply(t, conn, "GET after failed auth",
+		"*2\r\n$3\r\nGET\r\n$1\r\nk\r\n", "-NOAUTH Authentication required\r\n")
+	expectReply(t, conn, "AUTH correct password",
+		"*2\r\n$4\r\nAUTH\r\n$6\r\nsekret\r\n", "+OK\r\n")
+	expectReply(t, conn, "SET after auth",
+		"*3\r\n$3\r\nSET\r\n$1\r\nk\r\n$1\r\nv\r\n", "+OK\r\n")
+	expectReply(t, conn, "GET after auth",
+		"*2\r\n$3\r\nGET\r\n$1\r\nk\r\n", "$1\r\nv\r\n")
+
+	// Auth state is per-connection: a fresh connection must authenticate again.
+	conn2 := dialWithRetry(t, addr)
+	defer conn2.Close()
+	expectReply(t, conn2, "GET on second conn",
+		"*2\r\n$3\r\nGET\r\n$1\r\nk\r\n", "-NOAUTH Authentication required\r\n")
+}
+
+func TestRESPServer_AuthWithUsername(t *testing.T) {
+	addr := startServer(t, "sekret")
+
+	conn := dialWithRetry(t, addr)
+	defer conn.Close()
+
+	expectReply(t, conn, "AUTH wrong username",
+		"*3\r\n$4\r\nAUTH\r\n$5\r\nadmin\r\n$6\r\nsekret\r\n", "-ERR invalid password\r\n")
+	expectReply(t, conn, "AUTH default user",
+		"*3\r\n$4\r\nAUTH\r\n$7\r\ndefault\r\n$6\r\nsekret\r\n", "+OK\r\n")
+	expectReply(t, conn, "GET after auth",
+		"*2\r\n$3\r\nGET\r\n$1\r\nk\r\n", "$-1\r\n")
+}
+
+func TestRESPServer_AuthNoPasswordConfigured(t *testing.T) {
+	addr := startServer(t, "")
+
+	conn := dialWithRetry(t, addr)
+	defer conn.Close()
+
+	// Without --require-pass every connection starts authenticated and AUTH is a no-op.
+	expectReply(t, conn, "GET without auth",
+		"*2\r\n$3\r\nGET\r\n$1\r\nk\r\n", "$-1\r\n")
+	expectReply(t, conn, "AUTH no-op",
+		"*2\r\n$4\r\nAUTH\r\n$8\r\nwhatever\r\n", "+OK\r\n")
+}
+
+func TestRESPServer_AuthWrongArity(t *testing.T) {
+	addr := startServer(t, "sekret")
+
+	conn := dialWithRetry(t, addr)
+	defer conn.Close()
+
+	expectReply(t, conn, "AUTH no args",
+		"*1\r\n$4\r\nAUTH\r\n", "-ERR wrong number of arguments for 'auth' command\r\n")
+	expectReply(t, conn, "AUTH too many args",
+		"*4\r\n$4\r\nAUTH\r\n$1\r\na\r\n$1\r\nb\r\n$1\r\nc\r\n",
+		"-ERR wrong number of arguments for 'auth' command\r\n")
 }
 
 func dialWithRetry(t *testing.T, addr string) net.Conn {

--- a/internal/resp/server_test.go
+++ b/internal/resp/server_test.go
@@ -114,7 +114,7 @@ func startServer(t *testing.T, requirePass string) (addr string) {
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
-		_ = gnet.Stop(ctx, "tcp://"+addr)
+		_ = srv.Shutdown(ctx)
 	})
 	return addr
 }
@@ -147,6 +147,22 @@ func TestRESPServer_AuthRequired(t *testing.T) {
 	defer conn2.Close()
 	expectReply(t, conn2, "GET on second conn",
 		"*2\r\n$3\r\nGET\r\n$1\r\nk\r\n", "-NOAUTH Authentication required\r\n")
+}
+
+func TestRESPServer_QuitPreAuth(t *testing.T) {
+	addr := startServer(t, "sekret")
+
+	conn := dialWithRetry(t, addr)
+	defer conn.Close()
+
+	// QUIT is allowed before authentication and must close the connection after +OK.
+	expectReply(t, conn, "QUIT before auth", "*1\r\n$4\r\nQUIT\r\n", "+OK\r\n")
+	if err := conn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("QUIT deadline: %v", err)
+	}
+	if _, err := conn.Read(make([]byte, 1)); err != io.EOF {
+		t.Fatalf("expected EOF after QUIT, got %v", err)
+	}
 }
 
 func TestRESPServer_AuthWithUsername(t *testing.T) {

--- a/internal/shard/runner.go
+++ b/internal/shard/runner.go
@@ -29,6 +29,7 @@ const (
 	CmdDel     string = "DEL"
 	CmdPing    string = "PING"
 	CmdCommand string = "COMMAND"
+	CmdAuth    string = "AUTH"
 )
 
 type Shard struct {

--- a/server/server.go
+++ b/server/server.go
@@ -251,7 +251,7 @@ func (s *Server) startRESPServer() {
 	cfg := s.app.GetConfig()
 	logger := s.app.GetLogger()
 	store := &RouterStore{router: s.router}
-	respSrv := resp.NewServer(cfg.GetRESPAddr(), store, s.shards, logger, s.tlsConfig)
+	respSrv := resp.NewServer(cfg.GetRESPAddr(), store, s.shards, logger, s.tlsConfig, cfg.GetRequirePass())
 	s.respSrv = respSrv
 	go func() {
 		if err := respSrv.ListenAndServe(); err != nil {


### PR DESCRIPTION
## Description

Implements the Redis-compatible `AUTH` command for the RESP listener, with a new `--require-pass` / `TSD_REQUIRE_PASS` server password option.

- `AUTH <password>` (single-password mode, Redis < 6.0 compatible) and `AUTH <username> <password>` (ACL form — only the implicit `default` user exists until #9 lands)
- Replies `+OK` on success, `-ERR invalid password` on failure, per the Redis AUTH spec
- Unauthenticated connections may only issue `AUTH`, `PING`, and `QUIT`; everything else gets `-NOAUTH Authentication required`
- When no password is configured, `AUTH` is a `+OK` no-op and every connection starts authenticated — fully backward compatible
- Failed AUTH attempts are logged at warn level with the remote address, mirroring the existing malformed-frame log

**Component:** Networking/RESP, CLI

**Type of Change:**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance optimization (no change in behavior, improved speed/memory)
- [ ] Refactoring (no functional changes, code cleanup)
- [ ] Build / CI / Documentation

---

## Related Issue

Closes #7

---

## Technical Deep Dive & Context

The implementation follows the touch points laid out in the issue:

- **Password hashing off the hot path.** The password is hashed once at startup with `bcrypt.GenerateFromPassword` (stored as `[]byte` on `Server`); `bcrypt.CompareHashAndPassword` runs only inside the `AUTH` handler. GET/SET/DEL never touch bcrypt. bcrypt's cost factor also acts as a natural brute-force rate limit on AUTH attempts. No new dependency — `golang.org/x/crypto` is already a direct dependency (TLS, ChaCha20).
- **Per-connection auth state.** `connState` gains `authenticated bool` (plus `remoteAddr`, captured once in `OnOpen` so the failed-AUTH log path allocates nothing per attempt). State initializes to `true` when no password is configured, `false` otherwise. Works identically on the plaintext and TLS traffic paths since both funnel through `dispatch`.
- **Zero-overhead guarantee.** With `--require-pass` unset the per-command cost is one `EqualFold(cmd, "AUTH")` length-check-first comparison and a single bool test that short-circuits. Dispatch benchmarks confirm no measurable change and no new allocations (table below).
- **Guard placement.** `AUTH` is checked before the auth guard so unauthenticated clients can always authenticate; the guard then allow-lists `PING`/`QUIT` per Redis semantics before the command switch.
- **`dispatch` signature** changed from `dispatch(args, out)` to `dispatch(st, args, out)` to carry connection state; benchmarks updated accordingly.
- **Trade-off:** the two-arg ACL form rejects any username other than `default` (byte-equal, case-sensitive like Redis) with the same `-ERR invalid password` reply, so usernames aren't oracle-able. A real ACL system is deferred to #9.

---

## Performance & Benchmarks (If Applicable)

**Workload:** `go test -bench BenchmarkDispatch -benchmem -benchtime 3000000x -count 3` (Apple M4 Pro, best of 3)

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| DispatchGetHit | 15.43 ns/op, 0 allocs | 15.03 ns/op, 0 allocs | noise |
| DispatchSet | 26.30 ns/op, 1 alloc | 26.07 ns/op, 1 alloc | noise |
| DispatchSetParallel | 119.3 ns/op, 1 alloc | 117.4 ns/op, 1 alloc | noise |

No measurable change; zero new allocations on the hot path. (The 1 alloc on Set is the pre-existing fakeStore key copy in the benchmark harness, unchanged.)

```text
BenchmarkDispatchGetHit-12          3000000    15.03 ns/op    0 B/op    0 allocs/op
BenchmarkDispatchSet-12             3000000    26.07 ns/op   16 B/op    1 allocs/op
BenchmarkDispatchSetParallel-12     3000000   117.4 ns/op    16 B/op    1 allocs/op
```

---

## How Has This Been Tested?

Written test-first (tests were red before the implementation existed):

- `TestRESPServer_AuthRequired` — NOAUTH before auth, PING allowed pre-auth, wrong password rejected, correct password unlocks the connection, and auth state is per-connection (a second connection must re-authenticate)
- `TestRESPServer_AuthWithUsername` — `AUTH default <pass>` accepted, unknown username rejected
- `TestRESPServer_AuthNoPasswordConfigured` — no-op `+OK` path, commands work without auth
- `TestRESPServer_AuthWrongArity` — arity errors for 1 and 4 args
- Config tests for the `--require-pass` flag, `TSD_REQUIRE_PASS` env var, and empty default

`go test ./...`, `go test -race ./...`, and `go vet ./...` all pass locally with zero warnings.

---

## Checklist

- [x] My code follows the existing code style of this project
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally (`go test ./...` and `go test -race ./...`)
- [x] I have updated the documentation (README, comments, or any relevant docs)
- [x] My changes generate no new `go vet` warnings
- [x] Any breaking changes are documented and communicated

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional password protection for RESP connections.
  * Configure via `--require-pass` or `TSD_REQUIRE_PASS`; when enabled, clients must authenticate with `AUTH` before other commands.
  * Supports `AUTH <password>` and `AUTH default <password>`, with appropriate handling for wrong credentials, wrong argument counts, and username-based `AUTH`.
  * `PING` and `QUIT` remain available before authentication.
* **Bug Fixes**
  * Authentication enforcement is now consistent for plaintext and TLS connections.
* **Tests**
  * Added unit tests for defaults, CLI/env configuration, and authentication/session behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->