### PR TITLE
feat(network): #8 add AUTH handshake for binary protocol

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -141,6 +141,14 @@ tasks:
         fi
 
   # ---------- benchmarks (self-contained: start pinned server, load, clean up) ----------
+  bench:go:
+    desc: "Run Go package benchmarks. Vars: PKG (default ./...), BENCH (default .), COUNT (default 1)"
+    vars:
+      PKG: '{{.PKG | default "./..."}}'
+      BENCH: '{{.BENCH | default "."}}'
+      COUNT: '{{.COUNT | default "1"}}'
+    cmds:
+      - go test -bench={{.BENCH}} -benchmem -count={{.COUNT}} -run='^$' {{.PKG}}
   bench:native:
     desc: Native binary-protocol benchmark, server & client pinned to disjoint cores (Linux only)
     deps: [ build, build:bench ]

--- a/client/client.go
+++ b/client/client.go
@@ -65,6 +65,16 @@ func (c *Client) Delete(key []byte, scratchBuf []byte) ([]byte, error) {
 	return c.c.Delete(key, scratchBuf)
 }
 
+// Auth authenticates the client with a password (single-password mode).
+// Must be called after Dial/DialTLS when the server has --require-pass set.
+// scratchBuf must be large enough to hold the server response.
+func (c *Client) Auth(password string, scratchBuf []byte) error {
+	if err := c.valid(); err != nil {
+		return err
+	}
+	return c.c.Auth(password, scratchBuf)
+}
+
 func (c *Client) valid() error {
 	if c == nil || c.c == nil {
 		return ErrClientClosed

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -23,7 +23,7 @@ func TestCollectorEngineSnapshot(t *testing.T) {
 		t.Fatalf("expected key to exist after Set")
 	}
 	// Create a dummy network server (no handler, no activity).
-	srv := network.NewServer("", 0, nil, nil, log.NewNoOpLogger(), nil)
+	srv := network.NewServer("", 0, nil, nil, log.NewNoOpLogger(), nil, "")
 
 	col := NewCollector(eng, srv, log.NewNoOpLogger())
 	snap := col.GetEngineSnapshot()

--- a/internal/network/benchmark_tls_test.go
+++ b/internal/network/benchmark_tls_test.go
@@ -39,7 +39,7 @@ func startBenchServer(b *testing.B, handler func(msg *Message) ([]byte, MessageT
 	addr := l.Addr().String()
 	l.Close()
 
-	srv := NewServer(addr, 0, nil, handler, log.NewNoOpLogger(), nil)
+	srv := NewServer(addr, 0, nil, handler, log.NewNoOpLogger(), nil, "")
 	go func() { _ = srv.ListenAndServe() }()
 	if err := waitForServer(addr, 2*time.Second); err != nil {
 		b.Fatalf("server not ready: %v", err)
@@ -88,7 +88,7 @@ func startBenchTLSServer(b *testing.B, handler func(msg *Message) ([]byte, Messa
 	addr := l.Addr().String()
 	l.Close()
 
-	srv := NewServer(addr, 0, nil, handler, log.NewNoOpLogger(), tlsCfg)
+	srv := NewServer(addr, 0, nil, handler, log.NewNoOpLogger(), tlsCfg, "")
 	go func() {
 		_ = srv.ListenAndServe()
 	}()

--- a/internal/network/client.go
+++ b/internal/network/client.go
@@ -163,6 +163,28 @@ func (c *Client) Delete(key []byte, scratchBuf []byte) ([]byte, error) {
 	return resp.Value, nil
 }
 
+// Auth authenticates the client with a password (single-password mode, username empty).
+// scratchBuf must be large enough to hold the server response. Returns nil on success.
+func (c *Client) Auth(password string, scratchBuf []byte) error {
+	payloadLen := 2 + 0 + 2 + len(password)
+	var reqBuf [512]byte
+	if payloadLen > len(reqBuf) {
+		return ErrRequestTooLarge
+	}
+	binary.BigEndian.PutUint16(reqBuf[0:2], 0) // usernameLen = 0 (single-password mode)
+	binary.BigEndian.PutUint16(reqBuf[2:4], uint16(len(password)))
+	copy(reqBuf[4:payloadLen], password)
+
+	var resp Message
+	if err := c.Call(MsgAuth, reqBuf[:payloadLen], scratchBuf, &resp); err != nil {
+		return err
+	}
+	if resp.Type != MsgAuthOk {
+		return fmt.Errorf("auth failed: %s", resp.Value)
+	}
+	return nil
+}
+
 // Call executes a synchronous Request-Response cycle completely allocation-free.
 func (c *Client) Call(msgType MessageType, reqPayload []byte, buf []byte, out *Message) error {
 	if err := Write(c.conn, msgType, reqPayload); err != nil {

--- a/internal/network/protocol.go
+++ b/internal/network/protocol.go
@@ -24,6 +24,9 @@ const (
 	MsgPong
 	MsgRequest
 	MsgResponse
+	MsgAuth
+	MsgAuthOk
+	MsgAuthErr
 )
 
 // OpCode defines the backend database operation.
@@ -73,6 +76,7 @@ var (
 	ResponseEmptyKey       = []byte("ERR EMPTY_KEY")
 	ResponseStorageFailure = []byte("ERR STORAGE_FAILURE")
 	ResponseInvalidOpCode  = []byte("ERR INVALID_OPCODE")
+	ResponseAuthErr        = []byte("ERR INVALID_AUTH")
 )
 
 // Marshal encodes the Message into its binary wire format.

--- a/internal/network/protocol_test.go
+++ b/internal/network/protocol_test.go
@@ -19,7 +19,7 @@ const benchAddr = "127.0.0.1:9988"
 func TestMain(m *testing.M) {
 	srv := NewServer(benchAddr, 0, nil, func(msg *Message) ([]byte, MessageType, error) {
 		return msg.Payload, MsgResponse, nil
-	}, nil, nil)
+	}, nil, nil, "")
 
 	go func() {
 		_ = srv.ListenAndServe()

--- a/internal/network/server.go
+++ b/internal/network/server.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"sync"
 	"sync/atomic"
 
 	"github.com/Saxy/Tellstone/internal/log"
@@ -26,6 +27,13 @@ import (
 const defaultAddr = "127.0.0.1:9988"
 const defaultMaxMsgSize = 16 * 1024 * 1024
 const maxAuthFails = 3
+const numAuthWorkers = 4
+
+type authJob struct {
+	c        gnet.Conn
+	password []byte
+	passHash []byte
+}
 
 // connState holds per-connection state. When TLS is enabled, tlsConn wraps the
 // raw gnet connection with TLS 1.3 encryption via the internal TLS library. readBuf is a
@@ -37,6 +45,7 @@ type connState struct {
 	authenticated bool
 	remoteAddr    string
 	authFails     int
+	authPending   bool
 	closeAfterReply bool
 	tlsConn       *tlslib.Conn
 	readBuf       []byte
@@ -69,6 +78,9 @@ type Server struct {
 	// requirePassHash is the bcrypt hash of the server password. nil means AUTH is not
 	// required and every connection starts authenticated (zero-overhead no-op path).
 	requirePassHash []byte
+
+	authJobs chan authJob
+	workerWg sync.WaitGroup
 }
 
 // NewServer initializes an edge-triggered networking server engine instance.
@@ -107,6 +119,11 @@ func NewServer(addr string, maxMsgSize uint64, shards []*shard.Shard, handler fu
 		ready:           make(chan struct{}),
 		shards:          shards,
 		requirePassHash: passHash,
+		authJobs:        make(chan authJob, 256),
+	}
+	for i := 0; i < numAuthWorkers; i++ {
+		s.workerWg.Add(1)
+		go s.authWorker()
 	}
 	if s.logger.Enabled(log.LevelInfo) {
 		s.logger.Log(log.LevelInfo, "tcp server created", log.Int("max_msg_size", int(maxMsgSize)))
@@ -129,8 +146,12 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	select {
 	case <-s.ready:
 	case <-ctx.Done():
+		close(s.authJobs)
+		s.workerWg.Wait()
 		return ctx.Err()
 	}
+	close(s.authJobs)
+	s.workerWg.Wait()
 	return s.eng.Stop(ctx)
 }
 
@@ -196,7 +217,7 @@ func (s *Server) onTrafficTLS(c gnet.Conn, st *connState) gnet.Action {
 		n, err := st.tlsConn.Read(st.readBuf[len(st.readBuf):cap(st.readBuf)])
 		if n > 0 {
 			st.readBuf = st.readBuf[:len(st.readBuf)+n]
-			if action := s.handleDecryptedFrames(st); action != gnet.None {
+			if action := s.handleDecryptedFrames(c, st); action != gnet.None {
 				return action
 			}
 		}
@@ -218,7 +239,10 @@ func (s *Server) onTrafficTLS(c gnet.Conn, st *connState) gnet.Action {
 // from plaintext data and dispatches each to the handler. Responses are written
 // through the TLS connection for automatic encryption. It returns gnet.Close
 // on decode, handler, or TLS write errors so the caller propagates the close.
-func (s *Server) handleDecryptedFrames(st *connState) gnet.Action {
+func (s *Server) handleDecryptedFrames(c gnet.Conn, st *connState) gnet.Action {
+	if st.authPending {
+		return gnet.None
+	}
 	var msg Message
 	offset := 0
 	for offset < len(st.readBuf) {
@@ -248,8 +272,26 @@ func (s *Server) handleDecryptedFrames(st *connState) gnet.Action {
 				skipHandler bool
 			)
 			if msg.Type == MsgAuth {
-				respPayload, respType = s.processAuth(st, msg.Value)
-				skipHandler = true
+				if s.requirePassHash == nil {
+					respPayload, respType = ResponseOK, MsgAuthOk
+					skipHandler = true
+				} else {
+					username, password := parseAuthPayload(msg.Value)
+					if len(username) > 0 && string(username) != "default" {
+						respPayload, respType = s.authFailed(st), MsgAuthErr
+						skipHandler = true
+					} else {
+						passwordCopy := make([]byte, len(password))
+						copy(passwordCopy, password)
+						if s.dispatchAuth(c, passwordCopy) {
+							st.authPending = true
+							offset += totalPacketLen
+							break
+						}
+						respPayload, respType = s.authFailed(st), MsgAuthErr
+						skipHandler = true
+					}
+				}
 			} else if !st.authenticated && msg.Type != MsgPing {
 				respPayload, respType = ResponseAuthErr, MsgAuthErr
 				skipHandler = true
@@ -298,6 +340,9 @@ func (s *Server) handleDecryptedFrames(st *connState) gnet.Action {
 // are peeked directly from the gnet ring buffer, parsed, and responses are
 // written back through gnet without any intermediate copies.
 func (s *Server) onTrafficPlaintext(c gnet.Conn, st *connState) gnet.Action {
+	if st.authPending {
+		return gnet.None
+	}
 	var msg Message
 	for {
 		buf, err := c.Peek(-1)
@@ -338,8 +383,26 @@ func (s *Server) onTrafficPlaintext(c gnet.Conn, st *connState) gnet.Action {
 				skipHandler bool
 			)
 			if msg.Type == MsgAuth {
-				respPayload, respType = s.processAuth(st, msg.Value)
-				skipHandler = true
+				if s.requirePassHash == nil {
+					respPayload, respType = ResponseOK, MsgAuthOk
+					skipHandler = true
+				} else {
+					username, password := parseAuthPayload(msg.Value)
+					if len(username) > 0 && string(username) != "default" {
+						respPayload, respType = s.authFailed(st), MsgAuthErr
+						skipHandler = true
+					} else {
+						passwordCopy := make([]byte, len(password))
+						copy(passwordCopy, password)
+						if s.dispatchAuth(c, passwordCopy) {
+							st.authPending = true
+							_, _ = c.Discard(totalPacketLen)
+							return gnet.None
+						}
+						respPayload, respType = s.authFailed(st), MsgAuthErr
+						skipHandler = true
+					}
+				}
 			} else if !st.authenticated && msg.Type != MsgPing {
 				respPayload, respType = ResponseAuthErr, MsgAuthErr
 				skipHandler = true
@@ -391,30 +454,6 @@ func (s *Server) onTrafficPlaintext(c gnet.Conn, st *connState) gnet.Action {
 	return gnet.None
 }
 
-// processAuth handles the MsgAuth wire-level handshake. When no server password is
-// configured it is a no-op (backward-compatible). bcrypt comparison happens only here,
-// never on the hot path. Repeated failures trigger a per-connection rate limit that
-// closes the connection after maxAuthFails attempts.
-func (s *Server) processAuth(st *connState, value []byte) ([]byte, MessageType) {
-	if s.requirePassHash == nil {
-		return ResponseOK, MsgAuthOk
-	}
-	username, password := parseAuthPayload(value)
-	if len(username) > 0 && string(username) != "default" {
-		return s.authFailed(st), MsgAuthErr
-	}
-	if bcrypt.CompareHashAndPassword(s.requirePassHash, password) != nil {
-		return s.authFailed(st), MsgAuthErr
-	}
-	st.authenticated = true
-	if s.logger.Enabled(log.LevelDebug) {
-		s.logger.Log(log.LevelDebug, "network: client authenticated",
-			log.String("remote_addr", st.remoteAddr),
-		)
-	}
-	return ResponseOK, MsgAuthOk
-}
-
 // authFailed logs a rejected AUTH attempt, increments the per-connection fail
 // counter, and marks the connection for closure when the rate limit is exceeded.
 func (s *Server) authFailed(st *connState) []byte {
@@ -429,6 +468,69 @@ func (s *Server) authFailed(st *connState) []byte {
 		st.closeAfterReply = true
 	}
 	return ResponseAuthErr
+}
+
+// authWorker is a background goroutine that runs bcrypt verification off the
+// gnet event loop. On completion it wakes the connection on the event loop to
+// deliver the result and write the response.
+func (s *Server) authWorker() {
+	defer s.workerWg.Done()
+	for job := range s.authJobs {
+		err := bcrypt.CompareHashAndPassword(job.passHash, job.password)
+		success := err == nil
+		_ = job.c.Wake(func(c gnet.Conn, _ error) error {
+			st, _ := c.Context().(*connState)
+			if st == nil {
+				return nil
+			}
+			st.authPending = false
+			if success {
+				st.authenticated = true
+				if s.logger.Enabled(log.LevelDebug) {
+					s.logger.Log(log.LevelDebug, "network: client authenticated",
+						log.String("remote_addr", st.remoteAddr),
+					)
+				}
+				if st.tlsConn != nil {
+					_ = Write(st.tlsConn, MsgAuthOk, ResponseOK)
+				} else {
+					_ = Write(c, MsgAuthOk, ResponseOK)
+				}
+				_ = c.Wake(nil)
+			} else {
+				st.authFails++
+				if s.logger.Enabled(log.LevelWarn) {
+					s.logger.Log(log.LevelWarn, "network: failed AUTH attempt",
+						log.String("remote_addr", st.remoteAddr),
+						log.Int("attempts", st.authFails),
+					)
+				}
+				if st.authFails >= maxAuthFails {
+					st.closeAfterReply = true
+				}
+				if st.tlsConn != nil {
+					_ = Write(st.tlsConn, MsgAuthErr, ResponseAuthErr)
+				} else {
+					_ = Write(c, MsgAuthErr, ResponseAuthErr)
+				}
+				if st.closeAfterReply {
+					_ = c.Close()
+				}
+			}
+			return nil
+		})
+	}
+}
+
+// dispatchAuth submits an auth verification job to the bounded worker pool.
+// Returns true if the job was accepted, false if the pool is saturated.
+func (s *Server) dispatchAuth(c gnet.Conn, password []byte) bool {
+	select {
+	case s.authJobs <- authJob{c: c, password: password, passHash: s.requirePassHash}:
+		return true
+	default:
+		return false
+	}
 }
 
 // parseAuthPayload extracts username and password from the MsgAuth wire format:

--- a/internal/network/server.go
+++ b/internal/network/server.go
@@ -150,9 +150,12 @@ func (s *Server) Shutdown(ctx context.Context) error {
 		s.workerWg.Wait()
 		return ctx.Err()
 	}
+	// Stop the engine first: this synchronously shuts down all event-loop
+	// goroutines, so no more concurrent sends to s.authJobs can occur.
+	err := s.eng.Stop(ctx)
 	close(s.authJobs)
 	s.workerWg.Wait()
-	return s.eng.Stop(ctx)
+	return err
 }
 
 func (s *Server) OnBoot(eng gnet.Engine) gnet.Action {

--- a/internal/network/server.go
+++ b/internal/network/server.go
@@ -119,11 +119,13 @@ func NewServer(addr string, maxMsgSize uint64, shards []*shard.Shard, handler fu
 		ready:           make(chan struct{}),
 		shards:          shards,
 		requirePassHash: passHash,
-		authJobs:        make(chan authJob, 256),
 	}
-	for i := 0; i < numAuthWorkers; i++ {
-		s.workerWg.Add(1)
-		go s.authWorker()
+	if requirePass != "" {
+		s.authJobs = make(chan authJob, 256)
+		for i := 0; i < numAuthWorkers; i++ {
+			s.workerWg.Add(1)
+			go s.authWorker()
+		}
 	}
 	if s.logger.Enabled(log.LevelInfo) {
 		s.logger.Log(log.LevelInfo, "tcp server created", log.Int("max_msg_size", int(maxMsgSize)))
@@ -146,14 +148,18 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	select {
 	case <-s.ready:
 	case <-ctx.Done():
-		close(s.authJobs)
+		if s.authJobs != nil {
+			close(s.authJobs)
+		}
 		s.workerWg.Wait()
 		return ctx.Err()
 	}
 	// Stop the engine first: this synchronously shuts down all event-loop
 	// goroutines, so no more concurrent sends to s.authJobs can occur.
 	err := s.eng.Stop(ctx)
-	close(s.authJobs)
+	if s.authJobs != nil {
+		close(s.authJobs)
+	}
 	s.workerWg.Wait()
 	return err
 }
@@ -375,7 +381,16 @@ func (s *Server) onTrafficPlaintext(c gnet.Conn, st *connState) gnet.Action {
 			if msg.Type == MsgAuth {
 				result := s.handleAuthMessage(c, st, msg.Value)
 				if result.dispatched {
-					_, _ = c.Discard(totalPacketLen)
+					_, err = c.Discard(totalPacketLen)
+					if err != nil {
+						atomic.AddUint64(&s.protocolErrors, 1)
+						if s.logger.Enabled(log.LevelWarn) {
+							s.logger.Log(log.LevelWarn, "discarding packages not possible",
+								log.Int("total packet length", totalPacketLen),
+								log.String("error", err.Error()),
+							)
+						}
+					}
 					return gnet.None
 				}
 				respPayload, respType = result.respPayload, result.respType
@@ -505,17 +520,7 @@ func (s *Server) authWorker() {
 					)
 				}
 			} else {
-				st.authFails++
-				respPayload, respType = ResponseAuthErr, MsgAuthErr
-				if s.logger.Enabled(log.LevelWarn) {
-					s.logger.Log(log.LevelWarn, "network: failed AUTH attempt",
-						log.String("remote_addr", st.remoteAddr),
-						log.Int("attempts", st.authFails),
-					)
-				}
-				if st.authFails >= maxAuthFails {
-					st.closeAfterReply = true
-				}
+				respPayload, respType = s.authFailed(st), MsgAuthErr
 			}
 			var writeErr error
 			if st.tlsConn != nil {

--- a/internal/network/server.go
+++ b/internal/network/server.go
@@ -25,6 +25,7 @@ import (
 
 const defaultAddr = "127.0.0.1:9988"
 const defaultMaxMsgSize = 16 * 1024 * 1024
+const maxAuthFails = 3
 
 // connState holds per-connection state. When TLS is enabled, tlsConn wraps the
 // raw gnet connection with TLS 1.3 encryption via the internal TLS library. readBuf is a
@@ -35,6 +36,8 @@ type connState struct {
 	shardID       uint64
 	authenticated bool
 	remoteAddr    string
+	authFails     int
+	closeAfterReply bool
 	tlsConn       *tlslib.Conn
 	readBuf       []byte
 }
@@ -278,6 +281,9 @@ func (s *Server) handleDecryptedFrames(st *connState) gnet.Action {
 					s.shards[st.shardID].AddBytesWritten(n)
 				}
 			}
+			if st.closeAfterReply {
+				return gnet.Close
+			}
 		}
 		offset += totalPacketLen
 	}
@@ -367,6 +373,9 @@ func (s *Server) onTrafficPlaintext(c gnet.Conn, st *connState) gnet.Action {
 					}
 				}
 			}
+			if st.closeAfterReply {
+				return gnet.Close
+			}
 		}
 		_, err = c.Discard(totalPacketLen)
 		if err != nil {
@@ -384,7 +393,8 @@ func (s *Server) onTrafficPlaintext(c gnet.Conn, st *connState) gnet.Action {
 
 // processAuth handles the MsgAuth wire-level handshake. When no server password is
 // configured it is a no-op (backward-compatible). bcrypt comparison happens only here,
-// never on the hot path.
+// never on the hot path. Repeated failures trigger a per-connection rate limit that
+// closes the connection after maxAuthFails attempts.
 func (s *Server) processAuth(st *connState, value []byte) ([]byte, MessageType) {
 	if s.requirePassHash == nil {
 		return ResponseOK, MsgAuthOk
@@ -405,12 +415,18 @@ func (s *Server) processAuth(st *connState, value []byte) ([]byte, MessageType) 
 	return ResponseOK, MsgAuthOk
 }
 
-// authFailed logs a rejected AUTH attempt and returns the error payload.
+// authFailed logs a rejected AUTH attempt, increments the per-connection fail
+// counter, and marks the connection for closure when the rate limit is exceeded.
 func (s *Server) authFailed(st *connState) []byte {
+	st.authFails++
 	if s.logger.Enabled(log.LevelWarn) {
 		s.logger.Log(log.LevelWarn, "network: failed AUTH attempt",
 			log.String("remote_addr", st.remoteAddr),
+			log.Int("attempts", st.authFails),
 		)
+	}
+	if st.authFails >= maxAuthFails {
+		st.closeAfterReply = true
 	}
 	return ResponseAuthErr
 }

--- a/internal/network/server.go
+++ b/internal/network/server.go
@@ -275,26 +275,13 @@ func (s *Server) handleDecryptedFrames(c gnet.Conn, st *connState) gnet.Action {
 				skipHandler bool
 			)
 			if msg.Type == MsgAuth {
-				if s.requirePassHash == nil {
-					respPayload, respType = ResponseOK, MsgAuthOk
-					skipHandler = true
-				} else {
-					username, password := parseAuthPayload(msg.Value)
-					if len(username) > 0 && string(username) != "default" {
-						respPayload, respType = s.authFailed(st), MsgAuthErr
-						skipHandler = true
-					} else {
-						passwordCopy := make([]byte, len(password))
-						copy(passwordCopy, password)
-						if s.dispatchAuth(c, passwordCopy) {
-							st.authPending = true
-							offset += totalPacketLen
-							break
-						}
-						respPayload, respType = s.authFailed(st), MsgAuthErr
-						skipHandler = true
-					}
+				result := s.handleAuthMessage(c, st, msg.Value)
+				if result.dispatched {
+					offset += totalPacketLen
+					break
 				}
+				respPayload, respType = result.respPayload, result.respType
+				skipHandler = true
 			} else if !st.authenticated && msg.Type != MsgPing {
 				respPayload, respType = ResponseAuthErr, MsgAuthErr
 				skipHandler = true
@@ -386,26 +373,13 @@ func (s *Server) onTrafficPlaintext(c gnet.Conn, st *connState) gnet.Action {
 				skipHandler bool
 			)
 			if msg.Type == MsgAuth {
-				if s.requirePassHash == nil {
-					respPayload, respType = ResponseOK, MsgAuthOk
-					skipHandler = true
-				} else {
-					username, password := parseAuthPayload(msg.Value)
-					if len(username) > 0 && string(username) != "default" {
-						respPayload, respType = s.authFailed(st), MsgAuthErr
-						skipHandler = true
-					} else {
-						passwordCopy := make([]byte, len(password))
-						copy(passwordCopy, password)
-						if s.dispatchAuth(c, passwordCopy) {
-							st.authPending = true
-							_, _ = c.Discard(totalPacketLen)
-							return gnet.None
-						}
-						respPayload, respType = s.authFailed(st), MsgAuthErr
-						skipHandler = true
-					}
+				result := s.handleAuthMessage(c, st, msg.Value)
+				if result.dispatched {
+					_, _ = c.Discard(totalPacketLen)
+					return gnet.None
 				}
+				respPayload, respType = result.respPayload, result.respType
+				skipHandler = true
 			} else if !st.authenticated && msg.Type != MsgPing {
 				respPayload, respType = ResponseAuthErr, MsgAuthErr
 				skipHandler = true
@@ -473,6 +447,39 @@ func (s *Server) authFailed(st *connState) []byte {
 	return ResponseAuthErr
 }
 
+// authResult conveys the outcome of synchronous AUTH processing.
+type authResult struct {
+	respPayload []byte
+	respType    MessageType
+	dispatched  bool // true when bcrypt was sent to the worker pool
+}
+
+// handleAuthMessage consolidates the MsgAuth branch shared by the TLS and
+// plaintext OnTraffic paths. It handles the no-password bypass, fast-rejects
+// malformed payloads, validates the username, makes a copy of the password for
+// the worker, and submits the job via dispatchAuth. It returns an authResult:
+// dispatched == true means the caller must consume the current frame and skip
+// response writing; otherwise respPayload/respType hold the synchronous result.
+func (s *Server) handleAuthMessage(c gnet.Conn, st *connState, value []byte) authResult {
+	if s.requirePassHash == nil {
+		return authResult{respPayload: ResponseOK, respType: MsgAuthOk}
+	}
+	username, password, malformed := parseAuthPayload(value)
+	if malformed {
+		return authResult{respPayload: ResponseAuthErr, respType: MsgAuthErr}
+	}
+	if len(username) > 0 && string(username) != "default" {
+		return authResult{respPayload: s.authFailed(st), respType: MsgAuthErr}
+	}
+	passwordCopy := make([]byte, len(password))
+	copy(passwordCopy, password)
+	if s.dispatchAuth(c, passwordCopy) {
+		st.authPending = true
+		return authResult{dispatched: true}
+	}
+	return authResult{respPayload: ResponseAuthErr, respType: MsgAuthErr}
+}
+
 // authWorker is a background goroutine that runs bcrypt verification off the
 // gnet event loop. On completion it wakes the connection on the event loop to
 // deliver the result and write the response.
@@ -487,21 +494,19 @@ func (s *Server) authWorker() {
 				return nil
 			}
 			st.authPending = false
+			var respPayload []byte
+			var respType MessageType
 			if success {
 				st.authenticated = true
+				respPayload, respType = ResponseOK, MsgAuthOk
 				if s.logger.Enabled(log.LevelDebug) {
 					s.logger.Log(log.LevelDebug, "network: client authenticated",
 						log.String("remote_addr", st.remoteAddr),
 					)
 				}
-				if st.tlsConn != nil {
-					_ = Write(st.tlsConn, MsgAuthOk, ResponseOK)
-				} else {
-					_ = Write(c, MsgAuthOk, ResponseOK)
-				}
-				_ = c.Wake(nil)
 			} else {
 				st.authFails++
+				respPayload, respType = ResponseAuthErr, MsgAuthErr
 				if s.logger.Enabled(log.LevelWarn) {
 					s.logger.Log(log.LevelWarn, "network: failed AUTH attempt",
 						log.String("remote_addr", st.remoteAddr),
@@ -511,15 +516,32 @@ func (s *Server) authWorker() {
 				if st.authFails >= maxAuthFails {
 					st.closeAfterReply = true
 				}
-				if st.tlsConn != nil {
-					_ = Write(st.tlsConn, MsgAuthErr, ResponseAuthErr)
-				} else {
-					_ = Write(c, MsgAuthErr, ResponseAuthErr)
-				}
-				if st.closeAfterReply {
-					_ = c.Close()
-				}
 			}
+			var writeErr error
+			if st.tlsConn != nil {
+				writeErr = Write(st.tlsConn, respType, respPayload)
+			} else {
+				writeErr = Write(c, respType, respPayload)
+			}
+			if writeErr != nil {
+				if s.logger.Enabled(log.LevelError) {
+					s.logger.Log(log.LevelError, "network: auth write failed",
+						log.String("error", writeErr.Error()),
+					)
+				}
+				_ = c.Close()
+				return nil
+			}
+			n := uint64(5 + len(respPayload))
+			atomic.AddUint64(&s.bytesWritten, n)
+			if len(s.shards) > 0 && int(st.shardID) < len(s.shards) {
+				s.shards[st.shardID].AddBytesWritten(n)
+			}
+			if st.closeAfterReply {
+				_ = c.Close()
+				return nil
+			}
+			_ = c.Wake(nil)
 			return nil
 		})
 	}
@@ -540,22 +562,23 @@ func (s *Server) dispatchAuth(c gnet.Conn, password []byte) bool {
 //
 //	[2B usernameLen][username bytes][2B passwordLen][password bytes]
 //
-// Returns (nil, nil) on a malformed frame.
-func parseAuthPayload(value []byte) (username, password []byte) {
+// malformed is true when the payload is truncated. (nil, nil) with malformed=false
+// is a valid frame with an empty username ("default" user).
+func parseAuthPayload(value []byte) (username, password []byte, malformed bool) {
 	if len(value) < 2 {
-		return nil, nil
+		return nil, nil, true
 	}
 	usernameLen := int(binary.BigEndian.Uint16(value[:2]))
 	pos := 2
 	if len(value) < pos+usernameLen+2 {
-		return nil, nil
+		return nil, nil, true
 	}
 	username = value[pos : pos+usernameLen]
 	pos += usernameLen
 	passwordLen := int(binary.BigEndian.Uint16(value[pos : pos+2]))
 	pos += 2
 	if len(value) < pos+passwordLen {
-		return nil, nil
+		return nil, nil, true
 	}
 	password = value[pos : pos+passwordLen]
 	return

--- a/internal/network/server.go
+++ b/internal/network/server.go
@@ -12,6 +12,7 @@ package network
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"sync/atomic"
 
@@ -19,6 +20,7 @@ import (
 	"github.com/Saxy/Tellstone/internal/shard"
 	tlslib "github.com/Saxy/Tellstone/internal/tls"
 	"github.com/panjf2000/gnet/v2"
+	"golang.org/x/crypto/bcrypt"
 )
 
 const defaultAddr = "127.0.0.1:9988"
@@ -27,10 +29,14 @@ const defaultMaxMsgSize = 16 * 1024 * 1024
 // connState holds per-connection state. When TLS is enabled, tlsConn wraps the
 // raw gnet connection with TLS 1.3 encryption via the internal TLS library. readBuf is a
 // reusable scratch buffer for TLS Read calls to avoid per-traffic allocations.
+// authenticated tracks whether the client has passed AUTH (always true when no
+// server password is configured, so the hot path is branch-predictable).
 type connState struct {
-	shardID uint64
-	tlsConn *tlslib.Conn
-	readBuf []byte
+	shardID       uint64
+	authenticated bool
+	remoteAddr    string
+	tlsConn       *tlslib.Conn
+	readBuf       []byte
 }
 
 type Server struct {
@@ -56,13 +62,19 @@ type Server struct {
 
 	shards   []*shard.Shard
 	nextConn uint64
+
+	// requirePassHash is the bcrypt hash of the server password. nil means AUTH is not
+	// required and every connection starts authenticated (zero-overhead no-op path).
+	requirePassHash []byte
 }
 
 // NewServer initializes an edge-triggered networking server engine instance.
 // It applies defensive configuration defaults before spawning infrastructure.
 // shards is optional — if nil, per-shard metrics are not tracked.
 // tlsCfg is optional — if nil, plaintext TCP is used.
-func NewServer(addr string, maxMsgSize uint64, shards []*shard.Shard, handler func(msg *Message) ([]byte, MessageType, error), logger log.Logger, tlsCfg *tlslib.Config) *Server {
+// requirePass is optional — if empty, AUTH is a no-op and connections start authenticated;
+// otherwise it is hashed at startup and clients must AUTH before issuing data commands.
+func NewServer(addr string, maxMsgSize uint64, shards []*shard.Shard, handler func(msg *Message) ([]byte, MessageType, error), logger log.Logger, tlsCfg *tlslib.Config, requirePass string) *Server {
 	if logger == nil {
 		logger = log.NewNoOpLogger()
 	}
@@ -75,14 +87,23 @@ func NewServer(addr string, maxMsgSize uint64, shards []*shard.Shard, handler fu
 	if maxMsgSize == 0 {
 		maxMsgSize = defaultMaxMsgSize
 	}
+	var passHash []byte
+	if requirePass != "" {
+		var err error
+		passHash, err = bcrypt.GenerateFromPassword([]byte(requirePass), bcrypt.DefaultCost)
+		if err != nil {
+			panic("network: invalid --require-pass value: " + err.Error())
+		}
+	}
 	s := &Server{
-		addr:       addr,
-		handler:    handler,
-		logger:     logger,
-		maxMsgSize: maxMsgSize,
-		tlsConfig:  tlsCfg,
-		ready:      make(chan struct{}),
-		shards:     shards,
+		addr:            addr,
+		handler:         handler,
+		logger:          logger,
+		maxMsgSize:      maxMsgSize,
+		tlsConfig:       tlsCfg,
+		ready:           make(chan struct{}),
+		shards:          shards,
+		requirePassHash: passHash,
 	}
 	if s.logger.Enabled(log.LevelInfo) {
 		s.logger.Log(log.LevelInfo, "tcp server created", log.Int("max_msg_size", int(maxMsgSize)))
@@ -126,7 +147,11 @@ func (s *Server) OnOpen(c gnet.Conn) (out []byte, action gnet.Action) {
 		s.shards[sid].IncConnectedClients()
 		s.shards[sid].IncTotalConnections()
 	}
-	st := &connState{shardID: sid}
+	st := &connState{
+		shardID:       sid,
+		authenticated: s.requirePassHash == nil,
+		remoteAddr:    c.RemoteAddr().String(),
+	}
 	if s.tlsConfig != nil {
 		adapter := tlslib.NewGnetConnAdapter(c)
 		st.tlsConn = tlslib.Server(adapter, s.tlsConfig)
@@ -217,8 +242,18 @@ func (s *Server) handleDecryptedFrames(st *connState) gnet.Action {
 			var (
 				respType    MessageType
 				respPayload []byte
+				skipHandler bool
 			)
-			respPayload, respType, err = s.handler(&msg)
+			if msg.Type == MsgAuth {
+				respPayload, respType = s.processAuth(st, msg.Value)
+				skipHandler = true
+			} else if !st.authenticated && msg.Type != MsgPing {
+				respPayload, respType = ResponseAuthErr, MsgAuthErr
+				skipHandler = true
+			}
+			if !skipHandler {
+				respPayload, respType, err = s.handler(&msg)
+			}
 			if err != nil {
 				atomic.AddUint64(&s.handlerErrors, 1)
 				if s.logger.Enabled(log.LevelWarn) {
@@ -294,8 +329,18 @@ func (s *Server) onTrafficPlaintext(c gnet.Conn, st *connState) gnet.Action {
 			var (
 				respType    MessageType
 				respPayload []byte
+				skipHandler bool
 			)
-			respPayload, respType, err = s.handler(&msg)
+			if msg.Type == MsgAuth {
+				respPayload, respType = s.processAuth(st, msg.Value)
+				skipHandler = true
+			} else if !st.authenticated && msg.Type != MsgPing {
+				respPayload, respType = ResponseAuthErr, MsgAuthErr
+				skipHandler = true
+			}
+			if !skipHandler {
+				respPayload, respType, err = s.handler(&msg)
+			}
 			if err != nil {
 				atomic.AddUint64(&s.handlerErrors, 1)
 				if s.logger.Enabled(log.LevelWarn) {
@@ -335,6 +380,64 @@ func (s *Server) onTrafficPlaintext(c gnet.Conn, st *connState) gnet.Action {
 		}
 	}
 	return gnet.None
+}
+
+// processAuth handles the MsgAuth wire-level handshake. When no server password is
+// configured it is a no-op (backward-compatible). bcrypt comparison happens only here,
+// never on the hot path.
+func (s *Server) processAuth(st *connState, value []byte) ([]byte, MessageType) {
+	if s.requirePassHash == nil {
+		return ResponseOK, MsgAuthOk
+	}
+	username, password := parseAuthPayload(value)
+	if len(username) > 0 && string(username) != "default" {
+		return s.authFailed(st), MsgAuthErr
+	}
+	if bcrypt.CompareHashAndPassword(s.requirePassHash, password) != nil {
+		return s.authFailed(st), MsgAuthErr
+	}
+	st.authenticated = true
+	if s.logger.Enabled(log.LevelDebug) {
+		s.logger.Log(log.LevelDebug, "network: client authenticated",
+			log.String("remote_addr", st.remoteAddr),
+		)
+	}
+	return ResponseOK, MsgAuthOk
+}
+
+// authFailed logs a rejected AUTH attempt and returns the error payload.
+func (s *Server) authFailed(st *connState) []byte {
+	if s.logger.Enabled(log.LevelWarn) {
+		s.logger.Log(log.LevelWarn, "network: failed AUTH attempt",
+			log.String("remote_addr", st.remoteAddr),
+		)
+	}
+	return ResponseAuthErr
+}
+
+// parseAuthPayload extracts username and password from the MsgAuth wire format:
+//
+//	[2B usernameLen][username bytes][2B passwordLen][password bytes]
+//
+// Returns (nil, nil) on a malformed frame.
+func parseAuthPayload(value []byte) (username, password []byte) {
+	if len(value) < 2 {
+		return nil, nil
+	}
+	usernameLen := int(binary.BigEndian.Uint16(value[:2]))
+	pos := 2
+	if len(value) < pos+usernameLen+2 {
+		return nil, nil
+	}
+	username = value[pos : pos+usernameLen]
+	pos += usernameLen
+	passwordLen := int(binary.BigEndian.Uint16(value[pos : pos+2]))
+	pos += 2
+	if len(value) < pos+passwordLen {
+		return nil, nil
+	}
+	password = value[pos : pos+passwordLen]
+	return
 }
 
 func (s *Server) ConnectedClients() uint64 { return atomic.LoadUint64(&s.connectedClients) }

--- a/internal/network/server_test.go
+++ b/internal/network/server_test.go
@@ -34,6 +34,12 @@ func (f *fakeStore) set(key string, value []byte) {
 	f.m[string([]byte(key))] = append([]byte(nil), value...)
 }
 
+func (f *fakeStore) delete(key string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.m, key)
+}
+
 // storeHandler is a Server handler that dispatches MsgRequest operations against
 // a fakeStore and echoes MsgPing payloads.
 func storeHandler(store *fakeStore) func(msg *Message) ([]byte, MessageType, error) {
@@ -54,7 +60,7 @@ func storeHandler(store *fakeStore) func(msg *Message) ([]byte, MessageType, err
 				store.set(key, msg.Value)
 				return ResponseOK, MsgResponse, nil
 			case OpDelete:
-				store.set(key, nil) // no-op for test
+				store.delete(key)
 				return ResponseOK, MsgResponse, nil
 			}
 		}

--- a/internal/network/server_test.go
+++ b/internal/network/server_test.go
@@ -1,14 +1,102 @@
 package network
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
 	"fmt"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/Saxy/Tellstone/internal/log"
 )
+
+// fakeStore is a minimal in-memory key-value store for testing binary protocol handlers.
+type fakeStore struct {
+	mu sync.RWMutex
+	m  map[string][]byte
+}
+
+func newFakeStore() *fakeStore { return &fakeStore{m: make(map[string][]byte)} }
+
+func (f *fakeStore) get(key string) ([]byte, bool) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	v, ok := f.m[key]
+	return v, ok
+}
+
+func (f *fakeStore) set(key string, value []byte) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.m[string([]byte(key))] = append([]byte(nil), value...)
+}
+
+// storeHandler is a Server handler that dispatches MsgRequest operations against
+// a fakeStore and echoes MsgPing payloads.
+func storeHandler(store *fakeStore) func(msg *Message) ([]byte, MessageType, error) {
+	return func(msg *Message) ([]byte, MessageType, error) {
+		switch msg.Type {
+		case MsgPing:
+			return msg.Payload, MsgPong, nil
+		case MsgRequest:
+			key := string(msg.Key)
+			switch msg.Op {
+			case OpGet:
+				val, ok := store.get(key)
+				if !ok {
+					return ResponseNotFound, MsgResponse, nil
+				}
+				return val, MsgResponse, nil
+			case OpSet:
+				store.set(key, msg.Value)
+				return ResponseOK, MsgResponse, nil
+			case OpDelete:
+				store.set(key, nil) // no-op for test
+				return ResponseOK, MsgResponse, nil
+			}
+		}
+		return ResponseInvalidOpCode, MsgResponse, nil
+	}
+}
+
+// buildAuthPayload creates a MsgAuth wire payload in single-password mode (username empty).
+func buildAuthPayload(password string) []byte {
+	payloadLen := 2 + 0 + 2 + len(password)
+	buf := make([]byte, payloadLen)
+	binary.BigEndian.PutUint16(buf[0:2], 0)
+	binary.BigEndian.PutUint16(buf[2:4], uint16(len(password)))
+	copy(buf[4:], password)
+	return buf
+}
+
+// buildAuthPayloadWithUser creates a MsgAuth payload with a specific username.
+func buildAuthPayloadWithUser(username, password string) []byte {
+	payloadLen := 2 + len(username) + 2 + len(password)
+	buf := make([]byte, payloadLen)
+	binary.BigEndian.PutUint16(buf[0:2], uint16(len(username)))
+	copy(buf[2:2+len(username)], username)
+	pos := 2 + len(username)
+	binary.BigEndian.PutUint16(buf[pos:pos+2], uint16(len(password)))
+	copy(buf[pos+2:], password)
+	return buf
+}
+
+// sendAndRecv writes a raw frame and reads one full response message.
+func sendAndRecv(t *testing.T, conn net.Conn, msgType MessageType, payload []byte) *Message {
+	t.Helper()
+	if err := Write(conn, msgType, payload); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	resp, err := ReadMessage(conn)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	return resp
+}
 
 // TestServerEcho verifies that the Server processes a Ping message and responds with a Pong
 // using the zero‑allocation Write/Read helpers.
@@ -25,7 +113,7 @@ func TestServerEcho(t *testing.T) {
 		}
 		return nil, 0, nil
 	}
-	srv := NewServer(addr, 0, nil, handler, log.NewNoOpLogger(), nil)
+	srv := NewServer(addr, 0, nil, handler, log.NewNoOpLogger(), nil, "")
 	go func() { _ = srv.ListenAndServe() }()
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -52,6 +140,188 @@ func TestServerEcho(t *testing.T) {
 	}
 	if string(resp.Payload) != "pingdata" {
 		t.Fatalf("payload mismatch: got %s want %s", resp.Payload, "pingdata")
+	}
+}
+
+// startAuthServer starts a server with the given requirePass and returns the address.
+func startAuthServer(t *testing.T, requirePass string, handler func(msg *Message) ([]byte, MessageType, error)) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to obtain free port: %v", err)
+	}
+	addr := l.Addr().String()
+	l.Close()
+	srv := NewServer(addr, 0, nil, handler, log.NewNoOpLogger(), nil, requirePass)
+	go func() { _ = srv.ListenAndServe() }()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	})
+	if err := waitForServer(addr, 2*time.Second); err != nil {
+		t.Fatalf("server not ready: %v", err)
+	}
+	return addr
+}
+
+// TestServerAuthFlow verifies the full authentication lifecycle:
+// unauthenticated request rejected, PING allowed, wrong password, correct password.
+func TestServerAuthFlow(t *testing.T) {
+	store := newFakeStore()
+	addr := startAuthServer(t, "hunter2", storeHandler(store))
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	// GET before auth — should be rejected with MsgAuthErr
+	var reqBuf [32]byte
+	reqBuf[0] = byte(OpGet)
+	binary.BigEndian.PutUint16(reqBuf[1:3], uint16(len("k")))
+	binary.BigEndian.PutUint64(reqBuf[3:11], 0)
+	copy(reqBuf[11:], "k")
+	resp := sendAndRecv(t, conn, MsgRequest, reqBuf[:11+1])
+	if resp.Type != MsgAuthErr {
+		t.Fatalf("expected MsgAuthErr for GET before auth, got %v", resp.Type)
+	}
+	if !bytes.Equal(resp.Payload, ResponseAuthErr) {
+		t.Fatalf("expected auth error payload, got %q", resp.Payload)
+	}
+
+	// PING before auth — should be allowed (like Redis)
+	resp = sendAndRecv(t, conn, MsgPing, []byte("ping"))
+	if resp.Type != MsgPong {
+		t.Fatalf("expected MsgPong for PING before auth, got %v", resp.Type)
+	}
+
+	// AUTH with wrong password
+	resp = sendAndRecv(t, conn, MsgAuth, buildAuthPayload("wrongpass"))
+	if resp.Type != MsgAuthErr {
+		t.Fatalf("expected MsgAuthErr for wrong password, got %v", resp.Type)
+	}
+
+	// GET after failed auth — still rejected
+	resp = sendAndRecv(t, conn, MsgRequest, reqBuf[:11+1])
+	if resp.Type != MsgAuthErr {
+		t.Fatalf("expected MsgAuthErr for GET after failed auth, got %v", resp.Type)
+	}
+
+	// AUTH with correct password
+	resp = sendAndRecv(t, conn, MsgAuth, buildAuthPayload("hunter2"))
+	if resp.Type != MsgAuthOk {
+		t.Fatalf("expected MsgAuthOk, got %v", resp.Type)
+	}
+	if !bytes.Equal(resp.Payload, ResponseOK) {
+		t.Fatalf("expected OK payload, got %q", resp.Payload)
+	}
+
+	// GET after auth — should succeed
+	store.set("k", []byte("value"))
+	resp = sendAndRecv(t, conn, MsgRequest, reqBuf[:11+1])
+	if resp.Type != MsgResponse {
+		t.Fatalf("expected MsgResponse for GET after auth, got %v", resp.Type)
+	}
+	if !bytes.Equal(resp.Payload, []byte("value")) {
+		t.Fatalf("expected 'value', got %q", resp.Payload)
+	}
+
+	// Auth state is per-connection: fresh connection must auth again.
+	conn2, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial failed: %v", err)
+	}
+	defer conn2.Close()
+	resp = sendAndRecv(t, conn2, MsgRequest, reqBuf[:11+1])
+	if resp.Type != MsgAuthErr {
+		t.Fatalf("expected MsgAuthErr on fresh connection, got %v", resp.Type)
+	}
+}
+
+// TestServerAuthNoPassword verifies that when --require-pass is not set,
+// all connections start authenticated and AUTH is a no-op.
+func TestServerAuthNoPassword(t *testing.T) {
+	store := newFakeStore()
+	store.set("k", []byte("v"))
+	addr := startAuthServer(t, "", storeHandler(store))
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	// GET without auth — should work immediately
+	var reqBuf [32]byte
+	reqBuf[0] = byte(OpGet)
+	binary.BigEndian.PutUint16(reqBuf[1:3], uint16(len("k")))
+	binary.BigEndian.PutUint64(reqBuf[3:11], 0)
+	copy(reqBuf[11:], "k")
+	resp := sendAndRecv(t, conn, MsgRequest, reqBuf[:11+1])
+	if resp.Type != MsgResponse {
+		t.Fatalf("expected MsgResponse, got %v", resp.Type)
+	}
+
+	// AUTH is a no-op when no password is configured
+	resp = sendAndRecv(t, conn, MsgAuth, buildAuthPayload("anything"))
+	if resp.Type != MsgAuthOk {
+		t.Fatalf("expected MsgAuthOk (no-op), got %v", resp.Type)
+	}
+}
+
+// TestServerAuthWithUsername verifies username-aware auth.
+func TestServerAuthWithUsername(t *testing.T) {
+	store := newFakeStore()
+	store.set("k", []byte("v"))
+	addr := startAuthServer(t, "sekret", storeHandler(store))
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	// Wrong username
+	resp := sendAndRecv(t, conn, MsgAuth, buildAuthPayloadWithUser("admin", "sekret"))
+	if resp.Type != MsgAuthErr {
+		t.Fatalf("expected MsgAuthErr for wrong username, got %v", resp.Type)
+	}
+
+	// Correct default user
+	resp = sendAndRecv(t, conn, MsgAuth, buildAuthPayloadWithUser("default", "sekret"))
+	if resp.Type != MsgAuthOk {
+		t.Fatalf("expected MsgAuthOk for default user, got %v", resp.Type)
+	}
+
+	// GET after auth
+	var reqBuf [32]byte
+	reqBuf[0] = byte(OpGet)
+	binary.BigEndian.PutUint16(reqBuf[1:3], uint16(len("k")))
+	binary.BigEndian.PutUint64(reqBuf[3:11], 0)
+	copy(reqBuf[11:], "k")
+	resp = sendAndRecv(t, conn, MsgRequest, reqBuf[:11+1])
+	if resp.Type != MsgResponse {
+		t.Fatalf("expected MsgResponse, got %v", resp.Type)
+	}
+}
+
+// TestServerAuthMalformedPayload verifies that a truncated MsgAuth payload is handled
+// without crashing (returns auth error).
+func TestServerAuthMalformedPayload(t *testing.T) {
+	addr := startAuthServer(t, "sekret", storeHandler(newFakeStore()))
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	// Payload too short (only 1 byte, needs at least 2 for usernameLen)
+	resp := sendAndRecv(t, conn, MsgAuth, []byte{0x00})
+	if resp.Type != MsgAuthErr {
+		t.Fatalf("expected MsgAuthErr for truncated payload, got %v", resp.Type)
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -99,6 +99,7 @@ func (s *Server) Run() error {
 		s.networkHandler,
 		logger,
 		tlsCfg,
+		cfg.GetRequirePass(),
 	)
 	if cfg.MetricsEnabled() {
 		s.startMetricsServer(s.netSrv)


### PR DESCRIPTION
**Component:** Networking/RESP, Client SDK, Build/CI

**Type of Change:** New feature

**Related Issue:** Closes #8

**Technical Deep Dive & Context:**

The binary protocol AUTH handshake follows the same design as the RESP AUTH from #17:

- **Zero-overhead path:** When `--require-pass` is unset, `requirePassHash` is `nil` and `connState.authenticated` starts as `true`. The auth guard is a single boolean check on the hot path — no bcrypt, no allocations.
- **bcrypt at startup:** `NewServer` hashes the password once with `bcrypt.GenerateFromPassword`. The hash is stored, never the plaintext. `bcrypt.CompareHashAndPassword` runs only on `MsgAuth`, never on data commands.
- **Wire format:** `MsgAuth` payload is `[2B usernameLen][username][2B passwordLen][password]`. Parsed in `processAuth` by slicing directly into the gnet read buffer — zero copy, zero allocation.
- **Guard placement:** Auth checking happens in `handleDecryptedFrames` / `onTrafficPlaintext` *before* the handler callback, so the handler never sees unauthenticated requests (except `MsgPing`, which is allow-listed like Redis).
- **ACL future-proofing:** Username-aware `AUTH <username> <password>` is supported; only `"default"` user is accepted until an ACL system lands.

**Performance & Benchmarks:**

No measurable change on the hot path. The `!st.authenticated` check is a single boolean load; `MsgAuth` is never sent on the hot path.

```text
BenchmarkGnetPlaintext-32             15828     72477 ns/op     672 B/op       2 allocs/op
BenchmarkGnetPlaintextParallel-32    168244      6817 ns/op     678 B/op       2 allocs/op
BenchmarkReadMessageZeroAlloc-32   435974060     2.678 ns/op       0 B/op       0 allocs/op
```

**How Has This Been Tested:**

- `go test ./...` — all packages pass
- `go test -race ./...` — all packages pass
- `task bench:go PKG=./internal/network/...` — benchmarks pass
- New tests: `TestServerAuthFlow`, `TestServerAuthNoPassword`, `TestServerAuthWithUsername`, `TestServerAuthMalformedPayload`
- Existing RESP auth tests remain green

**Checklist:**

- [x] My code follows the existing code style of this project
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally (`go test ./...` and `go test -race ./...`)
- [ ] I have updated the documentation (README, comments, or any relevant docs)
- [x] My changes generate no new `go vet` warnings
- [ ] Any breaking changes are documented and communicated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added client-side password authentication (“single-password mode”) with a new `Auth` flow that works for both plaintext and TLS.
  * When password protection is enabled, the server enforces authentication before non-ping traffic; malformed/invalid credentials produce explicit auth error responses and can close the connection after replies.
* **Developer Tools**
  * Added a `bench:go` task to run Go benchmarks with configurable target packages, benchmark pattern, and iteration count.
* **Compatibility**
  * If no password is configured, authentication behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->