### PR TITLE
docs: #19 add AGENTS.md for coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,156 @@
+# AGENTS.md
+
+Instructions for coding agents (Claude Code, Cursor, Copilot, Codex, Aider) working in this
+repository. Read this before making any change.
+
+Human contributors: [CONTRIBUTING.md](CONTRIBUTING.md) is the full guide and the source of
+truth for everything summarised here.
+
+## Commits and attribution
+
+### No AI attribution
+
+Do not add AI attribution trailers or footers to commits or pull request descriptions. None
+of the following, in any form:
+
+```
+Co-authored-by: Claude <noreply@anthropic.com>
+Co-Authored-By: Claude Code <...>
+Generated with Claude Code
+🤖 Generated with ...
+```
+
+AI generated/co-authored tags create legal and licensing gray areas. This project uses the
+[DCO](https://developercertificate.org/): `Signed-off-by` is a certification by a real
+person who has the right to submit the work under Apache 2.0. A model is not a legal person
+and cannot make that certification, so naming one as an author muddies the provenance of
+every file it touches.
+
+The human contributor is the author and signs off. How the patch was drafted is not
+recorded in the commit.
+
+### Sign off every commit
+
+```bash
+git commit -s
+```
+
+Use a real name and a valid email — no pseudonyms, no `noreply` addresses. Commits without
+a `Signed-off-by` line are not merged. To fix commits you already made:
+
+```bash
+git commit --amend -s          # the last commit
+git rebase --signoff HEAD~3    # the last 3 commits
+```
+
+### Commit message format
+
+[Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <description>
+```
+
+| Field | Values |
+|-------|--------|
+| Type | `feat` `fix` `perf` `refactor` `docs` `test` `chore` `ci` `build` `style` |
+| Scope | `resp` `binary` `storage` `shard` `router` `persistence` `crypto` `metrics` `trace` `cli` `server` |
+
+- Description: lowercase, imperative mood, no period, max 72 characters.
+- Reference issues in the footer: `Closes #123`.
+- Breaking changes: append `!` after the type/scope, or put `BREAKING CHANGE:` in the
+  footer.
+
+## Before you commit
+
+```bash
+task check    # go vet + race tests — must pass
+task fmt      # format
+```
+
+Without the `task` CLI, run the equivalents:
+
+```bash
+go vet ./...
+go test -race ./...
+go fmt ./...
+```
+
+## Codebase rules
+
+- **The hot path must not allocate.** Request handling in `internal/storage`,
+  `internal/router`, `internal/shard`, `internal/resp`, and `internal/network` is
+  allocation-free by design. No `make()`, no string conversions, no `interface{}` boxing
+  there. Verify with `go test -bench=. -benchmem ./path/to/pkg` and put before/after
+  numbers in the pull request.
+- **Never invent benchmark numbers.** If you did not run a benchmark, say so.
+- **Every file opens with the C-style block header.** Copy the exact shape from a
+  neighbouring file in the same package — the second line is a component title
+  (`Tellstone Request Router`), not a fixed string.
+- **Comment why, not what**, especially around allocation-sensitive code, cache-line
+  padding, and non-obvious trade-offs. This codebase is heavily commented; match the
+  density of the file you are editing.
+- **Prefer the standard library.** Every dependency is a liability — security surface,
+  build complexity, license risk. A new one needs justification in the pull request.
+- **Opt-in features stay opt-in.** Encryption, metrics, persistence, RESP, and TLS are all
+  disabled by default. Do not add overhead for users who have not enabled a feature.
+- **Read [ARCHITECTURE.md](ARCHITECTURE.md)** before changing anything at the shard/router
+  boundary.
+
+## Coding Principles
+
+### 1. Think Before Coding
+Don't assume. Don't hide confusion. Surface tradeoffs.
+
+Before implementing:
+
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+### 2. Simplicity First
+Minimum code that solves the problem. Nothing speculative.
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+- Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+### 3. Surgical Changes
+Touch only what you must. Clean up only your own mess.
+
+When editing existing code:
+
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+- The test: Every changed line should trace directly to the user's request.
+
+### 4. Goal-Driven Execution
+Define success criteria. Loop until verified.
+
+Transform tasks into verifiable goals:
+
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+
+For multi-step tasks, state a brief plan with clear verification steps.
+
+## Where to look
+
+| File | What's in it |
+|------|--------------|
+| [ARCHITECTURE.md](ARCHITECTURE.md) | Package reference, request flow (binary + RESP), key design decisions |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Full contribution guide: DCO, commit conventions, code standards, PR process |
+| [ROADMAP.md](ROADMAP.md) | Planned work and priorities |
+| [Taskfile.yml](Taskfile.yml) | Build, test, benchmark, and profiling targets |
+| [.github/pull_request_template.md](.github/pull_request_template.md) | What a pull request description must contain |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,14 +13,14 @@ truth for everything summarised here.
 Do not add AI attribution trailers or footers to commits or pull request descriptions. None
 of the following, in any form:
 
-```
+```text
 Co-authored-by: Claude <noreply@anthropic.com>
 Co-Authored-By: Claude Code <...>
 Generated with Claude Code
 🤖 Generated with ...
 ```
 
-AI generated/co-authored tags create legal and licensing gray areas. This project uses the
+AI-generated/co-authored tags create legal and licensing gray areas. This project uses the
 [DCO](https://developercertificate.org/): `Signed-off-by` is a certification by a real
 person who has the right to submit the work under Apache 2.0. A model is not a legal person
 and cannot make that certification, so naming one as an author muddies the provenance of
@@ -47,7 +47,7 @@ git rebase --signoff HEAD~3    # the last 3 commits
 
 [Conventional Commits](https://www.conventionalcommits.org/):
 
-```
+```text
 <type>(<scope>): <description>
 ```
 
@@ -56,6 +56,8 @@ git rebase --signoff HEAD~3    # the last 3 commits
 | Type | `feat` `fix` `perf` `refactor` `docs` `test` `chore` `ci` `build` `style` |
 | Scope | `resp` `binary` `storage` `shard` `router` `persistence` `crypto` `metrics` `trace` `cli` `server` |
 
+- The scope is optional. Omit it when the change is not specific to one area, as
+  `CONTRIBUTING.md` does with `docs: update benchmark methodology section`.
 - Description: lowercase, imperative mood, no period, max 72 characters.
 - Reference issues in the footer: `Closes #123`.
 - Breaking changes: append `!` after the type/scope, or put `BREAKING CHANGE:` in the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,6 +144,7 @@ chore(deps): bump go.mod to Go 1.26
 - Description is lowercase, imperative mood, no period, max 72 characters.
 - Reference issues in the footer: `Closes #123`, `Fixes #456`.
 - Breaking changes must include `BREAKING CHANGE:` in the footer or append `!` after the type/scope: `feat(resp)!: remove deprecated HELLO command`.
+- Do not include AI-generated or co-authored trailers (`Co-authored-by: Claude ...`, `Generated with ...`). Such tags create legal and licensing gray areas, and only a person can certify the DCO. See [AGENTS.md](AGENTS.md).
 
 ### Code Standards
 
@@ -212,6 +213,8 @@ task bench:resp
 5. **Open a PR** against `main` using the PR template.
 6. **Fill out the PR template** completely — especially the benchmark table for performance changes.
 7. **Respond to review feedback** promptly.
+
+If you used a coding agent for any part of the change, follow [AGENTS.md](AGENTS.md).
 
 PRs that introduce new dependencies, change the public API, or affect performance will receive extra scrutiny. This is by design — it protects the project's core principles.
 


### PR DESCRIPTION
## Description

Adds an `AGENTS.md` at the repository root — a short, machine-readable entry point for coding agents (Claude Code, Cursor, Copilot, Codex, Aider) — and cross-references its central rule from `CONTRIBUTING.md`.

The primary rule, stated first in the file: commits and pull request descriptions must not carry AI generated or co-authored trailers. Such tags create legal and licensing gray areas, and `Signed-off-by` is a DCO certification that only a person can make.

**Component:** Build/CI (documentation)

**Type of Change:**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance optimization (no change in behavior, improved speed/memory)
- [ ] Refactoring (no functional changes, code cleanup)
- [x] Build / CI / Documentation

---

## Related Issue

Closes #19

---

## Technical Deep Dive & Context

No code is touched. Two files change: a new `AGENTS.md` (156 lines) and three added lines in `CONTRIBUTING.md`.

**Why a separate file rather than more of `CONTRIBUTING.md`.** `CONTRIBUTING.md` is written for humans and runs 238 lines. The failures this addresses — unsigned commits, AI trailers, wrong commit scopes, hot-path allocations, missing file block headers, speculative scope — happen precisely because that information is one hop away from where an agent is working. A pointer to a long document does not fix a problem caused by agents not reading a long document.

**What is duplicated, and why that is bounded.** `AGENTS.md` restates only rules that are short, mechanical, and checkable: `git commit -s`, the Conventional Commits format and scope list, `task check` before committing, the block-header shape. Everything narrative — architecture reasoning, benchmark methodology, the PR process — is linked, not copied. The duplicated facts change rarely, and the new `CONTRIBUTING.md` pointer means anyone editing either file learns the other exists.

**Alternatives considered.** A thin pointer file with no duplication was rejected: zero drift risk, but it documents a policy without changing behaviour. Inverting the relationship — making `AGENTS.md` canonical and having `CONTRIBUTING.md` link to it — was rejected as restructuring a maintainer-owned document well beyond the scope of issue #19. Per-tool files (`CLAUDE.md`, `.cursorrules`) were rejected because N copies of the same rules drift apart immediately; `AGENTS.md` is the cross-tool convention and one file serves all of them.

**Section order is deliberate.** Agents skim top-down, so the most-violated rules come first and the reasoning last: attribution and commits, then pre-commit checks, then codebase rules, then the coding principles, then a table of where to look.

**One inconsistency surfaced but not fixed.** `CONTRIBUTING.md`'s block-header template shows line 2 as the literal string `Tellstone Cloud-Native In-Memory Database`, while every real file uses a component title (`Tellstone Request Router`, `Tellstone Redis-Compatible Wire Protocol`). `AGENTS.md` tells agents to copy a neighbouring file in the same package rather than the template. I have left the `CONTRIBUTING.md` template alone — it is outside the scope of this issue, and I would rather flag it than change it unasked. Happy to fix it here or in a separate PR, whichever you prefer.

`internal/protocol` is deliberately absent from the list of allocation-free packages, since `ARCHITECTURE.md` describes it as the experimental frontend path rather than the hot path. Say the word if it belongs there.

---

## Performance & Benchmarks (If Applicable)

No measurable change — documentation only, no code paths touched.

---

## How Has This Been Tested?

No tests were added: the change is two Markdown files and adds no code to test. Verification focused on the failure modes that actually apply to a docs change — factual accuracy and self-consistency.

- `go vet ./...` — exit 0.
- `go test -race ./...` — exit 0, 14 packages ok, no FAIL, panic, or DATA RACE.
- Every path, file, and `task` target referenced in `AGENTS.md` was checked to exist mechanically rather than by eye: the five `internal/` packages, the five linked documents, and `task check` / `task fmt`. The stated non-`task` equivalents were read out of `Taskfile.yml` (`check` is `deps: [vet, test:race]`, `fmt` is `go fmt ./...`) rather than assumed.
- Prose is hard-wrapped to match the surrounding docs; no line exceeds 95 columns.
- The commit for this PR complies with the rules the PR adds: 37-character Conventional Commits subject, `Signed-off-by` present, no AI trailer. A commit that violated `AGENTS.md` while adding `AGENTS.md` would be self-refuting.

---

## Checklist

- [x] My code follows the existing code style of this project
- [ ] I have added tests that prove my fix/feature works — not applicable, documentation only
- [x] New and existing tests pass locally (`go test ./...` and `go test -race ./...`)
- [x] I have updated the documentation (README, comments, or any relevant docs)
- [x] My changes generate no new `go vet` warnings
- [x] Any breaking changes are documented and communicated — none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added/updated repository guidance for coding agents, including tightened Markdown formatting and conventional-commit requirements (with clarification that commit scope is optional when changes aren’t area-specific).
  * Updated contribution instructions to explicitly govern AI-assisted work, including restrictions on AI-generated/co-authored commit trailers and guidance to follow the coding agent standards during PRs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->