### PR TITLE
feat(server): add automatic certificate rotation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -77,6 +77,7 @@ Tellstone is a shared-nothing, in-memory key/value store with two protocol front
 | `protocol` | `internal/protocol/` | SQL-text-to-KV translator. Parses `SELECT`/`INSERT`/`DELETE` into operations (experimental/frontend path). |
 | `persistence` | `internal/persistence/` | Per-shard append-only WAL. Crash recovery with replay, tombstone deletes, truncation of corrupted tails. |
 | `crypto` | `internal/crypto/` | ChaCha20-Poly1305 encryption. `EncryptInPlace` / `DecryptInPlace`. Pass-through mode when disabled (zero overhead). |
+| `tls` | `internal/tls/` | TLS 1.3/mTLS transport, gnet connection adapter, and automatic certificate/key/CA rotation through a shared atomic config store. |
 | `metrics` | `internal/metrics/` | Prometheus exporter. Per-shard `Collector` + `AggregateCollector` (includes Go runtime stats). Hand-written exposition text. |
 | `trace` | `internal/trace/` | OpenTelemetry wrapper. `Tracer`/`Span` interfaces with `NoOpTracer` (zero-alloc) and `OTelTracer` (OTLP/gRPC). |
 | `version` | `internal/version/` | Build-time version/commit/date via `-ldflags`. |
@@ -142,6 +143,7 @@ Every optional feature is disabled by default and has zero overhead when off:
 | Feature | Flag | Default |
 |---------|------|---------|
 | RESP protocol | `--enable-resp` | off |
+| TLS / mTLS | `--tls-cert`, `--tls-key`, `--tls-ca` | off |
 | Encryption | `--enable-encryption` | off |
 | Metrics | `--enable-metrics` | off |
 | Persistence | `--enable-persistence` | off |
@@ -152,6 +154,15 @@ Every optional feature is disabled by default and has zero overhead when off:
 Both protocol servers use **gnet** (edge-triggered epoll), not `net.Conn` per-goroutine.
 This gives Linux-level performance with multi-reactor multicore support
 (`gnet.WithMulticore(true)`).
+
+### TLS Certificate Rotation
+
+When TLS is configured, one filesystem watcher monitors the distinct parent directories of the
+certificate, private key, and optional client CA. A complete replacement config is validated and
+published through a shared atomic pointer after a 500 ms debounce. Binary and RESP listeners load
+the pointer only when accepting a connection, so established connections retain their original
+TLS state while new connections use the rotated material. Parent-directory watching detects direct
+writes, atomic renames, and Kubernetes projected Secret `..data` symlink swaps.
 
 ### Persistence (WAL)
 

--- a/README.md
+++ b/README.md
@@ -142,11 +142,19 @@ Every option is available as a flag and an environment variable.
 | `--trace-ratio`       | `TSD_TRACE_RATIO`       | `0.0`            | OpenTelemetry sample ratio (`0` disables)                |
 | `--enable-persistence`| `TSD_ENABLE_PERSISTENCE`| `false`          | Enable write-ahead log persistence for crash recovery    |
 | `--persistence-dir`   | `TSD_PERSISTENCE_DIR`   | _(platform)_     | Directory for WAL data files                             |
+| `--tls-cert`          | `TSD_TLS_CERT`           | _(none)_         | TLS certificate path; watched for automatic rotation     |
+| `--tls-key`           | `TSD_TLS_KEY`            | _(none)_         | TLS private key path; watched for automatic rotation     |
+| `--tls-ca`            | `TSD_TLS_CA`             | _(none)_         | Client CA path for mTLS; watched for automatic rotation  |
 | `--shutdown-timeout`  | `TSD_SHUTDOWN_TIMEOUT`  | `10s`            | Max wait for graceful shutdown on SIGINT/SIGTERM         |
 
 Runtime tuning (environment only): `TSD_GC_PERCENT` (default `-1`, GC off for a zero‑GC hot
 path), `TSD_MEM_LIMIT_BYTES` (soft heap ceiling), `TSD_ENABLE_PROFILING` (serves `pprof` on
 `127.0.0.1:6060`).
+
+When TLS is enabled, Tellstone watches the parent directories of the certificate, key, and
+optional client CA. Valid replacements are applied to new connections after a 500 ms debounce;
+existing TLS connections continue uninterrupted. Directory watching supports atomic file renames
+and Kubernetes projected Secret updates.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,7 +13,7 @@ runs plaintext TCP with no access control — a non-starter for any real deploym
 
 - [x] TLS 1.3 support for both binary and RESP2 listeners (`--tls-cert`, `--tls-key`, `--tls-ca`)
 - [x] mTLS (mutual TLS) for service-to-service authentication in Kubernetes
-- [ ] Automatic certificate rotation via filesystem watcher or Kubernetes Secret projection
+- [x] Automatic certificate rotation via filesystem watcher or Kubernetes Secret projection
 - [ ] STARTTLS upgrade path for RESP connections (graceful upgrade from plaintext)
 
 ### 2b — Authentication & Authorization

--- a/config/config.go
+++ b/config/config.go
@@ -258,19 +258,19 @@ func LoadConfig(args []string) *Config {
 		&cfg.tlsCert,
 		"tls-cert",
 		getEnv("TSD_TLS_CERT", ""),
-		"Path to TLS certificate file (PEM); empty disables TLS (default: none)",
+		"Path to watched TLS certificate file (PEM); empty disables TLS (default: none)",
 	)
 	fs.StringVar(
 		&cfg.tlsKey,
 		"tls-key",
 		getEnv("TSD_TLS_KEY", ""),
-		"Path to TLS private key file (PEM); required when tls-cert is set",
+		"Path to watched TLS private key file (PEM); required when tls-cert is set",
 	)
 	fs.StringVar(
 		&cfg.tlsCA,
 		"tls-ca",
 		getEnv("TSD_TLS_CA", ""),
-		"Path to CA certificate for client verification (PEM); enables mTLS when set",
+		"Path to watched CA certificate for client verification (PEM); enables mTLS when set",
 	)
 	// Optional server password enforced via the RESP AUTH command.
 	fs.StringVar(

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/Saxy/Tellstone
 go 1.26.5
 
 require (
+	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-echarts/go-echarts/v2 v2.7.2
 	github.com/panjf2000/gnet/v2 v2.10.0
 	go.opentelemetry.io/otel v1.44.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/go-echarts/go-echarts/v2 v2.7.2 h1:lhypL1CekgqaLHM5V7fBPfaYGfimJ9dGylkk65aWlNI=
 github.com/go-echarts/go-echarts/v2 v2.7.2/go.mod h1:Z+spPygZRIEyqod69r0WMnkN5RV3MwhYDtw601w3G8w=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -131,15 +131,25 @@ func (c *Collector) writeMetric(name, mType, help string, value uint64) {
 	_, _ = c.writer.Write([]byte("\n\n"))
 }
 
+// TLSMetrics exposes process-level certificate rotation state without coupling
+// the metrics package to the concrete filesystem watcher.
+type TLSMetrics interface {
+	ReloadTotal() uint64
+	ReloadErrorsTotal() uint64
+	CertificateExpirySeconds() int64
+}
+
 type AggregateCollector struct {
 	shardCollectors []*Collector
 	networkServer   *network.Server
+	tlsMetrics      TLSMetrics
 }
 
-func NewAggregateCollector(shardCollectors []*Collector, netSrv *network.Server) *AggregateCollector {
+func NewAggregateCollector(shardCollectors []*Collector, netSrv *network.Server, tlsMetrics TLSMetrics) *AggregateCollector {
 	return &AggregateCollector{
 		shardCollectors: shardCollectors,
 		networkServer:   netSrv,
+		tlsMetrics:      tlsMetrics,
 	}
 }
 
@@ -161,4 +171,12 @@ func (ac *AggregateCollector) WritePrometheus(w io.Writer) {
 	writeRaw("tellstone_runtime_heap_alloc_bytes", "gauge", "Heap alloc bytes.", mem.HeapAlloc)
 	writeRaw("tellstone_runtime_heap_allocs_total", "counter", "Total heap allocations.", mem.Mallocs)
 	writeRaw("tellstone_runtime_gc_cycles_total", "counter", "Total GC cycles.", uint64(mem.NumGC))
+	if ac.tlsMetrics != nil {
+		writeRaw("tellstone_tls_cert_reload_total", "counter", "Successful TLS certificate reloads.", ac.tlsMetrics.ReloadTotal())
+		writeRaw("tellstone_tls_cert_reload_errors_total", "counter", "Failed TLS certificate reloads.", ac.tlsMetrics.ReloadErrorsTotal())
+		expiry := ac.tlsMetrics.CertificateExpirySeconds()
+		if expiry > 0 {
+			writeRaw("tellstone_tls_cert_expiry_seconds", "gauge", "Active TLS leaf certificate NotAfter as Unix epoch seconds.", uint64(expiry))
+		}
+	}
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,6 +1,8 @@
 package metrics
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,6 +13,38 @@ import (
 
 // TestCollectorEngineSnapshot verifies that the engine snapshot reflects
 // the values reported by the storage engine after a few operations.
+type fakeTLSMetrics struct {
+	reloads uint64
+	errors  uint64
+	expiry  int64
+}
+
+func (m fakeTLSMetrics) ReloadTotal() uint64             { return m.reloads }
+func (m fakeTLSMetrics) ReloadErrorsTotal() uint64       { return m.errors }
+func (m fakeTLSMetrics) CertificateExpirySeconds() int64 { return m.expiry }
+
+func TestAggregateCollectorTLSMetrics(t *testing.T) {
+	collector := NewAggregateCollector(nil, nil, fakeTLSMetrics{reloads: 2, errors: 1, expiry: 1234})
+	var output bytes.Buffer
+	collector.WritePrometheus(&output)
+	got := output.String()
+	for _, want := range []string{
+		"tellstone_tls_cert_reload_total 2",
+		"tellstone_tls_cert_reload_errors_total 1",
+		"tellstone_tls_cert_expiry_seconds 1234",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing TLS metric %q in output:\n%s", want, got)
+		}
+	}
+
+	output.Reset()
+	NewAggregateCollector(nil, nil, nil).WritePrometheus(&output)
+	if strings.Contains(output.String(), "tellstone_tls_") {
+		t.Fatalf("TLS metrics must be omitted when rotation is disabled:\n%s", output.String())
+	}
+}
+
 func TestCollectorEngineSnapshot(t *testing.T) {
 	// Create a simple storage engine with a minimal chronometer (interval 1ms, 1 slot).
 	eng := storage.NewEngine(time.Millisecond, 1, 0, log.NewNoOpLogger(), nil)

--- a/internal/network/benchmark_tls_test.go
+++ b/internal/network/benchmark_tls_test.go
@@ -25,9 +25,9 @@ import (
 
 // benchServer holds a running plaintext gnet server for benchmarks.
 type benchServer struct {
-	srv    *Server
-	addr   string
-	ready  chan struct{}
+	srv   *Server
+	addr  string
+	ready chan struct{}
 }
 
 func startBenchServer(b *testing.B, handler func(msg *Message) ([]byte, MessageType, error)) *benchServer {
@@ -54,8 +54,8 @@ func startBenchServer(b *testing.B, handler func(msg *Message) ([]byte, MessageT
 
 // benchTLS server holds a running TLS gnet server for benchmarks.
 type benchTLSServer struct {
-	srv    *Server
-	addr   string
+	srv     *Server
+	addr    string
 	certPEM []byte
 	keyPEM  []byte
 }
@@ -80,6 +80,10 @@ func startBenchTLSServer(b *testing.B, handler func(msg *Message) ([]byte, Messa
 	if err != nil {
 		b.Fatalf("failed to build TLS config: %v", err)
 	}
+	tlsConfigs, err := tlslib.NewConfigStore(tlsCfg)
+	if err != nil {
+		b.Fatalf("failed to create TLS config store: %v", err)
+	}
 
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -88,7 +92,7 @@ func startBenchTLSServer(b *testing.B, handler func(msg *Message) ([]byte, Messa
 	addr := l.Addr().String()
 	l.Close()
 
-	srv := NewServer(addr, 0, nil, handler, log.NewNoOpLogger(), tlsCfg, "")
+	srv := NewServer(addr, 0, nil, handler, log.NewNoOpLogger(), tlsConfigs, "")
 	go func() {
 		_ = srv.ListenAndServe()
 	}()

--- a/internal/network/server.go
+++ b/internal/network/server.go
@@ -41,14 +41,14 @@ type authJob struct {
 // authenticated tracks whether the client has passed AUTH (always true when no
 // server password is configured, so the hot path is branch-predictable).
 type connState struct {
-	shardID       uint64
-	authenticated bool
-	remoteAddr    string
-	authFails     int
-	authPending   bool
+	shardID         uint64
+	authenticated   bool
+	remoteAddr      string
+	authFails       int
+	authPending     bool
 	closeAfterReply bool
-	tlsConn       *tlslib.Conn
-	readBuf       []byte
+	tlsConn         *tlslib.Conn
+	readBuf         []byte
 }
 
 type Server struct {
@@ -57,7 +57,7 @@ type Server struct {
 	handler    func(msg *Message) ([]byte, MessageType, error)
 	logger     log.Logger
 	maxMsgSize uint64
-	tlsConfig  *tlslib.Config
+	tlsConfigs *tlslib.ConfigStore
 
 	// eng and ready let Shutdown reach the running gnet engine: OnBoot fires once the event
 	// loop is accepting connections and hands us the Engine handle we need to stop it; ready
@@ -86,10 +86,11 @@ type Server struct {
 // NewServer initializes an edge-triggered networking server engine instance.
 // It applies defensive configuration defaults before spawning infrastructure.
 // shards is optional — if nil, per-shard metrics are not tracked.
-// tlsCfg is optional — if nil, plaintext TCP is used.
+// tlsConfigs is optional — if nil, plaintext TCP is used. When configured, each
+// accepted connection atomically loads the latest immutable TLS configuration.
 // requirePass is optional — if empty, AUTH is a no-op and connections start authenticated;
 // otherwise it is hashed at startup and clients must AUTH before issuing data commands.
-func NewServer(addr string, maxMsgSize uint64, shards []*shard.Shard, handler func(msg *Message) ([]byte, MessageType, error), logger log.Logger, tlsCfg *tlslib.Config, requirePass string) *Server {
+func NewServer(addr string, maxMsgSize uint64, shards []*shard.Shard, handler func(msg *Message) ([]byte, MessageType, error), logger log.Logger, tlsConfigs *tlslib.ConfigStore, requirePass string) *Server {
 	if logger == nil {
 		logger = log.NewNoOpLogger()
 	}
@@ -115,7 +116,7 @@ func NewServer(addr string, maxMsgSize uint64, shards []*shard.Shard, handler fu
 		handler:         handler,
 		logger:          logger,
 		maxMsgSize:      maxMsgSize,
-		tlsConfig:       tlsCfg,
+		tlsConfigs:      tlsConfigs,
 		ready:           make(chan struct{}),
 		shards:          shards,
 		requirePassHash: passHash,
@@ -185,9 +186,9 @@ func (s *Server) OnOpen(c gnet.Conn) (out []byte, action gnet.Action) {
 		authenticated: s.requirePassHash == nil,
 		remoteAddr:    c.RemoteAddr().String(),
 	}
-	if s.tlsConfig != nil {
+	if tlsCfg := s.tlsConfigs.Load(); tlsCfg != nil {
 		adapter := tlslib.NewGnetConnAdapter(c)
-		st.tlsConn = tlslib.Server(adapter, s.tlsConfig)
+		st.tlsConn = tlslib.Server(adapter, tlsCfg)
 		st.readBuf = make([]byte, 0, 4096)
 	}
 	c.SetContext(st)

--- a/internal/network/server_test.go
+++ b/internal/network/server_test.go
@@ -3,14 +3,18 @@ package network
 import (
 	"bytes"
 	"context"
+	stdtls "crypto/tls"
+	"crypto/x509"
 	"encoding/binary"
 	"fmt"
 	"net"
+	"os"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/Saxy/Tellstone/internal/log"
+	tlslib "github.com/Saxy/Tellstone/internal/tls"
 )
 
 // fakeStore is a minimal in-memory key-value store for testing binary protocol handlers.
@@ -146,6 +150,104 @@ func TestServerEcho(t *testing.T) {
 	}
 	if string(resp.Payload) != "pingdata" {
 		t.Fatalf("payload mismatch: got %s want %s", resp.Payload, "pingdata")
+	}
+}
+
+// TestServerTLSConfigRotation verifies that established TLS connections retain their
+// original configuration while connections accepted after publication use the replacement.
+func TestServerTLSConfigRotation(t *testing.T) {
+	certA, keyA, err := generateSelfSignedCert()
+	if err != nil {
+		t.Fatalf("generate certificate A: %v", err)
+	}
+	certB, keyB, err := generateSelfSignedCert()
+	if err != nil {
+		t.Fatalf("generate certificate B: %v", err)
+	}
+	certFileA, keyFileA, err := writeTempCertFiles(certA, keyA)
+	if err != nil {
+		t.Fatalf("write certificate A: %v", err)
+	}
+	certFileB, keyFileB, err := writeTempCertFiles(certB, keyB)
+	if err != nil {
+		t.Fatalf("write certificate B: %v", err)
+	}
+	for _, path := range []string{certFileA, keyFileA, certFileB, keyFileB} {
+		path := path
+		t.Cleanup(func() { _ = os.Remove(path) })
+	}
+
+	cfgA, err := tlslib.BuildConfig(certFileA, keyFileA, "")
+	if err != nil {
+		t.Fatalf("build config A: %v", err)
+	}
+	cfgB, err := tlslib.BuildConfig(certFileB, keyFileB, "")
+	if err != nil {
+		t.Fatalf("build config B: %v", err)
+	}
+	configs, err := tlslib.NewConfigStore(cfgA)
+	if err != nil {
+		t.Fatalf("create config store: %v", err)
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	addr := listener.Addr().String()
+	_ = listener.Close()
+	srv := NewServer(addr, 0, nil, pingHandler, log.NewNoOpLogger(), configs, "")
+	go func() { _ = srv.ListenAndServe() }()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	})
+	if err := waitForServer(addr, 2*time.Second); err != nil {
+		t.Fatalf("server not ready: %v", err)
+	}
+
+	connA, err := stdtls.Dial("tcp", addr, clientTLSConfig(t, certA))
+	if err != nil {
+		t.Fatalf("dial with certificate A trust: %v", err)
+	}
+	defer connA.Close()
+	if got := sendAndRecv(t, connA, MsgPing, []byte("before")); got.Type != MsgPong {
+		t.Fatalf("expected pong before rotation, got %v", got.Type)
+	}
+
+	if err := configs.Store(cfgB); err != nil {
+		t.Fatalf("publish config B: %v", err)
+	}
+	if got := sendAndRecv(t, connA, MsgPing, []byte("after")); got.Type != MsgPong {
+		t.Fatalf("existing connection failed after rotation: %v", got.Type)
+	}
+
+	connB, err := stdtls.Dial("tcp", addr, clientTLSConfig(t, certB))
+	if err != nil {
+		t.Fatalf("new connection did not receive certificate B: %v", err)
+	}
+	defer connB.Close()
+	if got := sendAndRecv(t, connB, MsgPing, []byte("new")); got.Type != MsgPong {
+		t.Fatalf("expected pong on new connection, got %v", got.Type)
+	}
+
+	if staleConn, err := stdtls.Dial("tcp", addr, clientTLSConfig(t, certA)); err == nil {
+		_ = staleConn.Close()
+		t.Fatal("new connection unexpectedly trusted the rotated-out certificate")
+	}
+}
+
+func clientTLSConfig(t *testing.T, certPEM []byte) *stdtls.Config {
+	t.Helper()
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(certPEM) {
+		t.Fatal("append trusted certificate")
+	}
+	return &stdtls.Config{
+		MinVersion: stdtls.VersionTLS13,
+		MaxVersion: stdtls.VersionTLS13,
+		RootCAs:    roots,
 	}
 }
 

--- a/internal/resp/server.go
+++ b/internal/resp/server.go
@@ -58,10 +58,10 @@ type connState struct {
 // Server is an edge-triggered RESP2 listener backed by gnet.
 type Server struct {
 	gnet.BuiltinEventEngine
-	addr      string
-	store     Store
-	logger    log.Logger
-	tlsConfig *tlslib.Config
+	addr       string
+	store      Store
+	logger     log.Logger
+	tlsConfigs *tlslib.ConfigStore
 	// eng and ready let Shutdown reach the running gnet engine: OnBoot fires once the event
 	// loop is accepting connections and hands us the Engine handle we need to stop it; ready
 	// is closed at that point so a concurrent Shutdown call can block until it's safe to stop.
@@ -81,10 +81,11 @@ type Server struct {
 
 // NewServer creates a RESP server bound to addr that dispatches commands to store.
 // shards is optional — if nil, per-shard metrics are not tracked.
-// tlsCfg is optional — if nil, plaintext TCP is used.
+// tlsConfigs is optional — if nil, plaintext TCP is used. When configured, each
+// accepted connection atomically loads the latest immutable TLS configuration.
 // requirePass is optional — if empty, AUTH is a no-op and connections start authenticated;
 // otherwise it is hashed once at startup and clients must AUTH before issuing commands.
-func NewServer(addr string, store Store, shards []*shard.Shard, logger log.Logger, tlsCfg *tlslib.Config, requirePass string) *Server {
+func NewServer(addr string, store Store, shards []*shard.Shard, logger log.Logger, tlsConfigs *tlslib.ConfigStore, requirePass string) *Server {
 	if logger == nil {
 		logger = log.NewNoOpLogger()
 	}
@@ -103,7 +104,7 @@ func NewServer(addr string, store Store, shards []*shard.Shard, logger log.Logge
 		store:           store,
 		shards:          shards,
 		logger:          logger,
-		tlsConfig:       tlsCfg,
+		tlsConfigs:      tlsConfigs,
 		requirePassHash: passHash,
 		ready:           make(chan struct{}),
 	}
@@ -153,9 +154,9 @@ func (s *Server) OnOpen(c gnet.Conn) (out []byte, action gnet.Action) {
 		authenticated: s.requirePassHash == nil,
 		remoteAddr:    c.RemoteAddr().String(),
 	}
-	if s.tlsConfig != nil {
+	if tlsCfg := s.tlsConfigs.Load(); tlsCfg != nil {
 		adapter := tlslib.NewGnetConnAdapter(c)
-		st.tlsConn = tlslib.Server(adapter, s.tlsConfig)
+		st.tlsConn = tlslib.Server(adapter, tlsCfg)
 		st.readBuf = make([]byte, 0, 4096)
 		st.handshakeDeadline = time.Now().Add(10 * time.Second)
 	}

--- a/internal/tls/config.go
+++ b/internal/tls/config.go
@@ -7,10 +7,12 @@ file paths. Supports TLS 1.3 and optional mTLS.
 package tls
 
 import (
+	"crypto/sha256"
 	"crypto/x509"
 	"fmt"
 	"net"
 	"os"
+	"sync/atomic"
 	"time"
 
 	"github.com/panjf2000/gnet/v2"
@@ -73,22 +75,79 @@ func (a *GnetConnAdapter) InboundBuffered() int {
 	return a.c.InboundBuffered()
 }
 
+// ConfigStore publishes immutable TLS configurations to protocol listeners.
+// Existing connections retain the configuration loaded when they were accepted;
+// new connections observe the latest configuration after an atomic replacement.
+type ConfigStore struct {
+	current atomic.Pointer[Config]
+}
+
+// NewConfigStore returns a store initialized with cfg. A nil configuration is
+// rejected because a reload must never downgrade an encrypted listener to plaintext.
+func NewConfigStore(cfg *Config) (*ConfigStore, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("tls: config store requires a non-nil config")
+	}
+	store := new(ConfigStore)
+	store.current.Store(cfg)
+	return store, nil
+}
+
+// Load returns the immutable configuration used for the next accepted connection.
+func (s *ConfigStore) Load() *Config {
+	if s == nil {
+		return nil
+	}
+	return s.current.Load()
+}
+
+// Store atomically publishes cfg for future connections.
+func (s *ConfigStore) Store(cfg *Config) error {
+	if s == nil || cfg == nil {
+		return fmt.Errorf("tls: cannot store a nil config")
+	}
+	s.current.Store(cfg)
+	return nil
+}
+
 // BuildConfig constructs a *Config from cert/key/CA file paths.
 // If certPath and keyPath are empty, returns (nil, nil) to signal TLS is disabled.
 // If caPath is non-empty, client certificate verification is enabled (mTLS).
-// Forces TLS 1.3 as the minimum version.
+// Forces TLS 1.3 as the minimum and maximum version.
 func BuildConfig(certPath, keyPath, caPath string) (*Config, error) {
+	cfg, _, err := loadConfig(certPath, keyPath, caPath)
+	return cfg, err
+}
+
+// loadConfig reads a complete TLS snapshot and returns a content fingerprint.
+// The fingerprint covers the certificate chain, private key, and optional client CA,
+// so CA-only rotations and reused certificate serials are not mistaken for no-ops.
+func loadConfig(certPath, keyPath, caPath string) (*Config, [sha256.Size]byte, error) {
+	var fingerprint [sha256.Size]byte
 	if (certPath == "") != (keyPath == "") {
-		return nil, fmt.Errorf("tls: both cert and key are required")
+		return nil, fingerprint, fmt.Errorf("tls: both cert and key are required")
 	}
 	if certPath == "" && keyPath == "" {
-		return nil, nil
+		return nil, fingerprint, nil
 	}
 
-	cert, err := LoadX509KeyPair(certPath, keyPath)
+	certPEM, err := os.ReadFile(certPath)
 	if err != nil {
-		return nil, fmt.Errorf("tls: failed to load certificate/key: %w", err)
+		return nil, fingerprint, fmt.Errorf("tls: failed to read certificate file: %w", err)
 	}
+	keyPEM, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, fingerprint, fmt.Errorf("tls: failed to read key file: %w", err)
+	}
+	cert, err := X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return nil, fingerprint, fmt.Errorf("tls: failed to load certificate/key: %w", err)
+	}
+	leaf, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		return nil, fingerprint, fmt.Errorf("tls: failed to parse leaf certificate: %w", err)
+	}
+	cert.Leaf = leaf
 
 	cfg := &Config{
 		Certificates: []Certificate{cert},
@@ -96,20 +155,29 @@ func BuildConfig(certPath, keyPath, caPath string) (*Config, error) {
 		MaxVersion:   VersionTLS13,
 	}
 
+	var caPEM []byte
 	if caPath != "" {
-		caPEM, err := os.ReadFile(caPath)
+		caPEM, err = os.ReadFile(caPath)
 		if err != nil {
-			return nil, fmt.Errorf("tls: failed to read CA file: %w", err)
+			return nil, fingerprint, fmt.Errorf("tls: failed to read CA file: %w", err)
 		}
 		pool := x509.NewCertPool()
 		if !pool.AppendCertsFromPEM(caPEM) {
-			return nil, fmt.Errorf("tls: failed to parse CA certificate")
+			return nil, fingerprint, fmt.Errorf("tls: failed to parse CA certificate")
 		}
 		cfg.ClientCAs = pool
 		cfg.ClientAuth = RequireAndVerifyClientCert
 	}
 
-	return cfg, nil
+	h := sha256.New()
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write(certPEM)
+	_, _ = h.Write([]byte{1})
+	_, _ = h.Write(keyPEM)
+	_, _ = h.Write([]byte{2})
+	_, _ = h.Write(caPEM)
+	copy(fingerprint[:], h.Sum(nil))
+	return cfg, fingerprint, nil
 }
 
 // IsMTLS returns true if the config requires client certificate verification.

--- a/internal/tls/reloader.go
+++ b/internal/tls/reloader.go
@@ -1,0 +1,295 @@
+/*
+Package tls
+Tellstone TLS Certificate Rotation
+File: reloader.go
+Description: Watches TLS certificate, private key, and client CA directories and atomically publishes validated replacements for new connections.
+
+Authors:
+
+	Khai
+*/
+package tls
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/Saxy/Tellstone/internal/log"
+	"github.com/fsnotify/fsnotify"
+)
+
+const certificateReloadDebounce = 500 * time.Millisecond
+
+// Reloader watches the parent directories of configured TLS files. Watching
+// directories rather than individual files supports atomic rename workflows and
+// Kubernetes Secret projection, where the ..data symlink is replaced on rotation.
+type Reloader struct {
+	certPath string
+	keyPath  string
+	caPath   string
+
+	watcher     *fsnotify.Watcher
+	closeOnce   sync.Once
+	watchedDirs map[string]struct{}
+	targets     map[string]struct{}
+	configs     *ConfigStore
+	fingerprint [sha256.Size]byte
+	debounce    time.Duration
+
+	reloadTotal       atomic.Uint64
+	reloadErrorsTotal atomic.Uint64
+	expiryUnix        atomic.Int64
+}
+
+// NewReloader validates the initial TLS material, creates one watch per distinct
+// parent directory, and returns a reloader ready to run. The directory watches are
+// installed before the initial read so rotation cannot be missed during startup.
+func NewReloader(certPath, keyPath, caPath string) (*Reloader, error) {
+	certPath, err := absoluteCleanPath(certPath)
+	if err != nil {
+		return nil, fmt.Errorf("tls: certificate path: %w", err)
+	}
+	keyPath, err = absoluteCleanPath(keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("tls: key path: %w", err)
+	}
+	if caPath != "" {
+		caPath, err = absoluteCleanPath(caPath)
+		if err != nil {
+			return nil, fmt.Errorf("tls: CA path: %w", err)
+		}
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("tls: create certificate watcher: %w", err)
+	}
+	closeOnError := true
+	defer func() {
+		if closeOnError {
+			_ = watcher.Close()
+		}
+	}()
+
+	dirs := make(map[string]struct{}, 3)
+	targets := make(map[string]struct{}, 3)
+	for _, path := range []string{certPath, keyPath, caPath} {
+		if path == "" {
+			continue
+		}
+		targets[path] = struct{}{}
+		dirs[filepath.Dir(path)] = struct{}{}
+	}
+	for dir := range dirs {
+		if err = watcher.Add(dir); err != nil {
+			return nil, fmt.Errorf("tls: watch certificate directory %q: %w", dir, err)
+		}
+	}
+
+	cfg, fingerprint, err := loadConfig(certPath, keyPath, caPath)
+	if err != nil {
+		return nil, err
+	}
+	configs, err := NewConfigStore(cfg)
+	if err != nil {
+		return nil, err
+	}
+	r := &Reloader{
+		certPath:    certPath,
+		keyPath:     keyPath,
+		caPath:      caPath,
+		watcher:     watcher,
+		watchedDirs: dirs,
+		targets:     targets,
+		configs:     configs,
+		fingerprint: fingerprint,
+		debounce:    certificateReloadDebounce,
+	}
+	r.expiryUnix.Store(cfg.Certificates[0].Leaf.NotAfter.Unix())
+	closeOnError = false
+	return r, nil
+}
+
+func absoluteCleanPath(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	// Deliberately do not evaluate symlinks: resolving a Kubernetes ..data link
+	// would pin the reloader to the old Secret projection directory.
+	return filepath.Clean(absolute), nil
+}
+
+// Configs returns the shared atomic configuration store used by both listeners.
+func (r *Reloader) Configs() *ConfigStore {
+	if r == nil {
+		return nil
+	}
+	return r.configs
+}
+
+// Close releases the filesystem watcher. It is safe to call after Run exits or
+// during startup cleanup before Run begins.
+func (r *Reloader) Close() error {
+	if r == nil || r.watcher == nil {
+		return nil
+	}
+	var err error
+	r.closeOnce.Do(func() { err = r.watcher.Close() })
+	return err
+}
+
+// Run processes filesystem notifications until ctx is canceled. Invalid replacement
+// material is logged and ignored, leaving the last valid configuration active.
+func (r *Reloader) Run(ctx context.Context, logger log.Logger) error {
+	if r == nil || r.watcher == nil {
+		return fmt.Errorf("tls: certificate reloader is not initialized")
+	}
+	if logger == nil {
+		logger = log.NewNoOpLogger()
+	}
+	defer r.Close()
+
+	var timer *time.Timer
+	var timerC <-chan time.Time
+	schedule := func() {
+		if timer == nil {
+			timer = time.NewTimer(r.debounce)
+			timerC = timer.C
+			return
+		}
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+		timer.Reset(r.debounce)
+		timerC = timer.C
+	}
+	defer func() {
+		if timer != nil {
+			timer.Stop()
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case event, ok := <-r.watcher.Events:
+			if !ok {
+				return errors.New("tls: certificate watcher event channel closed")
+			}
+			if r.relevantEvent(event.Name) {
+				// Direct writes, atomic renames onto a target, and Kubernetes ..data
+				// symlink swaps all settle into one complete snapshot reload.
+				schedule()
+			}
+		case watchErr, ok := <-r.watcher.Errors:
+			if !ok {
+				return errors.New("tls: certificate watcher error channel closed")
+			}
+			r.reloadErrorsTotal.Add(1)
+			if logger.Enabled(log.LevelError) {
+				logger.Log(log.LevelError, "tls certificate watcher error",
+					log.String("error", watchErr.Error()),
+				)
+			}
+			// A watcher overflow means events may have been lost. Rescan the complete
+			// snapshot after the debounce window rather than waiting for another event.
+			schedule()
+		case <-timerC:
+			timerC = nil
+			r.reload(logger)
+		}
+	}
+}
+
+func (r *Reloader) relevantEvent(name string) bool {
+	name = filepath.Clean(name)
+	if _, ok := r.targets[name]; ok {
+		return true
+	}
+	if _, ok := r.watchedDirs[name]; ok {
+		return true
+	}
+	// Kubernetes publishes a projected Secret by atomically renaming ..data_tmp
+	// over ..data while the visible certificate paths remain unchanged symlinks.
+	base := filepath.Base(name)
+	if base != "..data" && base != "..data_tmp" {
+		return false
+	}
+	_, ok := r.watchedDirs[filepath.Dir(name)]
+	return ok
+}
+
+func (r *Reloader) reload(logger log.Logger) {
+	cfg, fingerprint, err := loadConfig(r.certPath, r.keyPath, r.caPath)
+	if err != nil {
+		r.reloadErrorsTotal.Add(1)
+		if logger.Enabled(log.LevelError) {
+			logger.Log(log.LevelError, "tls certificate reload failed; retaining current certificate",
+				log.String("error", err.Error()),
+			)
+		}
+		return
+	}
+	if bytes.Equal(fingerprint[:], r.fingerprint[:]) {
+		return
+	}
+	if err = r.configs.Store(cfg); err != nil {
+		r.reloadErrorsTotal.Add(1)
+		if logger.Enabled(log.LevelError) {
+			logger.Log(log.LevelError, "tls certificate reload failed; retaining current certificate",
+				log.String("error", err.Error()),
+			)
+		}
+		return
+	}
+
+	r.fingerprint = fingerprint
+	r.expiryUnix.Store(cfg.Certificates[0].Leaf.NotAfter.Unix())
+	r.reloadTotal.Add(1)
+	if logger.Enabled(log.LevelInfo) {
+		logger.Log(log.LevelInfo, "tls certificate rotated",
+			log.String("serial", cfg.Certificates[0].Leaf.SerialNumber.String()),
+			log.String("not_after", cfg.Certificates[0].Leaf.NotAfter.UTC().Format(time.RFC3339)),
+		)
+	}
+}
+
+// ReloadTotal returns the number of validated configurations published after startup.
+func (r *Reloader) ReloadTotal() uint64 {
+	if r == nil {
+		return 0
+	}
+	return r.reloadTotal.Load()
+}
+
+// ReloadErrorsTotal returns the number of watcher or validation failures.
+func (r *Reloader) ReloadErrorsTotal() uint64 {
+	if r == nil {
+		return 0
+	}
+	return r.reloadErrorsTotal.Load()
+}
+
+// CertificateExpirySeconds returns the active leaf certificate's NotAfter value
+// as Unix epoch seconds for Prometheus exposition.
+func (r *Reloader) CertificateExpirySeconds() int64 {
+	if r == nil {
+		return 0
+	}
+	return r.expiryUnix.Load()
+}

--- a/internal/tls/reloader_test.go
+++ b/internal/tls/reloader_test.go
@@ -1,0 +1,228 @@
+/*
+Package tls
+Tellstone TLS Certificate Rotation Tests
+File: reloader_test.go
+Description: Verifies atomic TLS config publication, invalid-reload retention, and Kubernetes Secret projection handling.
+
+Authors:
+
+	Khai
+*/
+package tls
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Saxy/Tellstone/internal/log"
+)
+
+func TestBuildConfigPopulatesLeaf(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "tls.crt")
+	keyPath := filepath.Join(dir, "tls.key")
+	writeTLSFiles(t, certPath, keyPath, []byte(rsaCertPEM), []byte(rsaKeyPEM))
+
+	cfg, err := BuildConfig(certPath, keyPath, "")
+	if err != nil {
+		t.Fatalf("BuildConfig: %v", err)
+	}
+	if cfg.Certificates[0].Leaf == nil {
+		t.Fatal("expected parsed leaf certificate")
+	}
+	if cfg.MinVersion != VersionTLS13 || cfg.MaxVersion != VersionTLS13 {
+		t.Fatalf("expected TLS 1.3 only, got min=%x max=%x", cfg.MinVersion, cfg.MaxVersion)
+	}
+}
+
+func TestReloaderPublishesValidRotationAndRetainsInvalidReplacement(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "tls.crt")
+	keyPath := filepath.Join(dir, "tls.key")
+	writeTLSFiles(t, certPath, keyPath, []byte(rsaCertPEM), []byte(rsaKeyPEM))
+
+	r, err := NewReloader(certPath, keyPath, "")
+	if err != nil {
+		t.Fatalf("NewReloader: %v", err)
+	}
+	r.debounce = 20 * time.Millisecond
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx, log.NewNoOpLogger()) }()
+	t.Cleanup(func() {
+		cancel()
+		if err := <-done; err != nil {
+			t.Errorf("Run: %v", err)
+		}
+	})
+
+	initial := r.Configs().Load()
+	writeTLSFiles(t, certPath, keyPath, []byte(ecdsaCertPEM), []byte(ecdsaKeyPEM))
+	waitForTLSCondition(t, time.Second, func() bool { return r.ReloadTotal() == 1 })
+	rotated := r.Configs().Load()
+	if rotated == initial {
+		t.Fatal("expected a newly published TLS config")
+	}
+	if rotated.Certificates[0].Leaf.SerialNumber.Cmp(initial.Certificates[0].Leaf.SerialNumber) == 0 {
+		t.Fatal("expected the active leaf certificate to change")
+	}
+
+	if err := os.WriteFile(certPath, []byte("not a certificate"), 0o600); err != nil {
+		t.Fatalf("write invalid certificate: %v", err)
+	}
+	waitForTLSCondition(t, time.Second, func() bool { return r.ReloadErrorsTotal() >= 1 })
+	if got := r.Configs().Load(); got != rotated {
+		t.Fatal("invalid replacement must retain the last valid TLS config")
+	}
+}
+
+func TestReloaderDoesNotDelayRotationForUnrelatedDirectoryNoise(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "tls.crt")
+	keyPath := filepath.Join(dir, "tls.key")
+	noisePath := filepath.Join(dir, "application.log")
+	writeTLSFiles(t, certPath, keyPath, []byte(rsaCertPEM), []byte(rsaKeyPEM))
+
+	r, err := NewReloader(certPath, keyPath, "")
+	if err != nil {
+		t.Fatalf("NewReloader: %v", err)
+	}
+	r.debounce = 40 * time.Millisecond
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx, log.NewNoOpLogger()) }()
+	t.Cleanup(func() {
+		cancel()
+		if err := <-done; err != nil {
+			t.Errorf("Run: %v", err)
+		}
+	})
+
+	noiseDone := make(chan struct{})
+	go func() {
+		defer close(noiseDone)
+		for i := 0; i < 40; i++ {
+			_ = os.WriteFile(noisePath, []byte(time.Now().String()), 0o600)
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+	writeTLSFiles(t, certPath, keyPath, []byte(ecdsaCertPEM), []byte(ecdsaKeyPEM))
+	waitForTLSCondition(t, 250*time.Millisecond, func() bool { return r.ReloadTotal() == 1 })
+	<-noiseDone
+}
+
+func TestReloaderPublishesCAOnlyRotation(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "tls.crt")
+	keyPath := filepath.Join(dir, "tls.key")
+	caPath := filepath.Join(dir, "ca.crt")
+	writeTLSFiles(t, certPath, keyPath, []byte(rsaCertPEM), []byte(rsaKeyPEM))
+	if err := os.WriteFile(caPath, []byte(rsaCertPEM), 0o600); err != nil {
+		t.Fatalf("write initial CA: %v", err)
+	}
+
+	r, err := NewReloader(certPath, keyPath, caPath)
+	if err != nil {
+		t.Fatalf("NewReloader: %v", err)
+	}
+	r.debounce = 20 * time.Millisecond
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx, log.NewNoOpLogger()) }()
+	t.Cleanup(func() {
+		cancel()
+		if err := <-done; err != nil {
+			t.Errorf("Run: %v", err)
+		}
+	})
+
+	initial := r.Configs().Load()
+	if err := os.WriteFile(caPath, []byte(ecdsaCertPEM), 0o600); err != nil {
+		t.Fatalf("write replacement CA: %v", err)
+	}
+	waitForTLSCondition(t, time.Second, func() bool { return r.ReloadTotal() == 1 })
+	rotated := r.Configs().Load()
+	if rotated == initial {
+		t.Fatal("expected CA-only rotation to publish a new config")
+	}
+	if rotated.Certificates[0].Leaf.SerialNumber.Cmp(initial.Certificates[0].Leaf.SerialNumber) != 0 {
+		t.Fatal("CA-only rotation must not change the server leaf certificate")
+	}
+}
+
+func TestReloaderDetectsKubernetesSecretProjectionSwap(t *testing.T) {
+	root := t.TempDir()
+	writeProjectedSecretVersion(t, root, "..2026_01", []byte(rsaCertPEM), []byte(rsaKeyPEM))
+	if err := os.Symlink("..2026_01", filepath.Join(root, "..data")); err != nil {
+		t.Fatalf("create ..data symlink: %v", err)
+	}
+	if err := os.Symlink("..data/tls.crt", filepath.Join(root, "tls.crt")); err != nil {
+		t.Fatalf("create certificate symlink: %v", err)
+	}
+	if err := os.Symlink("..data/tls.key", filepath.Join(root, "tls.key")); err != nil {
+		t.Fatalf("create key symlink: %v", err)
+	}
+
+	r, err := NewReloader(filepath.Join(root, "tls.crt"), filepath.Join(root, "tls.key"), "")
+	if err != nil {
+		t.Fatalf("NewReloader: %v", err)
+	}
+	r.debounce = 20 * time.Millisecond
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx, log.NewNoOpLogger()) }()
+	t.Cleanup(func() {
+		cancel()
+		if err := <-done; err != nil {
+			t.Errorf("Run: %v", err)
+		}
+	})
+
+	initial := r.Configs().Load()
+	writeProjectedSecretVersion(t, root, "..2026_02", []byte(ecdsaCertPEM), []byte(ecdsaKeyPEM))
+	if err := os.Symlink("..2026_02", filepath.Join(root, "..data_tmp")); err != nil {
+		t.Fatalf("create replacement ..data symlink: %v", err)
+	}
+	if err := os.Rename(filepath.Join(root, "..data_tmp"), filepath.Join(root, "..data")); err != nil {
+		t.Fatalf("replace ..data symlink: %v", err)
+	}
+
+	waitForTLSCondition(t, time.Second, func() bool { return r.ReloadTotal() == 1 })
+	if got := r.Configs().Load(); got == initial {
+		t.Fatal("expected Kubernetes projection swap to publish a new config")
+	}
+}
+
+func writeTLSFiles(t *testing.T, certPath, keyPath string, certPEM, keyPEM []byte) {
+	t.Helper()
+	if err := os.WriteFile(certPath, certPEM, 0o600); err != nil {
+		t.Fatalf("write certificate: %v", err)
+	}
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+}
+
+func writeProjectedSecretVersion(t *testing.T, root, name string, certPEM, keyPEM []byte) {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatalf("create projected Secret version: %v", err)
+	}
+	writeTLSFiles(t, filepath.Join(dir, "tls.crt"), filepath.Join(dir, "tls.key"), certPEM, keyPEM)
+}
+
+func waitForTLSCondition(t *testing.T, timeout time.Duration, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("condition was not met before timeout")
+}

--- a/server/server.go
+++ b/server/server.go
@@ -59,13 +59,14 @@ func (rs *RouterStore) Delete(key string) {
 }
 
 type Server struct {
-	app        *tellstone.App
-	router     *router.Router
-	shards     []*shard.Shard
-	netSrv     *network.Server
-	respSrv    *resp.Server
-	metricsSrv *http.Server
-	tlsConfig  *tlslib.Config
+	app         *tellstone.App
+	router      *router.Router
+	shards      []*shard.Shard
+	netSrv      *network.Server
+	respSrv     *resp.Server
+	metricsSrv  *http.Server
+	tlsConfigs  *tlslib.ConfigStore
+	tlsReloader *tlslib.Reloader
 }
 
 func NewServer(app *tellstone.App) *Server {
@@ -81,14 +82,19 @@ func (s *Server) Run() error {
 	if err != nil {
 		return fmt.Errorf("crypto init: %w", err)
 	}
-	var tlsCfg *tlslib.Config
+	tlsReloaderStarted := false
 	if cfg.TLSEnabled() {
-		tlsCfg, err = tlslib.BuildConfig(cfg.GetTLSCert(), cfg.GetTLSKey(), cfg.GetTLSCA())
+		s.tlsReloader, err = tlslib.NewReloader(cfg.GetTLSCert(), cfg.GetTLSKey(), cfg.GetTLSCA())
 		if err != nil {
 			return fmt.Errorf("tls config: %w", err)
 		}
+		defer func() {
+			if !tlsReloaderStarted {
+				_ = s.tlsReloader.Close()
+			}
+		}()
+		s.tlsConfigs = s.tlsReloader.Configs()
 	}
-	s.tlsConfig = tlsCfg
 	if err = s.initShards(cryptoEngine); err != nil {
 		return fmt.Errorf("shard init: %w", err)
 	}
@@ -98,7 +104,7 @@ func (s *Server) Run() error {
 		s.shards,
 		s.networkHandler,
 		logger,
-		tlsCfg,
+		s.tlsConfigs,
 		cfg.GetRequirePass(),
 	)
 	if cfg.MetricsEnabled() {
@@ -106,6 +112,24 @@ func (s *Server) Run() error {
 	}
 	if cfg.RESPEnabled() {
 		s.startRESPServer()
+	}
+
+	if s.tlsReloader != nil {
+		reloadCtx, cancelReload := context.WithCancel(context.Background())
+		tlsReloaderStarted = true
+		reloadDone := make(chan struct{})
+		go func() {
+			defer close(reloadDone)
+			if reloadErr := s.tlsReloader.Run(reloadCtx, logger); reloadErr != nil && logger.Enabled(log.LevelError) {
+				logger.Log(log.LevelError, "tls certificate watcher stopped",
+					log.String("error", reloadErr.Error()),
+				)
+			}
+		}()
+		defer func() {
+			cancelReload()
+			<-reloadDone
+		}()
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -223,7 +247,11 @@ func (s *Server) startMetricsServer(srv *network.Server) {
 	for i, sh := range s.shards {
 		shardCollectors[i] = metrics.NewShardCollector(uint32(sh.ID), sh, sh.Engine, srv, logger)
 	}
-	aggregateCollector := metrics.NewAggregateCollector(shardCollectors, srv)
+	var tlsMetrics metrics.TLSMetrics
+	if s.tlsReloader != nil {
+		tlsMetrics = s.tlsReloader
+	}
+	aggregateCollector := metrics.NewAggregateCollector(shardCollectors, srv, tlsMetrics)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
@@ -252,7 +280,7 @@ func (s *Server) startRESPServer() {
 	cfg := s.app.GetConfig()
 	logger := s.app.GetLogger()
 	store := &RouterStore{router: s.router}
-	respSrv := resp.NewServer(cfg.GetRESPAddr(), store, s.shards, logger, s.tlsConfig, cfg.GetRequirePass())
+	respSrv := resp.NewServer(cfg.GetRESPAddr(), store, s.shards, logger, s.tlsConfigs, cfg.GetRequirePass())
 	s.respSrv = respSrv
 	go func() {
 		if err := respSrv.ListenAndServe(); err != nil {


### PR DESCRIPTION
## Description

Adds automatic TLS certificate rotation for the binary and RESP listeners. Tellstone now watches
the configured certificate, private key, and optional client CA directories and atomically
publishes validated replacements to newly accepted connections without restarting the server.
Established TLS sessions retain their original configuration and continue uninterrupted.

The change also exposes certificate reload metrics, supports Kubernetes projected Secret updates,
and retains the last valid TLS configuration when replacement files are incomplete or invalid.
TLS-disabled deployments create no watcher and incur no additional request-path overhead.

**Component:** Networking/TLS

**Type of Change:**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance optimization (no change in behavior, improved speed/memory)
- [ ] Refactoring (no functional changes, code cleanup)
- [ ] Build / CI / Documentation

---

## Related Issue

Closes #14

---

## Technical Deep Dive & Context

### Atomic TLS configuration publication

A shared `tls.ConfigStore` owns an `atomic.Pointer` to the current immutable TLS configuration.
Both the binary and RESP listeners load this pointer once when accepting a connection and pass the
result to that connection's TLS state.

This establishes a clear rotation boundary:

- Connections accepted before publication retain the previous configuration.
- Connections accepted after publication use the replacement configuration.
- No published configuration is mutated in place.
- Binary and RESP listeners observe the same shared configuration store.
- The request hot path performs no additional loads, locks, or allocations.

### Filesystem watcher and validation

The new TLS reloader uses `fsnotify` to watch the distinct parent directories of the configured
certificate, key, and optional CA paths. Parent-directory watching handles direct writes and
atomic file replacement while also supporting Kubernetes projected Secrets, which rotate by
replacing the `..data` symlink.

Relevant events are debounced for 500 ms before Tellstone reads a complete snapshot. Unrelated
activity in the watched directories is ignored so it cannot indefinitely postpone a valid
rotation or cause unnecessary certificate parsing.

Each candidate snapshot is fully validated before publication:

1. Read the certificate, private key, and optional client CA.
2. Parse and validate the certificate/private-key pair.
3. Pre-parse the leaf certificate to avoid lazy parsing during future handshakes.
4. Build a fresh TLS 1.3 configuration, including mTLS client verification when a CA is configured.
5. Compare a SHA-256 fingerprint covering all input material.
6. Atomically publish the replacement only when the complete snapshot is valid and changed.

A full-input fingerprint is used instead of certificate serial comparison because serial-only
comparison would miss CA-only rotations, certificate-chain changes, and certificates that reuse a
serial number. Fingerprints are used only for in-memory comparison and are never logged or
exported.

If reading or validation fails, the error counter is incremented, the failure is logged, and the
last valid configuration remains active. Watcher resources are released during normal shutdown
and startup error paths.

### Metrics

When TLS and metrics are enabled, the aggregate Prometheus collector exports:

- `tellstone_tls_cert_reload_total` — successfully published replacements.
- `tellstone_tls_cert_reload_errors_total` — failed watcher or validation attempts.
- `tellstone_tls_cert_expiry_seconds` — active leaf certificate `NotAfter` as Unix epoch seconds.

TLS metrics are omitted when TLS is disabled.

### Dependency and operational impact

This adds `github.com/fsnotify/fsnotify` as a direct dependency. It provides portable filesystem
notifications across the platforms supported by Tellstone and reuses the existing
`golang.org/x/sys` dependency.

When TLS is enabled, the operational cost is one watcher goroutine, one filesystem watcher, and one
watch per distinct parent directory. When TLS is disabled, no watcher, goroutine, file descriptor,
or TLS rotation metric is created.

### Documentation

The TLS configuration table, architecture reference, rotation design, flag descriptions, and
roadmap status were updated to describe the new behavior.

---

## Performance & Benchmarks

No measurable request-path regression was observed. Rotation changes connection acceptance and
background certificate management; established request processing does not access the config
store. Heap usage and allocation count remained identical in the TLS round-trip benchmark.

**Workload:** `BenchmarkGnetTLS`, sequential TLS 1.3 binary-protocol PING/PONG round trips, three
runs per revision on macOS/arm64, Apple M3.

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| TLS round trip | 24,324 ns/op | 23,710 ns/op | -2.5% |
| Heap allocation | 696 B/op | 696 B/op | 0% |
| Allocations | 3 allocs/op | 3 allocs/op | 0% |

The small timing difference is within normal local benchmark variance and is not claimed as a
performance improvement.

```text
Before (upstream/main at 37a3e14):
BenchmarkGnetTLS-8       45944    24384 ns/op    696 B/op    3 allocs/op
BenchmarkGnetTLS-8       47055    24313 ns/op    696 B/op    3 allocs/op
BenchmarkGnetTLS-8       46028    24276 ns/op    696 B/op    3 allocs/op

After:
BenchmarkGnetTLS-8       47617    23886 ns/op    696 B/op    3 allocs/op
BenchmarkGnetTLS-8       45945    23527 ns/op    696 B/op    3 allocs/op
BenchmarkGnetTLS-8       47089    23717 ns/op    696 B/op    3 allocs/op
```

---

## How Has This Been Tested?

Repository-wide validation:

```text
go vet ./...          PASS
go test -race ./...   PASS
```

Focused race-detector validation:

```text
go test -race ./internal/tls ./internal/metrics ./internal/network ./internal/resp ./server
PASS
```

Rotation tests were repeatedly executed to check filesystem-event timing and stability:

```text
go test -count=10 ./internal/tls -run 'TestReloader|TestBuildConfigPopulatesLeaf'
PASS

go test -count=5 ./internal/network -run TestServerTLSConfigRotation
PASS
```

Coverage includes:

- TLS 1.3 config construction with a pre-parsed leaf certificate.
- Valid certificate/private-key rotation.
- Invalid replacement retention of the last valid configuration.
- CA-only mTLS trust rotation with an unchanged server certificate.
- Kubernetes projected Secret `..data` symlink replacement.
- Direct file writes and atomic replacement events.
- Unrelated high-frequency activity in a watched directory.
- Existing TLS connections remaining usable after rotation.
- New TLS connections receiving the replacement certificate.
- New connections rejecting the rotated-out certificate.
- Successful reload, failed reload, and certificate expiry metrics.
- Omission of TLS metrics when TLS rotation is disabled.
- Watcher cleanup during shutdown and startup failure paths.

---

## Checklist

- [x] My code follows the existing code style of this project
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally (`go test ./...` and `go test -race ./...`)
- [x] I have updated the documentation (README, comments, or any relevant docs)
- [x] My changes generate no new `go vet` warnings
- [x] Any breaking changes are documented and communicated — no breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic TLS certificate, private key, and client CA rotation when watched files change.
  * Updated connections use valid rotated certificates, while existing TLS connections remain uninterrupted.
  * Added TLS 1.3 and optional mutual TLS configuration options.
  * Added Prometheus metrics for certificate reloads, reload errors, and certificate expiry.

* **Documentation**
  * Expanded configuration and architecture documentation with TLS rotation details and command-line options.
  * Marked automatic certificate rotation as completed in the roadmap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->