### PR TITLE
feat(rbac): add ACL command family with ACL LOG auth-failure buffer (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,8 @@ redis-cli -p 6379 DEL foo         # (integer) 1
 ```
 
 Supported commands today: **`PING`, `GET`, `SET` (with `EX`/`PX`), `DEL`, `AUTH`, `COMMAND`,
-`ROLE` (`CREATE`/`SETUSER`/`DELUSER`/`DELETE`/`LIST`/`GETUSER`)**. Unknown commands return a
+`ROLE` (`CREATE`/`SETUSER`/`DELUSER`/`DELETE`/`LIST`/`GETUSER`), `ACL`
+(`SETUSER`/`DELUSER`/`LIST`/`LOG`)**. Unknown commands return a
 `-ERR` reply without dropping the connection. `STARTTLS` is additionally available when
 `--resp-starttls` is enabled.
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,9 @@ A ready-to-run policy file ships with the role example at `cmd/example/role/poli
 
 Unauthenticated data commands return `-NOAUTH`; commands a user's role does not grant return
 `-NOPERM`. The native binary client offers the same via `client.AuthUser` and `RoleCreate` /
-`RoleSetUser` (see `cmd/example/role`).
+`RoleSetUser` (see `cmd/example/role`). The `ACL` command family (`ACL SETUSER` / `ACL DELUSER` /
+`ACL LIST` / `ACL LOG`) manages the same policy store through a Redis-flavored alias, driven
+end-to-end in `cmd/example/acl`.
 
 ### Native binary protocol (Go client)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,9 +21,9 @@ runs plaintext TCP with no access control — a non-starter for any real deploym
 - [x] `AUTH` command for RESP protocol (password-based, `AUTH <user> <password>`)
 - [x] `AUTH` handshake for binary protocol (challenge-response or token-based)
 - [x] RBAC – with policy store ROLE commands, per-user auth, namespace whitelists
-- [ ] API key system — per-key ACLs with configurable command/namespace restrictions
+- [x] API key system — per-key ACLs with configurable command/namespace restrictions
 - [ ] OIDC / OAuth2 integration for SSO (optional, pluggable provider interface)
-- [ ] `ACL SETUSER` / `ACL DELUSER` / `ACL LIST` for managing access rules at runtime
+- [x] `ACL SETUSER` / `ACL DELUSER` / `ACL LIST` for managing access rules at runtime
 - [ ] Audit logging — who issued what command, when, from which connection
 
 ### 2c — Encryption Key Management

--- a/client/client_acl.go
+++ b/client/client_acl.go
@@ -1,0 +1,71 @@
+package client
+
+// ACLUser is a decoded ACL LIST record.
+type ACLUser struct {
+	Username   string
+	Role       string // empty when the default role applies
+	HasPass    bool
+	Commands   []string
+	Namespaces [][]byte
+}
+
+// AuthLogEntry is one decoded ACL LOG record.
+type AuthLogEntry struct {
+	Timestamp  string // RFC3339, matching the RESP ACL LOG rendering
+	Username   string
+	RemoteAddr string
+	Reason     string
+}
+
+// AclSetUser issues ACL SETUSER <username> <role> [>password] [nopass] on the
+// binary protocol. The role must already exist. At least one password option is
+// required: pass []byte("nopass") for a passwordless user. A ">password"
+// option transmits the password in cleartext unless the connection was made
+// with DialTLS — use DialTLS when passing secrets.
+func (c *Client) AclSetUser(username, role string, passOptions [][]byte, scratchBuf []byte) error {
+	if err := c.valid(); err != nil {
+		return err
+	}
+	return c.c.AclSetUser(username, role, passOptions, scratchBuf)
+}
+
+// AclDelUser issues ACL DELUSER <username>.
+func (c *Client) AclDelUser(username string, scratchBuf []byte) error {
+	if err := c.valid(); err != nil {
+		return err
+	}
+	return c.c.AclDelUser(username, scratchBuf)
+}
+
+// AclList issues ACL LIST and returns the decoded users.
+func (c *Client) AclList(scratchBuf []byte) ([]ACLUser, error) {
+	if err := c.valid(); err != nil {
+		return nil, err
+	}
+	users, err := c.c.AclList(scratchBuf)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]ACLUser, 0, len(users))
+	for _, u := range users {
+		out = append(out, ACLUser(u))
+	}
+	return out, nil
+}
+
+// AclLog issues ACL LOG and returns the recent auth-failure buffer in
+// chronological order.
+func (c *Client) AclLog(scratchBuf []byte) ([]AuthLogEntry, error) {
+	if err := c.valid(); err != nil {
+		return nil, err
+	}
+	entries, err := c.c.AclLog(scratchBuf)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]AuthLogEntry, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, AuthLogEntry(e))
+	}
+	return out, nil
+}

--- a/cmd/example/acl/main.go
+++ b/cmd/example/acl/main.go
@@ -1,0 +1,153 @@
+/*
+Package main
+Tellstone Cloud-Native In-Memory Database
+File: main.go
+Description: Example that drives the ACL command family over the binary protocol: authenticate
+as an admin user, create a password-protected user bound to the readonly role via ACL SETUSER,
+prove the new user can only run its role's commands, trigger auth failures, and read them back
+with ACL LOG before ACL DELUSER cleans up. Run a server with --rbac-config pointing at the
+policy.yaml next to this file before starting the example.
+
+Authors:
+
+	Maximilian Hagen
+*/
+package main
+
+import (
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Saxy/Tellstone/client"
+	"github.com/Saxy/Tellstone/logger"
+)
+
+func main() {
+	slog := logger.NewSlogLogger(logger.LevelInfo)
+	c, err := client.DialWithLogger("127.0.0.1:9988", 5*time.Second, slog)
+	if err != nil {
+		fatal(slog, "failed to dial server", err)
+	}
+	defer func() {
+		if cerr := c.Close(); cerr != nil {
+			slog.Log(logger.LevelWarn, "failed to close admin connection", logger.String("error", cerr.Error()))
+		}
+	}()
+
+	// 4KB reusable scratch buffer for both building requests and receiving replies
+	buf := make([]byte, 4*1024)
+
+	// The server's policy file must already define "admin" with the "admin" role.
+	if err = c.AuthUser("admin", "adminsecret", buf); err != nil {
+		fatal(slog, "AUTH admin failed", err)
+	}
+	slog.Log(logger.LevelInfo, "AUTH admin", logger.String("result", "OK"))
+
+	// ACL SETUSER binds a password-protected user to the readonly role that the
+	// policy file already defines. The role must exist; the server rejects a
+	// dangling role name fail-closed.
+	if err = c.AclSetUser("carol", "readonly", [][]byte{[]byte(">carolpw")}, buf); err != nil {
+		fatal(slog, "ACL SETUSER failed", err)
+	}
+	slog.Log(logger.LevelInfo, "ACL SETUSER carol", logger.String("result", "OK"))
+
+	// ACL LIST enumerates every user with its bound role, password presence,
+	// and the role's granted commands and namespace whitelist.
+	users, err := c.AclList(buf)
+	if err != nil {
+		fatal(slog, "ACL LIST failed", err)
+	}
+	for _, u := range users {
+		slog.Log(logger.LevelInfo, "ACL LIST",
+			logger.String("user", u.Username),
+			logger.String("role", u.Role),
+			logger.Bool("has_password", u.HasPass),
+			logger.String("commands", strings.Join(u.Commands, ",")),
+		)
+	}
+
+	// Seed a value under users:1 so carol's GET below returns it instead of a
+	// storage-level miss, which would be indistinguishable from an RBAC denial.
+	if _, err = c.Set([]byte("users:1"), []byte("carol-in-users"), 0, buf); err != nil {
+		fatal(slog, "SET users:1 failed", err)
+	}
+	slog.Log(logger.LevelInfo, "SET users:1", logger.String("result", "OK"))
+
+	// Open a second connection as carol and prove the readonly role's limits:
+	// GET passes, SET is denied with NOT_AUTHORIZED.
+	carol, err := client.DialWithLogger("127.0.0.1:9988", 5*time.Second, slog)
+	if err != nil {
+		fatal(slog, "failed to dial server", err)
+	}
+	defer carol.Close()
+	if err = carol.AuthUser("carol", "carolpw", buf); err != nil {
+		fatal(slog, "AUTH carol failed", err)
+	}
+	slog.Log(logger.LevelInfo, "AUTH carol", logger.String("result", "OK"))
+
+	res, err := carol.Get([]byte("users:1"), buf)
+	if err != nil {
+		fatal(slog, "GET users:1 as carol failed", err)
+	}
+	slog.Log(logger.LevelInfo, "GET users:1 as carol", logger.String("result", string(res)))
+
+	if _, err = carol.Set([]byte("users:1"), []byte("hacked"), 0, buf); err == nil {
+		fatal(slog, "SET as carol unexpectedly allowed", nil)
+	}
+	if !strings.Contains(err.Error(), "NOT_AUTHORIZED") {
+		fatal(slog, "SET as carol denied with the wrong error", err)
+	}
+	slog.Log(logger.LevelInfo, "SET as carol denied", logger.String("error", err.Error()))
+
+	// A bad password and an unknown user must land in the store-wide ACL LOG
+	// buffer with the attempted username, remote address, and reason.
+	bad, err := client.DialWithLogger("127.0.0.1:9988", 5*time.Second, slog)
+	if err != nil {
+		fatal(slog, "failed to dial server", err)
+	}
+	defer bad.Close()
+	if err = bad.AuthUser("carol", "wrongpw", buf); err == nil {
+		fatal(slog, "AUTH with wrong password unexpectedly succeeded", nil)
+	}
+	slog.Log(logger.LevelInfo, "AUTH carol wrong password", logger.String("result", "denied"))
+	if err = bad.AuthUser("ghost", "x", buf); err == nil {
+		fatal(slog, "AUTH as unknown user unexpectedly succeeded", nil)
+	}
+	slog.Log(logger.LevelInfo, "AUTH ghost unknown user", logger.String("result", "denied"))
+
+	// ACL LOG reads the auth-failure buffer back over the binary protocol,
+	// oldest entry first.
+	entries, err := c.AclLog(buf)
+	if err != nil {
+		fatal(slog, "ACL LOG failed", err)
+	}
+	for _, e := range entries {
+		slog.Log(logger.LevelInfo, "ACL LOG",
+			logger.String("timestamp", e.Timestamp),
+			logger.String("username", e.Username),
+			logger.String("remote_addr", e.RemoteAddr),
+			logger.String("reason", e.Reason),
+		)
+	}
+
+	// ACL DELUSER revokes carol: her credentials stop working.
+	if err = c.AclDelUser("carol", buf); err != nil {
+		fatal(slog, "ACL DELUSER failed", err)
+	}
+	slog.Log(logger.LevelInfo, "ACL DELUSER carol", logger.String("result", "OK"))
+	if err = carol.AuthUser("carol", "carolpw", buf); err == nil {
+		fatal(slog, "AUTH carol after ACL DELUSER unexpectedly succeeded", nil)
+	}
+	slog.Log(logger.LevelInfo, "AUTH carol after DELUSER", logger.String("result", "denied"))
+}
+
+// fatal logs the error and terminates the example process.
+func fatal(l logger.Logger, msg string, err error) {
+	if err != nil {
+		l.Log(logger.LevelFatal, msg, logger.String("error", err.Error()))
+	} else {
+		l.Log(logger.LevelFatal, msg)
+	}
+	os.Exit(1)
+}

--- a/cmd/example/acl/policy.yaml
+++ b/cmd/example/acl/policy.yaml
@@ -1,0 +1,18 @@
+# Example RBAC policy for cmd/example/acl. Run the ACL example against a
+# server started with this file:
+#
+#   ./bin/tellstone --rbac-config cmd/example/acl/policy.yaml --enable-resp
+#
+# The admin user below is required: the example authenticates as
+# admin/adminsecret before issuing ACL commands. There is no "default" user,
+# so every connection must AUTH.
+roles:
+  - name: admin
+    rules: ["+@all", "~*"]
+  - name: readonly
+    rules: ["+get", "~*"]
+users:
+  - name: admin
+    role: admin
+    password: "$2a$10$pcaKkTfRy.KSdNUgKszYYedE7L32P9fSEG3x1phq0EbjeYkn5WpEi"
+default_role: readonly    # least privilege: fallback for users without an explicit role

--- a/internal/network/acl.go
+++ b/internal/network/acl.go
@@ -1,0 +1,219 @@
+/*
+Package network
+Tellstone Secure TCP Networking Package
+File: acl.go
+Description: Wire codec for the ACL OpCodes. Requests reuse the ROLE primitive — length-prefixed
+tokens in the message Value field — and ACL LIST responses use the same primitive as ROLE LIST.
+All lengths are big-endian uint16, so a single token is capped at 64 KiB. ACL is an admin
+operation, so these helpers allocate freely — they never touch the KV hot path.
+
+Authors:
+
+	Maximilian Hagen
+*/
+package network
+
+import (
+	"encoding/binary"
+	"math"
+)
+
+// ACLUser is one user from an ACL LIST response.
+type ACLUser struct {
+	Username   string
+	Role       string // empty when the default role applies
+	HasPass    bool
+	Commands   []string
+	Namespaces [][]byte
+}
+
+// LIST response: [2B userCount] then per user
+// [2B nameLen][name][2B roleLen][role][1B hasPass][2B cmdCount]{[2B len][cmd]}[2B nsCount]{[2B len][ns]}.
+
+// EncodeACLListResponse packs an ACL LIST response. ok is false when the user
+// count or a name, command, or namespace exceeds the 64 KiB length-prefix
+// limit.
+func EncodeACLListResponse(users []ACLUser) ([]byte, bool) {
+	if len(users) > math.MaxUint16 {
+		return nil, false
+	}
+	buf := make([]byte, 0, 2)
+	buf = binary.BigEndian.AppendUint16(buf, uint16(len(users)))
+	for _, u := range users {
+		if len(u.Username) > math.MaxUint16 {
+			return nil, false
+		}
+		buf = binary.BigEndian.AppendUint16(buf, uint16(len(u.Username)))
+		buf = append(buf, u.Username...)
+		if len(u.Role) > math.MaxUint16 {
+			return nil, false
+		}
+		buf = binary.BigEndian.AppendUint16(buf, uint16(len(u.Role)))
+		buf = append(buf, u.Role...)
+		if u.HasPass {
+			buf = append(buf, 1)
+		} else {
+			buf = append(buf, 0)
+		}
+		if len(u.Commands) > math.MaxUint16 {
+			return nil, false
+		}
+		buf = binary.BigEndian.AppendUint16(buf, uint16(len(u.Commands)))
+		for _, cmd := range u.Commands {
+			if len(cmd) > math.MaxUint16 {
+				return nil, false
+			}
+			buf = binary.BigEndian.AppendUint16(buf, uint16(len(cmd)))
+			buf = append(buf, cmd...)
+		}
+		if len(u.Namespaces) > math.MaxUint16 {
+			return nil, false
+		}
+		buf = binary.BigEndian.AppendUint16(buf, uint16(len(u.Namespaces)))
+		for _, ns := range u.Namespaces {
+			if len(ns) > math.MaxUint16 {
+				return nil, false
+			}
+			buf = binary.BigEndian.AppendUint16(buf, uint16(len(ns)))
+			buf = append(buf, ns...)
+		}
+	}
+	return buf, true
+}
+
+// DecodeACLListResponse unpacks an ACL LIST response. ok is false on a
+// truncated payload.
+func DecodeACLListResponse(payload []byte) ([]ACLUser, bool) {
+	if len(payload) < 2 {
+		return nil, false
+	}
+	count := int(binary.BigEndian.Uint16(payload[:2]))
+	pos := 2
+	users := make([]ACLUser, 0, count)
+	for i := 0; i < count; i++ {
+		var u ACLUser
+		if pos+2 > len(payload) {
+			return nil, false
+		}
+		n := int(binary.BigEndian.Uint16(payload[pos : pos+2]))
+		pos += 2
+		if pos+n > len(payload) {
+			return nil, false
+		}
+		u.Username = string(payload[pos : pos+n])
+		pos += n
+		if pos+2 > len(payload) {
+			return nil, false
+		}
+		n = int(binary.BigEndian.Uint16(payload[pos : pos+2]))
+		pos += 2
+		if pos+n > len(payload) {
+			return nil, false
+		}
+		u.Role = string(payload[pos : pos+n])
+		pos += n
+		if pos >= len(payload) {
+			return nil, false
+		}
+		u.HasPass = payload[pos] == 1
+		pos++
+		if pos+2 > len(payload) {
+			return nil, false
+		}
+		cmdCount := int(binary.BigEndian.Uint16(payload[pos : pos+2]))
+		pos += 2
+		for j := 0; j < cmdCount; j++ {
+			if pos+2 > len(payload) {
+				return nil, false
+			}
+			clen := int(binary.BigEndian.Uint16(payload[pos : pos+2]))
+			pos += 2
+			if pos+clen > len(payload) {
+				return nil, false
+			}
+			u.Commands = append(u.Commands, string(payload[pos:pos+clen]))
+			pos += clen
+		}
+		if pos+2 > len(payload) {
+			return nil, false
+		}
+		nsCount := int(binary.BigEndian.Uint16(payload[pos : pos+2]))
+		pos += 2
+		for j := 0; j < nsCount; j++ {
+			if pos+2 > len(payload) {
+				return nil, false
+			}
+			nsl := int(binary.BigEndian.Uint16(payload[pos : pos+2]))
+			pos += 2
+			if pos+nsl > len(payload) {
+				return nil, false
+			}
+			u.Namespaces = append(u.Namespaces, append([]byte(nil), payload[pos:pos+nsl]...))
+			pos += nsl
+		}
+		users = append(users, u)
+	}
+	return users, pos == len(payload)
+}
+
+// AuthLogEntry is one ACL LOG record. Timestamp is an RFC3339 string, the same
+// rendering the RESP ACL LOG handler emits, so both protocols expose identical
+// log content.
+type AuthLogEntry struct {
+	Timestamp  string
+	Username   string
+	RemoteAddr string
+	Reason     string
+}
+
+// LOG response: [2B entryCount] then per entry
+// [2B tsLen][timestamp][2B userLen][username][2B addrLen][remoteAddr][2B reasonLen][reason].
+
+// EncodeACLLogResponse packs an ACL LOG response. ok is false when the entry
+// count or any field exceeds the 64 KiB length-prefix limit.
+func EncodeACLLogResponse(entries []AuthLogEntry) ([]byte, bool) {
+	if len(entries) > math.MaxUint16 {
+		return nil, false
+	}
+	buf := make([]byte, 0, 2)
+	buf = binary.BigEndian.AppendUint16(buf, uint16(len(entries)))
+	for _, e := range entries {
+		for _, field := range []string{e.Timestamp, e.Username, e.RemoteAddr, e.Reason} {
+			if len(field) > math.MaxUint16 {
+				return nil, false
+			}
+			buf = binary.BigEndian.AppendUint16(buf, uint16(len(field)))
+			buf = append(buf, field...)
+		}
+	}
+	return buf, true
+}
+
+// DecodeACLLogResponse unpacks an ACL LOG response. ok is false on a truncated
+// payload.
+func DecodeACLLogResponse(payload []byte) ([]AuthLogEntry, bool) {
+	if len(payload) < 2 {
+		return nil, false
+	}
+	count := int(binary.BigEndian.Uint16(payload[:2]))
+	pos := 2
+	entries := make([]AuthLogEntry, 0, count)
+	for i := 0; i < count; i++ {
+		var e AuthLogEntry
+		fields := []*string{&e.Timestamp, &e.Username, &e.RemoteAddr, &e.Reason}
+		for _, field := range fields {
+			if pos+2 > len(payload) {
+				return nil, false
+			}
+			n := int(binary.BigEndian.Uint16(payload[pos : pos+2]))
+			pos += 2
+			if pos+n > len(payload) {
+				return nil, false
+			}
+			*field = string(payload[pos : pos+n])
+			pos += n
+		}
+		entries = append(entries, e)
+	}
+	return entries, pos == len(payload)
+}

--- a/internal/network/acl_test.go
+++ b/internal/network/acl_test.go
@@ -74,6 +74,12 @@ func TestACLListCodecMalformed(t *testing.T) {
 	if _, ok := DecodeACLListResponse(enc[:len(enc)-2]); ok {
 		t.Fatal("expected truncated user payload to be rejected")
 	}
+	// A valid payload with a trailing byte must be rejected: the decoder is
+	// required to consume the payload exactly, not just the prefix it knows.
+	trailing := append(append([]byte(nil), enc...), 0xFF)
+	if _, ok := DecodeACLListResponse(trailing); ok {
+		t.Fatal("expected trailing-garbage payload to be rejected")
+	}
 }
 
 // TestACLLogCodec verifies EncodeACLLogResponse/DecodeACLLogResponse recover
@@ -111,6 +117,10 @@ func TestACLLogCodecMalformed(t *testing.T) {
 	enc, _ := EncodeACLLogResponse([]AuthLogEntry{{Timestamp: "t", Username: "u"}})
 	if _, ok := DecodeACLLogResponse(enc[:len(enc)-2]); ok {
 		t.Fatal("expected truncated entry payload to be rejected")
+	}
+	trailing := append(append([]byte(nil), enc...), 0xFF)
+	if _, ok := DecodeACLLogResponse(trailing); ok {
+		t.Fatal("expected trailing-garbage payload to be rejected")
 	}
 }
 
@@ -164,7 +174,7 @@ func aclTestHandler(store *rbac.Store) func(msg *Message) ([]byte, MessageType, 
 			users := make([]ACLUser, 0, len(p.Users))
 			for name, u := range p.Users {
 				e := ACLUser{Username: name, Role: u.Role, HasPass: len(u.PasswordHash) > 0}
-				if r, ok := p.Roles[u.Role]; ok {
+				if r := p.RoleFor(name); r != nil {
 					e.Commands = r.GrantedCommands()
 					for _, ns := range r.Namespaces {
 						e.Namespaces = append(e.Namespaces, append([]byte(nil), ns...))

--- a/internal/network/acl_test.go
+++ b/internal/network/acl_test.go
@@ -1,0 +1,463 @@
+package network
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/Saxy/Tellstone/internal/log"
+	"github.com/Saxy/Tellstone/internal/rbac"
+)
+
+// TestACLListCodec verifies EncodeACLListResponse/DecodeACLListResponse recover
+// the original user list, including users with no explicit role and empty
+// command or namespace lists.
+func TestACLListCodec(t *testing.T) {
+	users := []ACLUser{
+		{Username: "admin", Role: "admin", HasPass: true, Commands: []string{"GET", "SET"}},
+		{Username: "bob", Role: "", HasPass: false, Commands: nil, Namespaces: [][]byte{[]byte("users:")}},
+	}
+	payload, ok := EncodeACLListResponse(users)
+	if !ok {
+		t.Fatal("encode of ACL LIST response failed")
+	}
+	decoded, ok := DecodeACLListResponse(payload)
+	if !ok {
+		t.Fatal("decode of ACL LIST response failed")
+	}
+	if len(decoded) != len(users) {
+		t.Fatalf("user count: got %d want %d", len(decoded), len(users))
+	}
+	for i, u := range decoded {
+		if u.Username != users[i].Username || u.Role != users[i].Role || u.HasPass != users[i].HasPass {
+			t.Fatalf("user %d: got %+v want %+v", i, u, users[i])
+		}
+		if len(u.Commands) != len(users[i].Commands) {
+			t.Fatalf("user %d command count mismatch", i)
+		}
+		if len(u.Namespaces) != len(users[i].Namespaces) {
+			t.Fatalf("user %d namespace count mismatch", i)
+		}
+		for j := range u.Commands {
+			if u.Commands[j] != users[i].Commands[j] {
+				t.Fatalf("user %d command %d: got %q want %q", i, j, u.Commands[j], users[i].Commands[j])
+			}
+		}
+	}
+}
+
+// TestACLListCodecOverflow verifies a token over the 64 KiB length-prefix limit
+// is rejected by the encoder instead of being silently truncated.
+func TestACLListCodecOverflow(t *testing.T) {
+	big := make([]byte, 65536)
+	user := ACLUser{Username: "u", Commands: []string{string(big)}}
+	if _, ok := EncodeACLListResponse([]ACLUser{user}); ok {
+		t.Fatal("expected list encoder to reject a >64 KiB command")
+	}
+	user = ACLUser{Username: "u", Namespaces: [][]byte{big}}
+	if _, ok := EncodeACLListResponse([]ACLUser{user}); ok {
+		t.Fatal("expected list encoder to reject a >64 KiB namespace")
+	}
+}
+
+// TestACLListCodecMalformed verifies truncated and trailing-garbage payloads are
+// rejected.
+func TestACLListCodecMalformed(t *testing.T) {
+	if _, ok := DecodeACLListResponse([]byte{0, 1}); ok {
+		t.Fatal("expected truncated payload to be rejected")
+	}
+	// One user whose role length overruns the buffer.
+	enc, _ := EncodeACLListResponse([]ACLUser{{Username: "u", Role: "admin"}})
+	if _, ok := DecodeACLListResponse(enc[:len(enc)-2]); ok {
+		t.Fatal("expected truncated user payload to be rejected")
+	}
+}
+
+// TestACLLogCodec verifies EncodeACLLogResponse/DecodeACLLogResponse recover
+// the original entries, including empty reasons and an empty log.
+func TestACLLogCodec(t *testing.T) {
+	entries := []AuthLogEntry{
+		{Timestamp: "2026-08-03T18:30:29+02:00", Username: "admin", RemoteAddr: "127.0.0.1:1", Reason: "invalid password"},
+		{Timestamp: "2026-08-03T18:30:30+02:00", Username: "ghost", RemoteAddr: "127.0.0.1:2", Reason: "unknown user"},
+		{Timestamp: "2026-08-03T18:30:31+02:00", Username: "nopass", RemoteAddr: "127.0.0.1:3", Reason: ""},
+	}
+	payload, ok := EncodeACLLogResponse(entries)
+	if !ok {
+		t.Fatal("encode of ACL LOG response failed")
+	}
+	decoded, ok := DecodeACLLogResponse(payload)
+	if !ok {
+		t.Fatal("decode of ACL LOG response failed")
+	}
+	if len(decoded) != len(entries) {
+		t.Fatalf("entry count: got %d want %d", len(decoded), len(entries))
+	}
+	for i, e := range decoded {
+		if e != entries[i] {
+			t.Fatalf("entry %d: got %+v want %+v", i, e, entries[i])
+		}
+	}
+}
+
+// TestACLLogCodecMalformed verifies truncated and trailing-garbage ACL LOG
+// payloads are rejected.
+func TestACLLogCodecMalformed(t *testing.T) {
+	if _, ok := DecodeACLLogResponse([]byte{0, 1}); ok {
+		t.Fatal("expected truncated payload to be rejected")
+	}
+	enc, _ := EncodeACLLogResponse([]AuthLogEntry{{Timestamp: "t", Username: "u"}})
+	if _, ok := DecodeACLLogResponse(enc[:len(enc)-2]); ok {
+		t.Fatal("expected truncated entry payload to be rejected")
+	}
+}
+
+// aclTestHandler mirrors server.networkHandler for the ACL ops so the network
+// layer's auth gating and wire codec are exercised end-to-end.
+func aclTestHandler(store *rbac.Store) func(msg *Message) ([]byte, MessageType, error) {
+	return func(msg *Message) ([]byte, MessageType, error) {
+		switch msg.Op {
+		case OpGet:
+			return ResponseOK, MsgResponse, nil
+		case OpSet, OpDelete:
+			return ResponseOK, MsgResponse, nil
+		case OpRoleCreate:
+			args, ok := DecodeRoleArgs(msg.Value, nil)
+			if !ok || len(args) < 2 {
+				return []byte("invalid ROLE CREATE arguments"), MsgError, nil
+			}
+			rules := make([]string, 0, len(args)-1)
+			for _, r := range args[1:] {
+				rules = append(rules, string(r))
+			}
+			if err := store.CreateRole(string(args[0]), rules); err != nil {
+				return []byte(err.Error()), MsgError, nil
+			}
+			return ResponseOK, MsgResponse, nil
+		case OpACLSetUser:
+			args, ok := DecodeRoleArgs(msg.Value, nil)
+			if !ok || len(args) < 2 {
+				return []byte("invalid ACL SETUSER arguments"), MsgError, nil
+			}
+			if len(args) == 2 {
+				return []byte("ACL SETUSER requires a '>password' or 'nopass' option"), MsgError, nil
+			}
+			hash, err := rbac.PasswordFromOpts(args[2:])
+			if err != nil {
+				return []byte(err.Error()), MsgError, nil
+			}
+			if err := store.SetUser(string(args[0]), string(args[1]), hash); err != nil {
+				return []byte(err.Error()), MsgError, nil
+			}
+			return ResponseOK, MsgResponse, nil
+		case OpACLDelUser:
+			args, ok := DecodeRoleArgs(msg.Value, nil)
+			if !ok || len(args) != 1 {
+				return []byte("invalid ACL DELUSER arguments"), MsgError, nil
+			}
+			store.DelUser(string(args[0]))
+			return ResponseOK, MsgResponse, nil
+		case OpACLList:
+			p := store.Load()
+			users := make([]ACLUser, 0, len(p.Users))
+			for name, u := range p.Users {
+				e := ACLUser{Username: name, Role: u.Role, HasPass: len(u.PasswordHash) > 0}
+				if r, ok := p.Roles[u.Role]; ok {
+					e.Commands = r.GrantedCommands()
+					for _, ns := range r.Namespaces {
+						e.Namespaces = append(e.Namespaces, append([]byte(nil), ns...))
+					}
+				}
+				users = append(users, e)
+			}
+			sort.Slice(users, func(i, j int) bool { return users[i].Username < users[j].Username })
+			payload, ok := EncodeACLListResponse(users)
+			if !ok {
+				return []byte("acl rule exceeds the 64 KiB wire limit"), MsgError, nil
+			}
+			return payload, MsgResponse, nil
+		case OpACLLog:
+			src := store.AuthLog()
+			entries := make([]AuthLogEntry, 0, len(src))
+			for _, e := range src {
+				entries = append(entries, AuthLogEntry{
+					Timestamp:  e.Timestamp.Format(time.RFC3339),
+					Username:   e.Username,
+					RemoteAddr: e.RemoteAddr,
+					Reason:     e.Reason,
+				})
+			}
+			payload, ok := EncodeACLLogResponse(entries)
+			if !ok {
+				return []byte("acl log exceeds the 64 KiB wire limit"), MsgError, nil
+			}
+			return payload, MsgResponse, nil
+		default:
+			return ResponseNotFound, MsgError, nil
+		}
+	}
+}
+
+func startACLNetworkServer(t *testing.T) (addr string, store *rbac.Store) {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	addr = l.Addr().String()
+	_ = l.Close()
+	store = rbac.NewStore(rbacNetworkPolicy(t))
+	srv := NewServer(addr, 0, nil, aclTestHandler(store), log.NewNoOpLogger(), nil, "", store)
+	go func() { _ = srv.ListenAndServe() }()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	})
+	if err := waitForServer(addr, 2*time.Second); err != nil {
+		t.Fatalf("server not ready: %v", err)
+	}
+	return addr, store
+}
+
+// TestServerACLAuthGating verifies the binary protocol lets an admin manage
+// ACL users end-to-end: SETUSER creates a bound user, LIST reflects it, and
+// DELUSER removes it.
+func TestServerACLAuthGating(t *testing.T) {
+	addr, store := startACLNetworkServer(t)
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	// ACL ops before auth are rejected.
+	payload, err := roleRequestPayload(OpACLList, nil)
+	if err != nil {
+		t.Fatalf("roleRequestPayload: %v", err)
+	}
+	if resp := sendAndRecv(t, conn, MsgRequest, payload); resp.Type != MsgAuthErr {
+		t.Fatalf("expected MsgAuthErr for ACL before auth, got %v", resp.Type)
+	}
+	// Authenticate as admin.
+	if resp := sendAndRecv(t, conn, MsgAuth, buildAuthPayloadWithUser("admin", "sekret")); resp.Type != MsgAuthOk {
+		t.Fatalf("expected MsgAuthOk, got %v", resp.Type)
+	}
+	// Seed the role the user will be bound to.
+	if err := store.CreateRole("operator", []string{"+get", "~users:*"}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+	// ACL SETUSER bob.
+	payload, err = roleRequestPayload(OpACLSetUser, [][]byte{[]byte("bob"), []byte("operator"), []byte(">hunter2")})
+	if err != nil {
+		t.Fatalf("roleRequestPayload: %v", err)
+	}
+	if resp := sendAndRecv(t, conn, MsgRequest, payload); !bytes.Equal(resp.Value, ResponseOK) {
+		t.Fatalf("expected ACL SETUSER OK, got %q type %v", resp.Value, resp.Type)
+	}
+	if u := store.Load().UserFor("bob"); u == nil || u.Role != "operator" || len(u.PasswordHash) == 0 {
+		t.Fatalf("bob after ACL SETUSER = %+v", u)
+	}
+	// ACL LIST reflects bob.
+	payload, err = roleRequestPayload(OpACLList, nil)
+	if err != nil {
+		t.Fatalf("roleRequestPayload: %v", err)
+	}
+	resp := sendAndRecv(t, conn, MsgRequest, payload)
+	if resp.Type != MsgResponse {
+		t.Fatalf("expected MsgResponse for ACL LIST, got %v", resp.Type)
+	}
+	users, ok := DecodeACLListResponse(resp.Value)
+	if !ok {
+		t.Fatal("malformed ACL LIST response")
+	}
+	if len(users) != 3 {
+		t.Fatalf("ACL LIST user count = %d, want 3 (admin, bob, limited)", len(users))
+	}
+	// ACL DELUSER bob.
+	payload, err = roleRequestPayload(OpACLDelUser, [][]byte{[]byte("bob")})
+	if err != nil {
+		t.Fatalf("roleRequestPayload: %v", err)
+	}
+	if resp := sendAndRecv(t, conn, MsgRequest, payload); !bytes.Equal(resp.Value, ResponseOK) {
+		t.Fatalf("expected ACL DELUSER OK, got %q type %v", resp.Value, resp.Type)
+	}
+	if u := store.Load().UserFor("bob"); u != nil {
+		t.Fatalf("bob still present after ACL DELUSER: %+v", u)
+	}
+}
+
+// TestServerACLAuthorizationDenial verifies a limited user (GET only, no ACL
+// bit) is denied ACL management with ResponseNotAuthorized.
+func TestServerACLAuthorizationDenial(t *testing.T) {
+	addr, _ := startACLNetworkServer(t)
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	if resp := sendAndRecv(t, conn, MsgAuth, buildAuthPayloadWithUser("limited", "anything")); resp.Type != MsgAuthOk {
+		t.Fatalf("expected MsgAuthOk for nopass user, got %v", resp.Type)
+	}
+	payload, err := roleRequestPayload(OpACLSetUser, [][]byte{[]byte("eve"), []byte("limited"), []byte("nopass")})
+	if err != nil {
+		t.Fatalf("roleRequestPayload: %v", err)
+	}
+	if resp := sendAndRecv(t, conn, MsgRequest, payload); !bytes.Equal(resp.Value, ResponseNotAuthorized) {
+		t.Fatalf("expected ResponseNotAuthorized for ACL SETUSER, got %q", resp.Value)
+	}
+	payload, err = roleRequestPayload(OpACLList, nil)
+	if err != nil {
+		t.Fatalf("roleRequestPayload: %v", err)
+	}
+	if resp := sendAndRecv(t, conn, MsgRequest, payload); !bytes.Equal(resp.Value, ResponseNotAuthorized) {
+		t.Fatalf("expected ResponseNotAuthorized for ACL LIST, got %q", resp.Value)
+	}
+	payload, err = roleRequestPayload(OpACLLog, nil)
+	if err != nil {
+		t.Fatalf("roleRequestPayload: %v", err)
+	}
+	if resp := sendAndRecv(t, conn, MsgRequest, payload); !bytes.Equal(resp.Value, ResponseNotAuthorized) {
+		t.Fatalf("expected ResponseNotAuthorized for ACL LOG, got %q", resp.Value)
+	}
+}
+
+// TestServerACLLog verifies binary AUTH failures populate the store's ACL LOG
+// buffer with the attempted username and reason, including unknown users.
+func TestServerACLLog(t *testing.T) {
+	addr, store := startACLNetworkServer(t)
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	if resp := sendAndRecv(t, conn, MsgAuth, buildAuthPayloadWithUser("admin", "wrong")); resp.Type != MsgAuthErr {
+		t.Fatalf("expected MsgAuthErr for wrong password, got %v", resp.Type)
+	}
+	if resp := sendAndRecv(t, conn, MsgAuth, buildAuthPayloadWithUser("ghost", "x")); resp.Type != MsgAuthErr {
+		t.Fatalf("expected MsgAuthErr for unknown user, got %v", resp.Type)
+	}
+
+	entries := store.AuthLog()
+	if len(entries) != 2 {
+		t.Fatalf("AuthLog len = %d, want 2", len(entries))
+	}
+	if entries[0].Username != "admin" || entries[0].Reason != "invalid password" {
+		t.Fatalf("entry 0 = %+v, want admin/invalid password", entries[0])
+	}
+	if entries[1].Username != "ghost" || entries[1].Reason != "unknown user" {
+		t.Fatalf("entry 1 = %+v, want ghost/unknown user", entries[1])
+	}
+
+	// The wire path must expose the same entries: re-connect as admin (the
+	// first connection was never authenticated) and fetch OpACLLog.
+	admin, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer admin.Close()
+	if resp := sendAndRecv(t, admin, MsgAuth, buildAuthPayloadWithUser("admin", "sekret")); resp.Type != MsgAuthOk {
+		t.Fatalf("expected MsgAuthOk, got %v", resp.Type)
+	}
+	payload, err := roleRequestPayload(OpACLLog, nil)
+	if err != nil {
+		t.Fatalf("roleRequestPayload: %v", err)
+	}
+	resp := sendAndRecv(t, admin, MsgRequest, payload)
+	if resp.Type != MsgResponse {
+		t.Fatalf("expected MsgResponse for ACL LOG, got %v", resp.Type)
+	}
+	wireEntries, ok := DecodeACLLogResponse(resp.Value)
+	if !ok {
+		t.Fatal("malformed ACL LOG response")
+	}
+	if len(wireEntries) != 2 {
+		t.Fatalf("wire ACL LOG entry count = %d, want 2", len(wireEntries))
+	}
+	if wireEntries[0].Username != "admin" || wireEntries[0].Reason != "invalid password" {
+		t.Fatalf("wire entry 0 = %+v, want admin/invalid password", wireEntries[0])
+	}
+	if wireEntries[1].Username != "ghost" || wireEntries[1].Reason != "unknown user" {
+		t.Fatalf("wire entry 1 = %+v, want ghost/unknown user", wireEntries[1])
+	}
+}
+
+// TestClientACLMethods exercises the ACL client API against a live server.
+func TestClientACLMethods(t *testing.T) {
+	addr, _ := startACLNetworkServer(t)
+
+	client, err := Dial(addr, 2*time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer client.Close()
+	scratch := make([]byte, 4096)
+
+	if err := client.AuthUser("admin", "sekret", scratch); err != nil {
+		t.Fatalf("AuthUser: %v", err)
+	}
+	if err := client.RoleCreate("operator", []string{"+get", "~users:*"}, scratch); err != nil {
+		t.Fatalf("RoleCreate: %v", err)
+	}
+	if err := client.AclSetUser("bob", "operator", [][]byte{[]byte("nopass")}, scratch); err != nil {
+		t.Fatalf("AclSetUser: %v", err)
+	}
+	users, err := client.AclList(scratch)
+	if err != nil {
+		t.Fatalf("AclList: %v", err)
+	}
+	if len(users) != 3 {
+		t.Fatalf("AclList: got %d users want 3 (admin, bob, limited)", len(users))
+	}
+	var bob *ACLUser
+	for i := range users {
+		if users[i].Username == "bob" {
+			bob = &users[i]
+		}
+	}
+	if bob == nil || bob.Role != "operator" || bob.HasPass {
+		t.Fatalf("bob = %+v, want role operator without password", bob)
+	}
+	if err := client.AclDelUser("bob", scratch); err != nil {
+		t.Fatalf("AclDelUser: %v", err)
+	}
+	users, err = client.AclList(scratch)
+	if err != nil {
+		t.Fatalf("AclList after delete: %v", err)
+	}
+	if len(users) != 2 {
+		t.Fatalf("AclList after delete: got %d users want 2", len(users))
+	}
+
+	// Trigger a failed AUTH (wrong password) on a second connection, then read
+	// the resulting entry back through the client's AclLog.
+	other, err := Dial(addr, 2*time.Second)
+	if err != nil {
+		t.Fatalf("dial second client: %v", err)
+	}
+	defer other.Close()
+	if err := other.AuthUser("admin", "wrong", scratch); err == nil {
+		t.Fatal("expected AuthUser with wrong password to fail")
+	}
+	entries, err := client.AclLog(scratch)
+	if err != nil {
+		t.Fatalf("AclLog: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("AclLog returned no entries after a failed AUTH")
+	}
+	last := entries[len(entries)-1]
+	if last.Username != "admin" || last.Reason != "invalid password" {
+		t.Fatalf("last log entry = %+v, want admin/invalid password", last)
+	}
+	if last.Timestamp == "" || last.RemoteAddr == "" {
+		t.Fatalf("log entry missing timestamp or remote address: %+v", last)
+	}
+}

--- a/internal/network/acl_test.go
+++ b/internal/network/acl_test.go
@@ -167,7 +167,9 @@ func aclTestHandler(store *rbac.Store) func(msg *Message) ([]byte, MessageType, 
 			if !ok || len(args) != 1 {
 				return []byte("invalid ACL DELUSER arguments"), MsgError, nil
 			}
-			store.DelUser(string(args[0]))
+			if err := store.DelUser(string(args[0])); err != nil {
+				return []byte(err.Error()), MsgError, nil
+			}
 			return ResponseOK, MsgResponse, nil
 		case OpACLList:
 			p := store.Load()

--- a/internal/network/client_acl.go
+++ b/internal/network/client_acl.go
@@ -1,0 +1,75 @@
+/*
+Package network
+Tellstone Cloud-Native In-Memory Database
+File: client_acl.go
+Description: Binary-protocol client methods for the ACL command family. Requests carry their
+arguments in the message Value as length-prefixed tokens (EncodeRoleArgs); the server replies
+with ResponseOK in a MsgResponse frame on success, the encoded typed ACL LIST payload, or the
+error detail in a MsgError frame that surfaces as the returned error. Admin ops only — no
+allocation concerns on the hot path.
+
+Authors:
+
+	Maximilian Hagen
+*/
+package network
+
+import "fmt"
+
+// AclSetUser issues ACL SETUSER <username> <role> [>password] [nopass], the
+// ACL alias of ROLE SETUSER. The role must already exist.
+func (c *Client) AclSetUser(username, role string, passOptions [][]byte, scratchBuf []byte) error {
+	args := make([][]byte, 0, 2+len(passOptions))
+	args = append(args, []byte(username), []byte(role))
+	args = append(args, passOptions...)
+	return c.roleMutate(OpACLSetUser, args, scratchBuf)
+}
+
+// AclDelUser issues ACL DELUSER <username>.
+func (c *Client) AclDelUser(username string, scratchBuf []byte) error {
+	return c.roleMutate(OpACLDelUser, [][]byte{[]byte(username)}, scratchBuf)
+}
+
+// AclList issues ACL LIST and decodes the typed response: one user per entry
+// with username, bound role, password presence, and the role's granted
+// commands and namespace whitelist.
+func (c *Client) AclList(scratchBuf []byte) ([]ACLUser, error) {
+	payload, err := roleRequestPayload(OpACLList, nil)
+	if err != nil {
+		return nil, err
+	}
+	var resp Message
+	if err := c.Call(MsgRequest, payload, scratchBuf, &resp); err != nil {
+		return nil, err
+	}
+	if resp.Type != MsgResponse {
+		return nil, errRBACReply(resp.Value)
+	}
+	users, ok := DecodeACLListResponse(resp.Value)
+	if !ok {
+		return nil, fmt.Errorf("server: malformed ACL LIST response")
+	}
+	return users, nil
+}
+
+// AclLog issues ACL LOG and decodes the typed response: the recent auth-failure
+// buffer in chronological order, each entry carrying timestamp, username,
+// remote address, and reason.
+func (c *Client) AclLog(scratchBuf []byte) ([]AuthLogEntry, error) {
+	payload, err := roleRequestPayload(OpACLLog, nil)
+	if err != nil {
+		return nil, err
+	}
+	var resp Message
+	if err := c.Call(MsgRequest, payload, scratchBuf, &resp); err != nil {
+		return nil, err
+	}
+	if resp.Type != MsgResponse {
+		return nil, errRBACReply(resp.Value)
+	}
+	entries, ok := DecodeACLLogResponse(resp.Value)
+	if !ok {
+		return nil, fmt.Errorf("server: malformed ACL LOG response")
+	}
+	return entries, nil
+}

--- a/internal/network/protocol.go
+++ b/internal/network/protocol.go
@@ -55,6 +55,14 @@ func (o OpCode) String() string {
 		return "ROLE LIST"
 	case OpRoleGetUser:
 		return "ROLE GETUSER"
+	case OpACLSetUser:
+		return "ACL SETUSER"
+	case OpACLDelUser:
+		return "ACL DELUSER"
+	case OpACLList:
+		return "ACL LIST"
+	case OpACLLog:
+		return "ACL LOG"
 	default:
 		return "UNKNOWN"
 	}
@@ -70,6 +78,10 @@ const (
 	OpRoleDelete
 	OpRoleList
 	OpRoleGetUser
+	OpACLSetUser
+	OpACLDelUser
+	OpACLList
+	OpACLLog
 )
 
 // Message is the atomic execution frame of the Tellstone TCP protocol.

--- a/internal/network/role_test.go
+++ b/internal/network/role_test.go
@@ -205,7 +205,9 @@ func rbacTestHandler(store *rbac.Store) func(msg *Message) ([]byte, MessageType,
 			if !ok || len(args) != 1 {
 				return []byte("invalid ROLE DELUSER arguments"), MsgError, nil
 			}
-			store.DelUser(string(args[0]))
+			if err := store.DelUser(string(args[0])); err != nil {
+				return []byte(err.Error()), MsgError, nil
+			}
 			return ResponseOK, MsgResponse, nil
 		case OpRoleDelete:
 			args, ok := DecodeRoleArgs(msg.Value, nil)

--- a/internal/network/server.go
+++ b/internal/network/server.go
@@ -37,6 +37,10 @@ type authJob struct {
 	// session is the RBAC context pinned on success. nil when RBAC is disabled
 	// (single-password mode).
 	session *rbac.SessionContext
+	// username and reason identify the attempt for the ACL LOG entry recorded
+	// when verification fails; username is empty in single-password mode.
+	username string
+	reason   string
 }
 
 // connState holds per-connection state. When TLS is enabled, tlsConn wraps the
@@ -483,10 +487,9 @@ func (s *Server) onTrafficPlaintext(c gnet.Conn, st *connState) gnet.Action {
 
 // authFailed logs a rejected AUTH attempt, increments the per-connection fail
 // counter, and marks the connection for closure when the rate limit is exceeded.
+// The store-wide ACL counter and log entry are recorded by the caller via
+// LogAuthFailure, which carries the username and reason.
 func (s *Server) authFailed(st *connState) []byte {
-	if s.policy != nil {
-		s.policy.IncAuthFailure()
-	}
 	st.authFails++
 	if s.logger.Enabled(log.LevelWarn) {
 		s.logger.Log(log.LevelWarn, "network: failed AUTH attempt",
@@ -530,13 +533,15 @@ func (s *Server) handleAuthMessage(c gnet.Conn, st *connState, value []byte) aut
 	var (
 		passHash []byte
 		session  *rbac.SessionContext
+		name     string
+		reason   string
 	)
 	if s.policy != nil {
 		p := s.policy.Load()
 		if p == nil {
 			return authResult{respPayload: ResponseAuthErr, respType: MsgAuthErr}
 		}
-		name := "default"
+		name = "default"
 		if len(username) > 0 {
 			name = string(username)
 		}
@@ -547,6 +552,7 @@ func (s *Server) handleAuthMessage(c gnet.Conn, st *connState, value []byte) aut
 			// usernames exist. Dispatch the job against a fixed dummy hash so
 			// the worker's comparison fails normally (see dummyAuthHash).
 			passHash = dummyAuthHash
+			reason = "unknown user"
 		} else {
 			// Empty hash marks a nopass user that accepts any password (Redis
 			// ACL semantics). The session is built from the same snapshot that
@@ -554,6 +560,7 @@ func (s *Server) handleAuthMessage(c gnet.Conn, st *connState, value []byte) aut
 			// hot-swaps.
 			passHash = u.PasswordHash
 			session = rbac.NewSessionContext(name, p.RoleFor(name))
+			reason = "invalid password"
 		}
 	} else {
 		if len(username) > 0 && string(username) != "default" {
@@ -563,7 +570,7 @@ func (s *Server) handleAuthMessage(c gnet.Conn, st *connState, value []byte) aut
 	}
 	passwordCopy := make([]byte, len(password))
 	copy(passwordCopy, password)
-	if s.dispatchAuth(c, passwordCopy, passHash, session) {
+	if s.dispatchAuth(c, name, reason, passwordCopy, passHash, session) {
 		st.authPending = true
 		return authResult{dispatched: true}
 	}
@@ -598,6 +605,11 @@ func (s *Server) authWorker() {
 					)
 				}
 			} else {
+				// Record the store-wide failure counter and ACL LOG entry with
+				// the attempted username before the per-connection handling.
+				if s.policy != nil {
+					s.policy.LogAuthFailure(job.username, st.remoteAddr, job.reason)
+				}
 				respPayload, respType = s.authFailed(st), MsgAuthErr
 			}
 			var writeErr error
@@ -632,9 +644,9 @@ func (s *Server) authWorker() {
 
 // dispatchAuth submits an auth verification job to the bounded worker pool.
 // Returns true if the job was accepted, false if the pool is saturated.
-func (s *Server) dispatchAuth(c gnet.Conn, password, passHash []byte, session *rbac.SessionContext) bool {
+func (s *Server) dispatchAuth(c gnet.Conn, username, reason string, password, passHash []byte, session *rbac.SessionContext) bool {
 	select {
-	case s.authJobs <- authJob{c: c, password: password, passHash: passHash, session: session}:
+	case s.authJobs <- authJob{c: c, password: password, passHash: passHash, session: session, username: username, reason: reason}:
 		return true
 	default:
 		return false
@@ -658,6 +670,10 @@ func (s *Server) opAuthorized(msg Message, st *connState) bool {
 	// consulted, only the command bit (mirrors RESP's authorizedCmd).
 	case OpRoleCreate, OpRoleSetUser, OpRoleDelUser, OpRoleDelete, OpRoleList, OpRoleGetUser:
 		return st.session.AllowsCommand(rbac.CmdRole)
+	// ACL admin ops gate on the ACL command bit, a sibling of ROLE: a role
+	// granted only +role cannot manage ACL users and vice versa.
+	case OpACLSetUser, OpACLDelUser, OpACLList, OpACLLog:
+		return st.session.AllowsCommand(rbac.CmdACL)
 	case OpGet:
 		return st.session.IsAllowed(rbac.CmdGet, msg.Key)
 	case OpSet:

--- a/internal/network/server.go
+++ b/internal/network/server.go
@@ -528,7 +528,13 @@ func (s *Server) handleAuthMessage(c gnet.Conn, st *connState, value []byte) aut
 	}
 	username, password, malformed := parseAuthPayload(value)
 	if malformed {
-		return authResult{respPayload: ResponseAuthErr, respType: MsgAuthErr}
+		// A truncated frame is still a rejected AUTH: record it like any other
+		// failure so ACL LOG shows attempted-but-undeliverable credentials. The
+		// username is unknown, so the entry carries an empty name.
+		if s.policy != nil {
+			s.policy.LogAuthFailure("", st.remoteAddr, "malformed request")
+		}
+		return authResult{respPayload: s.authFailed(st), respType: MsgAuthErr}
 	}
 	var (
 		passHash []byte

--- a/internal/rbac/README.md
+++ b/internal/rbac/README.md
@@ -99,7 +99,7 @@ func (s *Store) Store(policy *PolicyStore)
 func (s *Store) Reload(policy *PolicyStore)            // SIGHUP path, serialized vs. mutations
 func (s *Store) CreateRole(name string, rules []string) error
 func (s *Store) SetUser(username, roleName string, passHash []byte) error
-func (s *Store) DelUser(username string)
+func (s *Store) DelUser(username string) error // rejects deleting the last ACL-management user
 func (s *Store) DeleteRole(name string) error
 
 // Per-connection authorization state — pinned at handshake

--- a/internal/rbac/README.md
+++ b/internal/rbac/README.md
@@ -134,6 +134,13 @@ func PasswordFromOpts(opts [][]byte) ([]byte, error) // ">pw" hashes, "nopass" c
 func (s *Store) IncAuthFailure(); func (s *Store) AuthFailures() uint64
 func (s *Store) IncDenied(); func (s *Store) DeniedCommands() uint64
 func (s *Store) RoleCommandCounts() map[string]uint64
+
+// ACL LOG — the auth-failure buffer behind ACL LOG (mutex-protected, lives
+// across policy hot-swaps). LogAuthFailure records an entry and bumps the
+// auth-failure counter; AuthLog returns the entries oldest-first.
+type AuthLogEntry struct { Timestamp time.Time; Username, RemoteAddr, Reason string }
+func (s *Store) LogAuthFailure(username, remoteAddr, reason string)
+func (s *Store) AuthLog() []AuthLogEntry
 ```
 
 ---
@@ -229,4 +236,4 @@ go test -bench=. -benchmem ./internal/rbac/
 * **Mutations are serialized.** `CreateRole`/`SetUser`/`DelUser`/`DeleteRole` and `Reload` all take `mu` so a `SIGHUP` reload can never land between a mutation's clone and its republish and silently discard the other operation.
 * **Hashes are secrets.** A `User`'s `PasswordHash` is never rendered by `ROLE LIST` or `ROLE GETUSER`; only role assignment and the AUTH path touch it.
 
-*This document accurately represents the authorization core of Tellstone as of 2026-08-01.*
+*This document accurately represents the authorization core of Tellstone as of 2026-08-03.*

--- a/internal/rbac/log.go
+++ b/internal/rbac/log.go
@@ -18,8 +18,8 @@ import (
 	"time"
 )
 
-// DefaultAuthLogCap is the default capacity of the ACL LOG circular buffer,
-// matching Redis's default max ACL log length.
+// DefaultAuthLogCap is the capacity of the ACL LOG circular buffer: 100 recent
+// rejected AUTH attempts, oldest evicted once full.
 const DefaultAuthLogCap = 100
 
 // AuthLogEntry is one rejected AUTH attempt. Timestamp is wall-clock time at

--- a/internal/rbac/log.go
+++ b/internal/rbac/log.go
@@ -1,0 +1,76 @@
+/*
+Package rbac
+Tellstone Role-Based Access Control
+File: log.go
+Description: The ACL auth-failure log behind ACL LOG. A mutex-protected circular buffer of
+recent rejected AUTH attempts (timestamp, username, remote address, reason) kept on the Store,
+so it survives policy hot-swaps and is shared by both protocol layers. Recording happens only
+on the failed-AUTH path — never on the hot path.
+
+Authors:
+
+	Maximilian Hagen
+*/
+package rbac
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// DefaultAuthLogCap is the default capacity of the ACL LOG circular buffer,
+// matching Redis's default max ACL log length.
+const DefaultAuthLogCap = 100
+
+// AuthLogEntry is one rejected AUTH attempt. Timestamp is wall-clock time at
+// record time; Username may be empty when it was not parseable from the frame.
+type AuthLogEntry struct {
+	Timestamp  time.Time
+	Username   string
+	RemoteAddr string
+	Reason     string
+}
+
+// LogAuthFailure records one rejected AUTH attempt in the circular buffer and
+// bumps the store-wide auth-failure counter (the ACL LOG view of IncAuthFailure).
+// The buffer is lazily allocated at DefaultAuthLogCap and evicts the oldest
+// entry once full, newest last. Callers are the protocol AUTH paths only.
+func (s *Store) LogAuthFailure(username, remoteAddr, reason string) {
+	atomic.AddUint64(&s.authFailures, 1)
+	s.logMu.Lock()
+	defer s.logMu.Unlock()
+	if s.log == nil {
+		s.log = make([]AuthLogEntry, DefaultAuthLogCap)
+	}
+	s.log[s.logHead] = AuthLogEntry{
+		Timestamp:  time.Now(),
+		Username:   username,
+		RemoteAddr: remoteAddr,
+		Reason:     reason,
+	}
+	s.logHead = (s.logHead + 1) % len(s.log)
+	if s.logLen < len(s.log) {
+		s.logLen++
+	}
+}
+
+// AuthLog returns the buffered auth-failure entries in chronological order,
+// oldest first. It returns a copy, so the caller may hold the result after the
+// buffer advances. Empty when nothing has failed. ACL LOG is the only consumer;
+// the allocation is fine off the hot path.
+func (s *Store) AuthLog() []AuthLogEntry {
+	s.logMu.Lock()
+	defer s.logMu.Unlock()
+	if s.logLen == 0 {
+		return nil
+	}
+	start := s.logHead - s.logLen
+	if start < 0 {
+		start += len(s.log)
+	}
+	out := make([]AuthLogEntry, s.logLen)
+	for i := 0; i < s.logLen; i++ {
+		out[i] = s.log[(start+i)%len(s.log)]
+	}
+	return out
+}

--- a/internal/rbac/log_test.go
+++ b/internal/rbac/log_test.go
@@ -1,0 +1,95 @@
+package rbac
+
+import (
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// itoa is a tiny alias so the eviction test's expected usernames read clearly.
+func itoa(i int) string { return strconv.Itoa(i) }
+
+// TestACLLogOrder verifies the auth-failure buffer returns entries in
+// chronological order and that overflowing it evicts the oldest entries.
+func TestACLLogOrder(t *testing.T) {
+	s := NewStore(&PolicyStore{})
+	for i := 0; i < 5; i++ {
+		s.LogAuthFailure("alice", "1.2.3.4:5", "invalid password")
+	}
+	entries := s.AuthLog()
+	if len(entries) != 5 {
+		t.Fatalf("AuthLog len = %d, want 5", len(entries))
+	}
+	for i, e := range entries {
+		if e.Username != "alice" || e.Reason != "invalid password" || e.RemoteAddr != "1.2.3.4:5" {
+			t.Fatalf("entry %d = %+v", i, e)
+		}
+		if e.Timestamp.IsZero() {
+			t.Fatalf("entry %d has zero timestamp", i)
+		}
+	}
+	if got := s.AuthFailures(); got != 5 {
+		t.Fatalf("AuthFailures = %d, want 5", got)
+	}
+}
+
+// TestACLLogEviction overflows the default capacity and verifies the oldest
+// entries are dropped while order is preserved and capacity stays bounded.
+func TestACLLogEviction(t *testing.T) {
+	s := NewStore(&PolicyStore{})
+	total := DefaultAuthLogCap + 7
+	for i := 0; i < total; i++ {
+		s.LogAuthFailure("u"+itoa(i), "addr", "reason")
+	}
+	entries := s.AuthLog()
+	if len(entries) != DefaultAuthLogCap {
+		t.Fatalf("AuthLog len = %d, want %d", len(entries), DefaultAuthLogCap)
+	}
+	// The first 7 writes are evicted; the oldest survivor is write #7, and
+	// the newest is the last write (total-1), in that order.
+	if entries[0].Username != "u7" {
+		t.Fatalf("oldest survivor = %q, want u7", entries[0].Username)
+	}
+	if entries[len(entries)-1].Username != "u"+itoa(total-1) {
+		t.Fatalf("newest entry = %q, want u%d", entries[len(entries)-1].Username, total-1)
+	}
+	if got := s.AuthFailures(); got != uint64(total) {
+		t.Fatalf("AuthFailures = %d, want %d", got, total)
+	}
+}
+
+// TestACLLogEmpty verifies an untouched store reports no entries.
+func TestACLLogEmpty(t *testing.T) {
+	s := NewStore(&PolicyStore{})
+	if entries := s.AuthLog(); entries != nil {
+		t.Fatalf("AuthLog = %v, want nil", entries)
+	}
+}
+
+// TestACLLogConcurrent exercises the mutex-protected buffer from many
+// goroutines; run with -race to prove no data race on append/read.
+func TestACLLogConcurrent(t *testing.T) {
+	s := NewStore(&PolicyStore{})
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 200; i++ {
+				s.LogAuthFailure("alice", "1.2.3.4:5", "invalid password")
+				_ = s.AuthLog()
+			}
+		}()
+	}
+	wg.Wait()
+	entries := s.AuthLog()
+	if len(entries) != DefaultAuthLogCap {
+		t.Fatalf("AuthLog len = %d, want %d", len(entries), DefaultAuthLogCap)
+	}
+	for i, e := range entries {
+		if strings.TrimSpace(e.Username) == "" || e.Reason == "" {
+			t.Fatalf("entry %d has empty fields: %+v", i, e)
+		}
+	}
+}

--- a/internal/rbac/manager.go
+++ b/internal/rbac/manager.go
@@ -63,17 +63,42 @@ func (s *Store) SetUser(username, roleName string, passHash []byte) error {
 }
 
 // DelUser removes username. Deleting the only "default" nopass user forces
-// future connections to authenticate.
-func (s *Store) DelUser(username string) {
+// future connections to authenticate. It rejects deleting the last user whose
+// effective role grants the ACL command bit: runtime ACL changes are never
+// written back to the policy file, so losing the final administrator would
+// lock every client out of ACL management until a restart or SIGHUP reload
+// restores one. Pinned sessions keep working either way; this only closes the
+// re-administration path.
+func (s *Store) DelUser(username string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	p := s.Load()
 	if p == nil {
-		return
+		return nil
+	}
+	if _, ok := p.Users[username]; ok {
+		if r := p.RoleFor(username); r != nil && r.Permissions.Has(CmdACL) && !p.hasOtherAdmin(username) {
+			return fmt.Errorf("rbac: cannot delete %q: last user with ACL management rights", username)
+		}
 	}
 	p = p.Clone()
 	delete(p.Users, username)
 	s.Store(p)
+	return nil
+}
+
+// hasOtherAdmin reports whether any user other than username has an effective
+// role — explicit or the Default fallback — granting the ACL command bit.
+func (p *PolicyStore) hasOtherAdmin(username string) bool {
+	for name := range p.Users {
+		if name == username {
+			continue
+		}
+		if r := p.RoleFor(name); r != nil && r.Permissions.Has(CmdACL) {
+			return true
+		}
+	}
+	return false
 }
 
 // DeleteRole removes a role. Users referencing the removed role fall back to

--- a/internal/rbac/manager_test.go
+++ b/internal/rbac/manager_test.go
@@ -61,9 +61,55 @@ func TestStoreDelUserAndDeleteRole(t *testing.T) {
 		t.Fatalf("user referencing a deleted role must resolve to the nil default, got %q", r.Name)
 	}
 
-	store.DelUser("alice")
+	if err := store.DelUser("alice"); err != nil {
+		t.Fatalf("DelUser: %v", err)
+	}
 	if store.Load().UserFor("alice") != nil {
 		t.Fatal("deleted user must be gone")
+	}
+}
+
+func TestStoreDelUserLastAdminGuard(t *testing.T) {
+	admin, err := ParseRole("admin", "+@admin", "~*")
+	if err != nil {
+		t.Fatalf("parse admin role: %v", err)
+	}
+	limited, err := ParseRole("limited", "+get", "~*")
+	if err != nil {
+		t.Fatalf("parse limited role: %v", err)
+	}
+	store := NewStore(&PolicyStore{
+		Roles: map[string]*Role{"admin": admin, "limited": limited},
+		Users: map[string]*User{
+			"admin":   {Role: "admin"},
+			"alice":   {Role: "limited"},
+			"limited": {Role: "limited"},
+		},
+		Default: limited,
+	})
+
+	// Deleting the last user whose effective role grants CmdACL is rejected.
+	if err := store.DelUser("admin"); err == nil {
+		t.Fatal("deleting the last admin user must be rejected")
+	}
+	if store.Load().UserFor("admin") == nil {
+		t.Fatal("rejected deletion must not mutate the store")
+	}
+
+	// A non-admin user, even the last one, may always be deleted.
+	if err := store.DelUser("alice"); err != nil {
+		t.Fatalf("deleting a non-admin user: %v", err)
+	}
+	// With a second admin present, deleting one is allowed.
+	if err := store.SetUser("nopass", "admin", nil); err != nil {
+		t.Fatalf("SetUser: %v", err)
+	}
+	if err := store.DelUser("admin"); err != nil {
+		t.Fatalf("deleting one of two admins: %v", err)
+	}
+	// Deleting an unknown user stays a no-op success.
+	if err := store.DelUser("ghost"); err != nil {
+		t.Fatalf("deleting an unknown user: %v", err)
 	}
 }
 

--- a/internal/rbac/policy.go
+++ b/internal/rbac/policy.go
@@ -94,6 +94,13 @@ type Store struct {
 	// (fail-closed deny-all). The request path only bumps them atomically.
 	authFailures   uint64
 	deniedCommands uint64
+	// logMu serializes the ACL auth-failure log. The log is mutable state that
+	// lives for the Store's lifetime and survives policy Reload swaps; entries
+	// are recorded off the hot path at failed AUTH time.
+	logMu   sync.Mutex
+	log     []AuthLogEntry // circular buffer, oldest at (logHead-logLen) mod cap
+	logHead int            // next write slot
+	logLen  int            // number of valid entries
 }
 
 // NewStore returns a Store seeded with policy.

--- a/internal/rbac/rbac.go
+++ b/internal/rbac/rbac.go
@@ -27,24 +27,27 @@ func (b *Bitset) Set(id uint16) {
 	(*b)[word] |= bit
 }
 
-// Has reports whether id is granted. Out-of-range IDs are denied. A value
-// receiver keeps the read callable on non-addressable Bitset expressions.
-func (b Bitset) Has(id uint16) bool {
+// Has reports whether id is granted. Out-of-range IDs are denied. The
+// authorization hot path is a single dereference plus bit test with zero
+// allocations.
+func (b *Bitset) Has(id uint16) bool {
 	word := id / 64
-	if int(word) >= len(b) {
+	if int(word) >= len(*b) {
 		return false
 	}
-	return b[word]&(uint64(1)<<(id%64)) != 0
+	v := *b
+	return v[word]&(uint64(1)<<(id%64)) != 0
 }
 
-// Clear revokes id. Out-of-range IDs are a no-op. A value receiver is safe: it
-// only mutates existing slice contents, which share the backing array.
-func (b Bitset) Clear(id uint16) {
+// Clear revokes id. Out-of-range IDs are a no-op. It mutates the existing
+// backing array in place, so it never reallocates or grows the slice.
+func (b *Bitset) Clear(id uint16) {
 	word := id / 64
-	if int(word) >= len(b) {
+	if int(word) >= len(*b) {
 		return
 	}
-	b[word] &^= uint64(1) << (id % 64)
+	v := *b
+	v[word] &^= uint64(1) << (id % 64)
 }
 
 // NewBitset returns a bitset pre-sized for commands with every listed ID granted.

--- a/internal/resp/acl.go
+++ b/internal/resp/acl.go
@@ -65,7 +65,9 @@ func (s *Server) aclDelUser(args [][]byte, out []byte) []byte {
 	if len(args) != 3 {
 		return AppendError(out, "ERR wrong number of arguments for 'acl|deluser' command")
 	}
-	s.policy.DelUser(string(args[2]))
+	if err := s.policy.DelUser(string(args[2])); err != nil {
+		return AppendError(out, "ERR "+err.Error())
+	}
 	return append(out, respOK...)
 }
 

--- a/internal/resp/acl.go
+++ b/internal/resp/acl.go
@@ -56,14 +56,7 @@ func (s *Server) aclSetUser(args [][]byte, out []byte) []byte {
 	if len(args) == 4 {
 		return AppendError(out, "ERR acl|setuser requires a '>password' or 'nopass' option")
 	}
-	passHash, err := rbac.PasswordFromOpts(args[4:])
-	if err != nil {
-		return AppendError(out, "ERR "+err.Error())
-	}
-	if err := s.policy.SetUser(string(args[2]), string(args[3]), passHash); err != nil {
-		return AppendError(out, "ERR "+err.Error())
-	}
-	return append(out, respOK...)
+	return s.setUser(args, out)
 }
 
 // aclDelUser implements ACL DELUSER <username>. Deleting the only "default"
@@ -96,20 +89,22 @@ func (s *Server) aclList(args [][]byte, out []byte) []byte {
 	out = AppendArray(out, len(names))
 	for _, name := range names {
 		u := p.Users[name]
-		var r *rbac.Role
-		if u.Role != "" {
-			r = p.Roles[u.Role]
-		}
+		// Effective permissions come from the resolved role — the explicit
+		// assignment or the Default role for unassigned users and for users
+		// whose role was deleted — so LIST never shows empty grants for a user
+		// the default role covers. The role identity field stays u.Role (null
+		// for the default-role case) so the assignment is visible.
+		r := p.RoleFor(name)
 		hasPass := 0
 		if len(u.PasswordHash) > 0 {
 			hasPass = 1
 		}
 		out = AppendArray(out, 5)
 		out = AppendBulk(out, []byte(name))
-		if r == nil {
+		if u.Role == "" {
 			out = AppendNullBulk(out)
 		} else {
-			out = AppendBulk(out, []byte(r.Name))
+			out = AppendBulk(out, []byte(u.Role))
 		}
 		out = AppendInt(out, int64(hasPass))
 		out = appendACLCommands(out, r)

--- a/internal/resp/acl.go
+++ b/internal/resp/acl.go
@@ -1,0 +1,166 @@
+/*
+Package resp
+Tellstone Redis-Compatible Wire Protocol
+File: acl.go
+Description: ACL command family (SETUSER, DELUSER, LIST, LOG) — the Redis-flavored management
+alias over the RBAC policy store. Users bind to a role plus password options exactly like
+ROLE SETUSER; LIST renders each user with its role's command and namespace permissions but
+never a password hash; LOG returns the recent auth-failure buffer. Reply building is RESP2
+only; the binary protocol carries its own wire encoding.
+
+Authors:
+
+	Maximilian Hagen
+*/
+package resp
+
+import (
+	"sort"
+	"time"
+
+	"github.com/Saxy/Tellstone/internal/rbac"
+)
+
+// acl dispatches ACL subcommands. Connections need the ACL command permission
+// (granted by the "admin" category) to reach this handler; the check happens
+// in dispatch.
+func (s *Server) acl(st *connState, args [][]byte, out []byte) []byte {
+	if s.policy == nil {
+		return AppendError(out, "ERR RBAC is not enabled")
+	}
+	if len(args) < 2 {
+		return AppendError(out, "ERR wrong number of arguments for 'acl' command")
+	}
+	switch {
+	case EqualFold(args[1], "SETUSER"):
+		return s.aclSetUser(args, out)
+	case EqualFold(args[1], "DELUSER"):
+		return s.aclDelUser(args, out)
+	case EqualFold(args[1], "LIST"):
+		return s.aclList(args, out)
+	case EqualFold(args[1], "LOG"):
+		return s.aclLog(args, out)
+	default:
+		return AppendError(out, "ERR unknown acl subcommand '"+string(args[1])+"'")
+	}
+}
+
+// aclSetUser implements ACL SETUSER <username> <role> [>password] [nopass].
+// Tellstone's RBAC model binds a user to a role, so the permission rules live
+// on the role rather than inline on the user as in Redis; the password options
+// and the fail-closed unknown-role rejection mirror ROLE SETUSER.
+func (s *Server) aclSetUser(args [][]byte, out []byte) []byte {
+	if len(args) < 4 {
+		return AppendError(out, "ERR wrong number of arguments for 'acl|setuser' command")
+	}
+	if len(args) == 4 {
+		return AppendError(out, "ERR acl|setuser requires a '>password' or 'nopass' option")
+	}
+	passHash, err := rbac.PasswordFromOpts(args[4:])
+	if err != nil {
+		return AppendError(out, "ERR "+err.Error())
+	}
+	if err := s.policy.SetUser(string(args[2]), string(args[3]), passHash); err != nil {
+		return AppendError(out, "ERR "+err.Error())
+	}
+	return append(out, respOK...)
+}
+
+// aclDelUser implements ACL DELUSER <username>. Deleting the only "default"
+// nopass user forces future connections to authenticate.
+func (s *Server) aclDelUser(args [][]byte, out []byte) []byte {
+	if len(args) != 3 {
+		return AppendError(out, "ERR wrong number of arguments for 'acl|deluser' command")
+	}
+	s.policy.DelUser(string(args[2]))
+	return append(out, respOK...)
+}
+
+// aclList implements ACL LIST: one entry per user, sorted by name, with the
+// username, bound role (null when the default role applies), whether a password
+// is set, and the role's granted commands and namespace whitelist. Password
+// hashes are never rendered (mirrors ROLE LIST).
+func (s *Server) aclList(args [][]byte, out []byte) []byte {
+	if len(args) != 2 {
+		return AppendError(out, "ERR wrong number of arguments for 'acl|list' command")
+	}
+	p := s.policy.Load()
+	if p == nil {
+		return AppendError(out, "ERR policy not loaded")
+	}
+	names := make([]string, 0, len(p.Users))
+	for name := range p.Users {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out = AppendArray(out, len(names))
+	for _, name := range names {
+		u := p.Users[name]
+		var r *rbac.Role
+		if u.Role != "" {
+			r = p.Roles[u.Role]
+		}
+		hasPass := 0
+		if len(u.PasswordHash) > 0 {
+			hasPass = 1
+		}
+		out = AppendArray(out, 5)
+		out = AppendBulk(out, []byte(name))
+		if r == nil {
+			out = AppendNullBulk(out)
+		} else {
+			out = AppendBulk(out, []byte(r.Name))
+		}
+		out = AppendInt(out, int64(hasPass))
+		out = appendACLCommands(out, r)
+		out = appendACLNamespaces(out, r)
+	}
+	return out
+}
+
+// aclLog implements ACL LOG: the recent auth-failure buffer in chronological
+// order, each entry a [timestamp, username, remote address, reason] tuple.
+// Unlike Redis's keyed field map the response is a flat array of tuples; the
+// content (who failed, when, from where, why) is the same.
+func (s *Server) aclLog(args [][]byte, out []byte) []byte {
+	if len(args) != 2 {
+		return AppendError(out, "ERR wrong number of arguments for 'acl|log' command")
+	}
+	entries := s.policy.AuthLog()
+	out = AppendArray(out, len(entries))
+	for _, e := range entries {
+		out = AppendArray(out, 4)
+		out = AppendBulk(out, []byte(e.Timestamp.Format(time.RFC3339)))
+		out = AppendBulk(out, []byte(e.Username))
+		out = AppendBulk(out, []byte(e.RemoteAddr))
+		out = AppendBulk(out, []byte(e.Reason))
+	}
+	return out
+}
+
+// appendACLCommands renders a user's role's granted commands as a RESP array.
+// A nil role (no explicit assignment) grants nothing.
+func appendACLCommands(out []byte, r *rbac.Role) []byte {
+	if r == nil {
+		return AppendArray(out, 0)
+	}
+	names := r.GrantedCommands()
+	out = AppendArray(out, len(names))
+	for _, name := range names {
+		out = AppendBulk(out, []byte(name))
+	}
+	return out
+}
+
+// appendACLNamespaces renders a user's role's namespace whitelist as a RESP
+// array. An empty array means every key is allowed.
+func appendACLNamespaces(out []byte, r *rbac.Role) []byte {
+	if r == nil {
+		return AppendArray(out, 0)
+	}
+	out = AppendArray(out, len(r.Namespaces))
+	for _, ns := range r.Namespaces {
+		out = AppendBulk(out, ns)
+	}
+	return out
+}

--- a/internal/resp/acl_test.go
+++ b/internal/resp/acl_test.go
@@ -1,0 +1,184 @@
+package resp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Saxy/Tellstone/internal/log"
+	"github.com/Saxy/Tellstone/internal/rbac"
+)
+
+// startACLServer runs a RESP server on the seeded RBAC policy and returns the
+// live store so tests can assert store-level effects of the ACL commands.
+func startACLServer(t *testing.T) (addr string, store *rbac.Store) {
+	t.Helper()
+	addr = freeAddr(t)
+	store = rbac.NewStore(rbacTestPolicy(t))
+	srv := NewServer(addr, newFakeStore(), nil, log.NewNoOpLogger(), nil, "", false, store)
+	go func() { _ = srv.ListenAndServe() }()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	})
+	return addr, store
+}
+
+// TestRESPServer_ACLNotEnabled verifies the ACL command family is rejected
+// when RBAC is disabled, mirroring the ROLE command's guard.
+func TestRESPServer_ACLNotEnabled(t *testing.T) {
+	addr := freeAddr(t)
+	srv := NewServer(addr, newFakeStore(), nil, log.NewNoOpLogger(), nil, "", false, nil)
+	go func() { _ = srv.ListenAndServe() }()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	})
+	conn := dialWithRetry(t, addr)
+	defer conn.Close()
+	expectReply(t, conn, "ACL LIST without RBAC",
+		"*2\r\n$3\r\nACL\r\n$4\r\nLIST\r\n", "-ERR RBAC is not enabled\r\n")
+}
+
+// TestRESPServer_ACLGating verifies the ACL command family needs the ACL
+// command bit: the limited role (GET only) is denied with NOPERM.
+func TestRESPServer_ACLGating(t *testing.T) {
+	addr, _ := startACLServer(t)
+	conn := dialWithRetry(t, addr)
+	defer conn.Close()
+
+	expectReply(t, conn, "AUTH limited",
+		"*3\r\n$4\r\nAUTH\r\n$7\r\nlimited\r\n$8\r\nwhatever\r\n", "+OK\r\n")
+	expectReply(t, conn, "ACL LIST denied",
+		"*2\r\n$3\r\nACL\r\n$4\r\nLIST\r\n", "-NOPERM no permission for 'acl' command\r\n")
+}
+
+// TestRESPServer_ACLCommands exercises the SETUSER/DELUSER/LIST management
+// surface end-to-end: create a role, bind a user via ACL SETUSER, list users,
+// then delete the user and confirm the store dropped it.
+func TestRESPServer_ACLCommands(t *testing.T) {
+	addr, store := startACLServer(t)
+	conn := dialWithRetry(t, addr)
+	defer conn.Close()
+
+	expectReply(t, conn, "AUTH admin",
+		"*3\r\n$4\r\nAUTH\r\n$5\r\nadmin\r\n$6\r\nsekret\r\n", "+OK\r\n")
+
+	// ACL SETUSER requires a role to bind to; create it first via ROLE CREATE.
+	expectReply(t, conn, "ROLE CREATE operator",
+		"*5\r\n$4\r\nROLE\r\n$6\r\nCREATE\r\n$8\r\noperator\r\n$4\r\n+get\r\n$8\r\n~users:*\r\n", "+OK\r\n")
+
+	// ACL SETUSER with a password option.
+	expectReply(t, conn, "ACL SETUSER bob",
+		"*5\r\n$3\r\nACL\r\n$7\r\nSETUSER\r\n$3\r\nbob\r\n$8\r\noperator\r\n$8\r\n>hunter2\r\n", "+OK\r\n")
+	if u := store.Load().UserFor("bob"); u == nil || u.Role != "operator" || len(u.PasswordHash) == 0 {
+		t.Fatalf("user bob after ACL SETUSER = %+v, want operator with password", u)
+	}
+
+	// ACL SETUSER without a password option is rejected, like ROLE SETUSER.
+	expectReply(t, conn, "ACL SETUSER missing option",
+		"*4\r\n$3\r\nACL\r\n$7\r\nSETUSER\r\n$3\r\neve\r\n$8\r\noperator\r\n",
+		"-ERR acl|setuser requires a '>password' or 'nopass' option\r\n")
+	if u := store.Load().UserFor("eve"); u != nil {
+		t.Fatalf("user eve exists after rejected SETUSER: %+v", u)
+	}
+
+	// ACL LIST: seeded users admin/limited/nopass plus bob, sorted by name.
+	admin, err := rbac.ParseRole("admin", "+@all", "~*")
+	if err != nil {
+		t.Fatalf("parse admin role: %v", err)
+	}
+	limited, err := rbac.ParseRole("limited", "+get", "~*")
+	if err != nil {
+		t.Fatalf("parse limited role: %v", err)
+	}
+	operator, err := rbac.ParseRole("operator", "+get", "~users:*")
+	if err != nil {
+		t.Fatalf("parse operator role: %v", err)
+	}
+	want := AppendArray(nil, 4)
+	for _, u := range []struct {
+		name    string
+		role    string
+		hasPass int64
+		cmds    *rbac.Role
+		ns      int
+	}{
+		{"admin", "admin", 1, admin, 0},
+		{"bob", "operator", 1, operator, 1},
+		{"limited", "limited", 0, limited, 0},
+		{"nopass", "admin", 0, admin, 0},
+	} {
+		want = AppendArray(want, 5)
+		want = AppendBulk(want, []byte(u.name))
+		want = AppendBulk(want, []byte(u.role))
+		want = AppendInt(want, u.hasPass)
+		cmds := u.cmds.GrantedCommands()
+		want = AppendArray(want, len(cmds))
+		for _, n := range cmds {
+			want = AppendBulk(want, []byte(n))
+		}
+		want = AppendArray(want, u.ns)
+		if u.ns == 1 {
+			want = AppendBulk(want, []byte("users:"))
+		}
+	}
+	expectReply(t, conn, "ACL LIST",
+		"*2\r\n$3\r\nACL\r\n$4\r\nLIST\r\n", string(want))
+
+	// ACL DELUSER removes the user from the store.
+	expectReply(t, conn, "ACL DELUSER bob",
+		"*3\r\n$3\r\nACL\r\n$7\r\nDELUSER\r\n$3\r\nbob\r\n", "+OK\r\n")
+	if u := store.Load().UserFor("bob"); u != nil {
+		t.Fatalf("user bob still present after ACL DELUSER: %+v", u)
+	}
+
+	// Unknown subcommand and wrong arity are rejected.
+	expectReply(t, conn, "ACL unknown subcommand",
+		"*3\r\n$3\r\nACL\r\n$3\r\nFOO\r\n$1\r\nx\r\n", "-ERR unknown acl subcommand 'FOO'\r\n")
+	expectReply(t, conn, "ACL LOG wrong arity",
+		"*3\r\n$3\r\nACL\r\n$3\r\nLOG\r\n$1\r\nx\r\n", "-ERR wrong number of arguments for 'acl|log' command\r\n")
+}
+
+// TestRESPServer_ACLLog verifies failed AUTH attempts are recorded in the ACL
+// LOG buffer with username, remote address, and reason, and that ACL LOG
+// renders them in chronological order without leaking password hashes.
+func TestRESPServer_ACLLog(t *testing.T) {
+	addr, store := startACLServer(t)
+	conn := dialWithRetry(t, addr)
+	defer conn.Close()
+
+	// Two failures: a wrong password for an existing user, then an unknown user.
+	expectReply(t, conn, "AUTH wrong password",
+		"*3\r\n$4\r\nAUTH\r\n$5\r\nadmin\r\n$5\r\nwrong\r\n", "-ERR invalid password\r\n")
+	expectReply(t, conn, "AUTH unknown user",
+		"*3\r\n$4\r\nAUTH\r\n$5\r\nghost\r\n$5\r\nwrong\r\n", "-ERR invalid password\r\n")
+	expectReply(t, conn, "AUTH admin ok",
+		"*3\r\n$4\r\nAUTH\r\n$5\r\nadmin\r\n$6\r\nsekret\r\n", "+OK\r\n")
+
+	entries := store.AuthLog()
+	if len(entries) != 2 {
+		t.Fatalf("AuthLog len = %d, want 2", len(entries))
+	}
+	if entries[0].Username != "admin" || entries[0].Reason != "invalid password" {
+		t.Fatalf("entry 0 = %+v, want admin/invalid password", entries[0])
+	}
+	if entries[1].Username != "ghost" || entries[1].Reason != "unknown user" {
+		t.Fatalf("entry 1 = %+v, want ghost/unknown user", entries[1])
+	}
+
+	// The reply must match exactly what the store's log renders.
+	var want []byte
+	want = AppendArray(want, len(entries))
+	for _, e := range entries {
+		want = AppendArray(want, 4)
+		want = AppendBulk(want, []byte(e.Timestamp.Format(time.RFC3339)))
+		want = AppendBulk(want, []byte(e.Username))
+		want = AppendBulk(want, []byte(e.RemoteAddr))
+		want = AppendBulk(want, []byte(e.Reason))
+	}
+	expectReply(t, conn, "ACL LOG",
+		"*2\r\n$3\r\nACL\r\n$3\r\nLOG\r\n", string(want))
+}

--- a/internal/resp/role.go
+++ b/internal/resp/role.go
@@ -76,6 +76,14 @@ func (s *Server) roleSetUser(args [][]byte, out []byte) []byte {
 	if len(args) == 4 {
 		return AppendError(out, "ERR role|setuser requires a '>password' or 'nopass' option")
 	}
+	return s.setUser(args, out)
+}
+
+// setUser applies the SETUSER tail shared by ROLE SETUSER and ACL SETUSER:
+// parse the password options and bind the user to the named role, replying OK
+// on success or an error otherwise. The arg-count checks stay in the callers so
+// each family reports its own command name in the error message.
+func (s *Server) setUser(args [][]byte, out []byte) []byte {
 	passHash, err := rbac.PasswordFromOpts(args[4:])
 	if err != nil {
 		return AppendError(out, "ERR "+err.Error())

--- a/internal/resp/role.go
+++ b/internal/resp/role.go
@@ -99,7 +99,9 @@ func (s *Server) roleDelUser(args [][]byte, out []byte) []byte {
 	if len(args) != 3 {
 		return AppendError(out, "ERR wrong number of arguments for 'role|deluser' command")
 	}
-	s.policy.DelUser(string(args[2]))
+	if err := s.policy.DelUser(string(args[2])); err != nil {
+		return AppendError(out, "ERR "+err.Error())
+	}
 	return append(out, respOK...)
 }
 

--- a/internal/resp/server.go
+++ b/internal/resp/server.go
@@ -547,6 +547,14 @@ func (s *Server) dispatch(st *connState, args [][]byte, out []byte) []byte {
 		s.countCommand(st)
 		return s.role(st, args, out)
 
+	case EqualFold(cmd, shard.CmdACL):
+		if !s.authorizedCmd(st, rbac.CmdACL) {
+			s.countDenied()
+			return AppendError(out, "NOPERM no permission for 'acl' command")
+		}
+		s.countCommand(st)
+		return s.acl(st, args, out)
+
 	case EqualFold(cmd, "QUIT"):
 		st.closeAfterReply = true
 		return append(out, respOK...)
@@ -624,12 +632,17 @@ func (s *Server) auth(st *connState, args [][]byte, out []byte) []byte {
 	if s.requirePassHash == nil {
 		return append(out, respOK...)
 	}
-	// Only the implicit "default" user exists until an ACL system lands (issue #9).
+	// Single-password mode knows only the implicit "default" user; per-user
+	// identities and the ACL command family live in the RBAC/ACL path above.
 	if len(args) == 3 && string(args[1]) != "default" {
-		return s.authFailed(st, out)
+		return s.authFailed(st, string(args[1]), "unknown user", out)
 	}
 	if bcrypt.CompareHashAndPassword(s.requirePassHash, args[len(args)-1]) != nil {
-		return s.authFailed(st, out)
+		username := "default"
+		if len(args) == 3 {
+			username = string(args[1])
+		}
+		return s.authFailed(st, username, "invalid password", out)
 	}
 	st.authenticated = true
 	return append(out, respOK...)
@@ -651,27 +664,29 @@ func (s *Server) authRBAC(st *connState, args [][]byte, out []byte) []byte {
 	}
 	p := s.policy.Load()
 	if p == nil {
-		return s.authFailed(st, out)
+		return s.authFailed(st, username, "policy not loaded", out)
 	}
 	u := p.UserFor(username)
 	if u == nil {
 		// Burn one bcrypt comparison so the failure latency matches an
 		// existing user with a wrong password (see dummyAuthHash).
 		_ = bcrypt.CompareHashAndPassword(dummyAuthHash, args[len(args)-1])
-		return s.authFailed(st, out)
+		return s.authFailed(st, username, "unknown user", out)
 	}
 	if len(u.PasswordHash) > 0 && bcrypt.CompareHashAndPassword(u.PasswordHash, args[len(args)-1]) != nil {
-		return s.authFailed(st, out)
+		return s.authFailed(st, username, "invalid password", out)
 	}
 	st.authenticated = true
 	st.session = rbac.NewSessionContext(username, p.RoleFor(username))
 	return append(out, respOK...)
 }
 
-// authFailed logs a rejected AUTH attempt and appends the RESP error reply.
-func (s *Server) authFailed(st *connState, out []byte) []byte {
+// authFailed records a rejected AUTH attempt — bumping the store-wide counter
+// and appending to the ACL LOG buffer when RBAC is enabled — logs it, and
+// appends the RESP error reply.
+func (s *Server) authFailed(st *connState, username, reason string, out []byte) []byte {
 	if s.policy != nil {
-		s.policy.IncAuthFailure()
+		s.policy.LogAuthFailure(username, st.remoteAddr, reason)
 	}
 	if s.logger.Enabled(log.LevelWarn) {
 		s.logger.Log(log.LevelWarn, "resp: failed AUTH attempt",

--- a/internal/resp/server.go
+++ b/internal/resp/server.go
@@ -269,14 +269,17 @@ func (s *Server) onTrafficTLS(c gnet.Conn, st *connState) gnet.Action {
 	}
 }
 
-// handleDecryptedResp parses RESP commands from decrypted plaintext and
-// writes encrypted responses through the TLS connection. It returns gnet.Close
-// on protocol or write errors so the caller propagates the close.
-func (s *Server) handleDecryptedResp(st *connState, c gnet.Conn) gnet.Action {
+// processBuffer parses and dispatches every complete command in src, appending
+// replies to st.out. It is the shared core of the plaintext and TLS traffic
+// paths, whose only differences are the buffer ownership and the STARTTLS
+// upgrade. A STARTTLS upgrade flushes the replies and installs TLS state
+// before returning. The results tell the caller what to flush: bad means the
+// connection must close (malformed frame or failed upgrade), upgraded means
+// the replies were already written and the caller must not flush again.
+func (s *Server) processBuffer(st *connState, c gnet.Conn, src []byte) (consumed int, upgraded bool, bad bool) {
 	st.out = st.out[:0]
-	consumed := 0
-	for consumed < len(st.readBuf) {
-		args, n, perr := Parse(st.readBuf[consumed:], st.args)
+	for consumed < len(src) {
+		args, n, perr := Parse(src[consumed:], st.args)
 		if perr != nil {
 			if errors.Is(perr, errIncomplete) {
 				break
@@ -287,15 +290,32 @@ func (s *Server) handleDecryptedResp(st *connState, c gnet.Conn) gnet.Action {
 					log.String("remote_addr", c.RemoteAddr().String()),
 				)
 			}
-			return gnet.Close
+			return consumed, false, true
 		}
 		st.args = args[:0]
 		consumed += n
 		st.out = s.dispatch(st, args, st.out)
+		if st.upgradeTLS {
+			if s.upgradeToTLS(c, st, consumed) == gnet.Close {
+				return consumed, false, true
+			}
+			return consumed, true, false
+		}
 		if st.closeAfterReply {
 			// QUIT: stop parsing pipelined commands; flush replies, then close below.
 			break
 		}
+	}
+	return consumed, false, false
+}
+
+// handleDecryptedResp parses RESP commands from decrypted plaintext and
+// writes encrypted responses through the TLS connection. It returns gnet.Close
+// on protocol or write errors so the caller propagates the close.
+func (s *Server) handleDecryptedResp(st *connState, c gnet.Conn) gnet.Action {
+	consumed, _, bad := s.processBuffer(st, c, st.readBuf)
+	if bad {
+		return gnet.Close
 	}
 	if consumed == 0 {
 		return gnet.None
@@ -357,32 +377,14 @@ func (s *Server) onTrafficPlaintext(c gnet.Conn, st *connState) gnet.Action {
 		}
 		return gnet.Close
 	}
-	st.out = st.out[:0]
-	consumed := 0
-	for consumed < len(buf) {
-		args, n, perr := Parse(buf[consumed:], st.args)
-		if perr != nil {
-			if errors.Is(perr, errIncomplete) {
-				break
-			}
-			atomic.AddUint64(&s.protocolErrors, 1)
-			if s.logger.Enabled(log.LevelWarn) {
-				s.logger.Log(log.LevelWarn, "resp: malformed frame; closing connection",
-					log.String("remote_addr", c.RemoteAddr().String()),
-				)
-			}
-			return gnet.Close
-		}
-		st.args = args[:0]
-		consumed += n
-		st.out = s.dispatch(st, args, st.out)
-		if st.upgradeTLS {
-			return s.upgradeToTLS(c, st, consumed)
-		}
-		if st.closeAfterReply {
-			// QUIT: stop parsing pipelined commands; flush replies, then close below.
-			break
-		}
+	consumed, upgraded, bad := s.processBuffer(st, c, buf)
+	if bad {
+		return gnet.Close
+	}
+	if upgraded {
+		// upgradeToTLS already flushed the replies, discarded the consumed bytes,
+		// and installed TLS state; the TLS path takes over from here.
+		return gnet.None
 	}
 	if consumed == 0 {
 		return gnet.None
@@ -634,14 +636,16 @@ func (s *Server) auth(st *connState, args [][]byte, out []byte) []byte {
 	}
 	// Single-password mode knows only the implicit "default" user; per-user
 	// identities and the ACL command family live in the RBAC/ACL path above.
-	if len(args) == 3 && string(args[1]) != "default" {
-		return s.authFailed(st, string(args[1]), "unknown user", out)
+	// Derive the username once so the unknown-user and invalid-password
+	// branches report the same identity.
+	username := "default"
+	if len(args) == 3 {
+		username = string(args[1])
+	}
+	if username != "default" {
+		return s.authFailed(st, username, "unknown user", out)
 	}
 	if bcrypt.CompareHashAndPassword(s.requirePassHash, args[len(args)-1]) != nil {
-		username := "default"
-		if len(args) == 3 {
-			username = string(args[1])
-		}
 		return s.authFailed(st, username, "invalid password", out)
 	}
 	st.authenticated = true

--- a/internal/shard/runner.go
+++ b/internal/shard/runner.go
@@ -31,6 +31,7 @@ const (
 	CmdCommand string = "COMMAND"
 	CmdAuth    string = "AUTH"
 	CmdRole    string = "ROLE"
+	CmdACL     string = "ACL"
 )
 
 type Shard struct {

--- a/server/server.go
+++ b/server/server.go
@@ -421,6 +421,20 @@ func (s *Server) networkHandler(msg *network.Message) ([]byte, network.MessageTy
 		default:
 			return s.roleGetUser(msg)
 		}
+	case network.OpACLSetUser, network.OpACLDelUser, network.OpACLList, network.OpACLLog:
+		if s.policy == nil {
+			return roleReply(fmt.Errorf("rbac not enabled"))
+		}
+		switch msg.Op {
+		case network.OpACLSetUser:
+			return s.aclSetUser(msg)
+		case network.OpACLDelUser:
+			return s.aclDelUser(msg)
+		case network.OpACLList:
+			return s.aclList(msg)
+		default:
+			return s.aclLog(msg)
+		}
 	default:
 		return network.ResponseInvalidOpCode, network.MsgError, nil
 	}
@@ -518,4 +532,80 @@ func (s *Server) roleGetUser(msg *network.Message) ([]byte, network.MessageType,
 		return roleReply(fmt.Errorf("user '%s' does not exist", args[0]))
 	}
 	return network.EncodeRoleGetUserResponse(network.RoleUser{Role: u.Role, HasPass: len(u.PasswordHash) > 0}), network.MsgResponse, nil
+}
+
+// aclSetUser handles OpACLSetUser, the binary ACL alias of ROLE SETUSER.
+func (s *Server) aclSetUser(msg *network.Message) ([]byte, network.MessageType, error) {
+	args, ok := network.DecodeRoleArgs(msg.Value, nil)
+	if !ok || len(args) < 2 {
+		return roleReply(fmt.Errorf("invalid ACL SETUSER arguments"))
+	}
+	if len(args) == 2 {
+		return roleReply(fmt.Errorf("ACL SETUSER requires a '>password' or 'nopass' option"))
+	}
+	passHash, err := rbac.PasswordFromOpts(args[2:])
+	if err != nil {
+		return roleReply(err)
+	}
+	return roleReply(s.policy.SetUser(string(args[0]), string(args[1]), passHash))
+}
+
+func (s *Server) aclDelUser(msg *network.Message) ([]byte, network.MessageType, error) {
+	args, ok := network.DecodeRoleArgs(msg.Value, nil)
+	if !ok || len(args) != 1 {
+		return roleReply(fmt.Errorf("invalid ACL DELUSER arguments"))
+	}
+	s.policy.DelUser(string(args[0]))
+	return network.ResponseOK, network.MsgResponse, nil
+}
+
+// aclList handles OpACLList, returning one entry per user with the username,
+// bound role, password presence, and the role's commands and namespace
+// whitelist — never a password hash (mirrors the RESP ACL LIST handler).
+func (s *Server) aclList(msg *network.Message) ([]byte, network.MessageType, error) {
+	p := s.policy.Load()
+	if p == nil {
+		return roleReply(fmt.Errorf("rbac policy not loaded"))
+	}
+	users := make([]network.ACLUser, 0, len(p.Users))
+	for name, u := range p.Users {
+		e := network.ACLUser{Username: name, Role: u.Role, HasPass: len(u.PasswordHash) > 0}
+		if r, ok := p.Roles[u.Role]; ok {
+			e.Commands = r.GrantedCommands()
+			for _, ns := range r.Namespaces {
+				e.Namespaces = append(e.Namespaces, append([]byte(nil), ns...))
+			}
+		}
+		users = append(users, e)
+	}
+	// Map iteration is unordered; sort by username so identical policies
+	// produce a stable, name-ordered response (mirrors the RESP LIST handler).
+	sort.Slice(users, func(i, j int) bool { return users[i].Username < users[j].Username })
+	payload, ok := network.EncodeACLListResponse(users)
+	if !ok {
+		return roleReply(fmt.Errorf("acl rule exceeds the 64 KiB wire limit"))
+	}
+	return payload, network.MsgResponse, nil
+}
+
+// aclLog handles OpACLLog, returning the recent auth-failure buffer in
+// chronological order with timestamp, username, remote address, and reason —
+// the binary twin of the RESP ACL LOG handler. Entries are already ordered by
+// the store, so no sort is needed.
+func (s *Server) aclLog(msg *network.Message) ([]byte, network.MessageType, error) {
+	src := s.policy.AuthLog()
+	entries := make([]network.AuthLogEntry, 0, len(src))
+	for _, e := range src {
+		entries = append(entries, network.AuthLogEntry{
+			Timestamp:  e.Timestamp.Format(time.RFC3339),
+			Username:   e.Username,
+			RemoteAddr: e.RemoteAddr,
+			Reason:     e.Reason,
+		})
+	}
+	payload, ok := network.EncodeACLLogResponse(entries)
+	if !ok {
+		return roleReply(fmt.Errorf("acl log exceeds the 64 KiB wire limit"))
+	}
+	return payload, network.MsgResponse, nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -483,8 +483,7 @@ func (s *Server) roleDelUser(msg *network.Message) ([]byte, network.MessageType,
 	if !ok || len(args) != 1 {
 		return roleReply(fmt.Errorf("invalid ROLE DELUSER arguments"))
 	}
-	s.policy.DelUser(string(args[0]))
-	return network.ResponseOK, network.MsgResponse, nil
+	return roleReply(s.policy.DelUser(string(args[0])))
 }
 
 func (s *Server) roleDelete(msg *network.Message) ([]byte, network.MessageType, error) {
@@ -555,8 +554,7 @@ func (s *Server) aclDelUser(msg *network.Message) ([]byte, network.MessageType, 
 	if !ok || len(args) != 1 {
 		return roleReply(fmt.Errorf("invalid ACL DELUSER arguments"))
 	}
-	s.policy.DelUser(string(args[0]))
-	return network.ResponseOK, network.MsgResponse, nil
+	return roleReply(s.policy.DelUser(string(args[0])))
 }
 
 // aclList handles OpACLList, returning one entry per user with the username,

--- a/server/server.go
+++ b/server/server.go
@@ -570,7 +570,10 @@ func (s *Server) aclList(msg *network.Message) ([]byte, network.MessageType, err
 	users := make([]network.ACLUser, 0, len(p.Users))
 	for name, u := range p.Users {
 		e := network.ACLUser{Username: name, Role: u.Role, HasPass: len(u.PasswordHash) > 0}
-		if r, ok := p.Roles[u.Role]; ok {
+		// Effective permissions come from RoleFor: the explicit assignment or
+		// the Default role for unassigned / role-deleted users, matching the
+		// RESP ACL LIST handler.
+		if r := p.RoleFor(name); r != nil {
 			e.Commands = r.GrantedCommands()
 			for _, ns := range r.Namespaces {
 				e.Namespaces = append(e.Namespaces, append([]byte(nil), ns...))


### PR DESCRIPTION
## Description

Implements the Redis-flavored ACL command family (`ACL SETUSER` / `ACL DELUSER` / `ACL LIST` / `ACL LOG`) on top of the existing RBAC policy store, plus a store-wide auth-failure log shared by both protocol layers.

- `ACL SETUSER <user> <role> [>password] [nopass]` binds a user to a role with a bcrypt password; `ACL DELUSER` revokes it; `ACL LIST` renders each user with its bound role, password presence, command grants, and namespace whitelist (never a password hash).
- `ACL LOG` exposes the recent rejected-AUTH buffer (timestamp, username, remote address, reason), recorded off the hot path on the `rbac.Store`.
- Binary protocol gains `OpACLSetUser` / `OpACLDelUser` / `OpACLList` / `OpACLLog` with typed wire codecs, RBAC command-bit gating, and client methods on both the `internal/network` and public `client` packages.
- RESP and binary AUTH failures feed one shared buffer; `ACL LOG` reads it back over either protocol.
- Adds `cmd/example/acl` driving the family end-to-end over the binary protocol; updates README and ROADMAP.

**Component:** RBAC / ACL (RESP + binary protocol + client)

**Type of Change:**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance optimization (no change in behavior, improved speed/memory)
- [ ] Refactoring (no functional changes, code cleanup)
- [ ] Build / CI / Documentation

---

## Related Issue

Closes #9

---

## Technical Deep Dive & Context

**Policy store as the single source of truth.** ACL mutations go through the existing `rbac.Store` helpers (`SetUser` / `DelUser`), which validate against the active snapshot, clone it, and republish with one atomic swap under `Store.mu` — the published policy is never mutated in place. `SetUser` rejects an unknown role fail-closed, so a user can never reference a dangling role. Sessions pin the `*Role` value they authenticated with, so a hot-swap only affects future connections.

**ACL LOG circular buffer** (`internal/rbac/log.go`). A mutex-protected ring buffer (capacity `DefaultAuthLogCap = 100`, matching Redis's default) living on the `Store`, so it survives policy `Reload` hot-swaps and is shared by RESP and binary. `LogAuthFailure` bumps the store-wide atomic auth-failure counter and records `(timestamp, username, remote_addr, reason)`; `AuthLog()` returns a chronological copy. It runs only on the failed-AUTH path — never on the request hot path.

**Binary protocol.** Four new opcodes appended after the existing set (stable values), with typed codecs in `internal/network/acl.go` reusing the ROLE length-prefixed-token primitive (`EncodeRoleArgs` / `DecodeRoleArgs`), all lengths big-endian uint16 capped at 64 KiB. Admin ops allocate freely — they never touch the KV hot path. `opAuthorized` gates the ACL ops on the `rbac.CmdACL` command bit (keyless, mirroring ROLE), so a role granted only `+role` cannot manage ACL users and vice versa.

**Auth-failure threading.** Both protocols route rejected AUTH through `Store.LogAuthFailure`. The binary path records username+reason from the bcrypt worker pool, using a fixed dummy hash for unknown users so AUTH latency does not leak which usernames exist. The RESP path threads username+reason through `authFailed`. Both write one buffer; `ACL LOG` renders it identically over both protocols.

**Client surface.** `internal/network` (raw) and the public `client` package each expose `AclSetUser` / `AclDelUser` / `AclList` / `AclLog`, mirroring the existing `Role*` methods.

**Trade-offs considered.**
- `ACL LIST` returns flat 5-field arrays (name, role, has-pass, commands, namespaces) rather than Redis's `user ... on ...` grammar — we do not implement the Redis ACL string parser, so redis-cli prints the entries as raw arrays. This is documented.
- `ACL LOG` records auth failures only, not per-command denials — the per-command audit trail is scoped to issue #11.
- The ring buffer is deliberately in-memory; durable persistence is deferred to issue #11 (audit logging).

---

## Performance & Benchmarks (If Applicable)

**No benchmarks were run.** Per repo policy I did not invent before/after numbers. The request hot path (GET/SET/DEL dispatch and encoding) is untouched; the additions — ACL dispatch branches, two opcode cases in `opAuthorized`, and auth-failure logging — execute only on admin commands and the failed-AUTH path, never on successful data requests. The AUTH path itself allocates once per connection (username string + session), which is off the hot path.

**Workload:** n/a

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| Throughput | — | — | no measurable change expected (not measured) |
| p50 latency | — | — | — |
| p99 latency | — | — | — |

---

## How Has This Been Tested?

- `go build ./...` — passes
- `go vet ./...` — passes, no new warnings
- `go test -race ./...` — full suite passes (incl. new tests in `internal/rbac`, `internal/resp`, `internal/network`)
- `gofmt` — clean on all touched files
- **New tests:** ACL LOG order/eviction/empty/concurrent (`internal/rbac/log_test.go`); RESP ACL SETUSER/DELUSER/LIST/LOG reply shapes and NOPERM gating (`internal/resp/acl_test.go`); binary codec round-trips + malformed/overflow payloads, auth gating, authorization denial, wire ACL LOG, and client methods (`internal/network/acl_test.go`).
- **Manual, live:** started `tellstone --enable-resp --rbac-config cmd/example/acl/policy.yaml` and verified over redis-cli (RESP) — unauthenticated `NOAUTH`, `AUTH admin` OK, `ACL SETUSER/DELUSER/LIST` with fail-closed unknown-role rejection, readonly user granted GET but denied SET with `NOPERM`, and `ACL LOG` showing `invalid password` / `unknown user` entries — and over the binary protocol via `cmd/example/acl`, which observed the same ACL LOG entries that redis-cli had produced, confirming both protocols share one buffer.

---

## Checklist

- [x] My code follows the existing code style of this project
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally (`go test ./...` and `go test -race ./...`)
- [x] I have updated the documentation (README, comments, or any relevant docs)
- [x] My changes generate no new `go vet` warnings
- [x] Any breaking changes are documented and communicated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Redis-compatible ACL commands: `SETUSER`, `DELUSER`, `LIST`, and `LOG`.
  * Added client and binary-protocol support for managing ACL users and viewing user details and authentication logs.
  * Authentication failures now include timestamps, usernames, connection details, and failure reasons.
  * ACL operations are protected by role-based permissions, with validation for users, roles, and passwords.
* **Documentation**
  * Added an end-to-end ACL example with administrator and read-only roles.
  * Updated authentication, authorization, and roadmap documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->