### PR TITLE
Feat/audit log

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -79,6 +79,7 @@ Tellstone is a shared-nothing, in-memory key/value store with two protocol front
 | `crypto` | `internal/crypto/` | ChaCha20-Poly1305 encryption. `EncryptInPlace` / `DecryptInPlace`. Pass-through mode when disabled (zero overhead). |
 | `tls` | `internal/tls/` | TLS 1.3/mTLS transport, gnet connection adapter, and automatic certificate/key/CA rotation through a shared atomic config store. |
 | `metrics` | `internal/metrics/` | Prometheus exporter. Per-shard `Collector` + `AggregateCollector` (includes Go runtime stats). Hand-written exposition text. |
+| `audit` | `internal/audit/` | Structured audit logging. Event-type filter (`--audit-events`), JSON engine emitting `"level":"AUDIT"` lines, rotating and optionally encrypted file writer. |
 | `trace` | `internal/trace/` | OpenTelemetry wrapper. `Tracer`/`Span` interfaces with `NoOpTracer` (zero-alloc) and `OTelTracer` (OTLP/gRPC). |
 | `version` | `internal/version/` | Build-time version/commit/date via `-ldflags`. |
 
@@ -151,6 +152,7 @@ Every optional feature is disabled by default and has zero overhead when off:
 | Metrics | `--enable-metrics` | off |
 | Persistence | `--enable-persistence` | off |
 | Tracing | `--trace-ratio 0` | off |
+| Audit logging | `--enable-audit` | off |
 
 ### Role-Based Access Control (RBAC)
 
@@ -193,9 +195,38 @@ client sees exactly which permission it lacks. Passwords are bcrypt hashes verif
 `bcrypt.CompareHashAndPassword` (constant-time by construction); hashes are never rendered by
 `ROLE LIST` / `ROLE GETUSER`.
 
-**Integration seams.** `SessionContext` already carries `RoleName` and `Username` for audit
-logging. Planned integrations: API keys intersect role permissions (most restrictive wins), and
-OIDC `groups` claims map to roles through the policy store.
+**Integration seams.** `SessionContext` carries `RoleName` and `Username`, consumed by the audit
+engine for `auth_success`, `auth_failure`, and `acl_deny` events (see Audit Logging). Planned
+integrations: API keys intersect role permissions (most restrictive wins), and OIDC `groups`
+claims map to roles through the policy store.
+
+### Audit Logging
+
+Opt-in via `--enable-audit` / `TSD_ENABLE_AUDIT`. One shared `audit.LogEngine` is built in
+`server` and passed to both the binary and RESP listeners. It is **always non-nil**: without the
+flag it is a disabled no-op whose `Record()` returns on a single bool comparison — no writer, no
+encoder, no allocation — so the listeners call it unconditionally with no `nil` guard on the
+dispatch path.
+
+**Event types.** `connect`, `disconnect`, `auth_success`, `auth_failure`, `acl_deny`, and
+`command`. The filter is parsed once at startup from `--audit-events` (default `auth,acl`;
+`all` enables every event) and consulted per `Record()`. The `command` event is the only one with
+per-command dispatch overhead and is off by default. Each line is one JSON object with
+`"level":"AUDIT"`, distinguishing it from operational INFO/WARN/ERROR logs.
+
+**Concurrency.** `Record()` and `Close()` are serialized by a mutex, so a gnet event loop never
+races file rotation or shutdown. `Close()` runs at the end of `server.shutdown()`, only after both
+listeners are stopped, so no in-flight write can race the file close.
+
+**Zero-copy keys.** Command and key strings alias the gnet buffer via the same `unsafe`
+slice-header pattern used on the dispatch paths, consumed synchronously by the encoder before the
+frame is discarded — no allocation is added to the audit path.
+
+**File writer.** `--audit-log-path` selects `stdout` or a directory. File names are generated
+(`<unix-nanoseconds>_<8-hex-dir-hash>_tsd.log`), created `0600`, and rotated at 50 MiB by closing
+and reopening a fresh file in the same directory — rotation never truncates or renames history.
+When `--enable-encryption` is set, every record is sealed with the crypto engine before it is
+flushed. A failed file open falls back to stdout with an error log.
 
 ### Event-Driven Networking
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ workloads. Tellstone offers a **lean, modern, memory‑efficient buffer** that:
   O(1); lazy eviction on read backs it up.
 * **Optional At‑Rest Encryption** – ChaCha20‑Poly1305, off by default.
 * **Write-Ahead Log Persistence** – Per-shard append-only WAL for crash recovery. SET and DEL operations are persisted (deletes as tombstones) and replayed on restart. Zero-allocation on the hot path (`Write` = 0 allocs/op). Disabled by default.
-* **Metrics & Tracing** – Built‑in Prometheus exporter and optional OpenTelemetry tracing.
+* **Metrics, Tracing & Audit Logging** – Built‑in Prometheus exporter, optional OpenTelemetry tracing, and an opt-in structured audit trail for security events.
 
 ### Core Architecture
 
@@ -55,6 +55,7 @@ see [ARCHITECTURE.md](ARCHITECTURE.md).
 | Storage engine | `internal/storage` | Single‑map engine, TTL eviction via timing wheel |
 | Persistence | `internal/persistence` | Per‑shard append‑only WAL, zero‑alloc write path |
 | Crypto | `internal/crypto` | Optional ChaCha20‑Poly1305 |
+| Audit | `internal/audit` | Structured JSON security events (`connect`, `auth_*`, `acl_deny`, `command`); rotating file writer, optional encryption |
 | Metrics / tracing | `internal/metrics`, `internal/trace` | Prometheus text exporter, OTLP/gRPC tracing |
 
 ---
@@ -148,6 +149,9 @@ Every option is available as a flag and an environment variable.
 | `--tls-ca`            | `TSD_TLS_CA`             | _(none)_         | Client CA path for mTLS; watched for automatic rotation  |
 | `--require-pass`      | `TSD_REQUIRE_PASS`       | _(none)_         | Single password required via `AUTH`; empty disables it   |
 | `--rbac-config`       | `TSD_RBAC_CONFIG`        | _(none)_         | YAML/JSON RBAC policy file (roles, users, default role); hot-reloaded on SIGHUP |
+| `--enable-audit`      | `TSD_ENABLE_AUDIT`       | `false`          | Enable structured audit logging                          |
+| `--audit-log-path`    | `TSD_AUDIT_LOG_PATH`     | `stdout`         | Audit destination: a directory (rotated `0600` files) or `stdout` |
+| `--audit-events`      | `TSD_AUDIT_EVENTS`       | `auth,acl`       | Comma-separated event types: `auth`, `acl`, `connect`, `disconnect`, `command`, or `all` |
 | `--shutdown-timeout`  | `TSD_SHUTDOWN_TIMEOUT`  | `10s`            | Max wait for graceful shutdown on SIGINT/SIGTERM         |
 
 Runtime tuning (environment only): `TSD_GC_PERCENT` (default `-1`, GC off for a zero‑GC hot
@@ -247,6 +251,37 @@ Unauthenticated data commands return `-NOAUTH`; commands a user's role does not 
 `RoleSetUser` (see `cmd/example/role`). The `ACL` command family (`ACL SETUSER` / `ACL DELUSER` /
 `ACL LIST` / `ACL LOG`) manages the same policy store through a Redis-flavored alias, driven
 end-to-end in `cmd/example/acl`.
+
+### Audit logging
+
+Opt-in structured audit trail via `--enable-audit`. Every security-relevant operation is written
+as one JSON line carrying `"level": "AUDIT"`, so log aggregators can separate it from operational
+INFO/WARN/ERROR output without custom parsing:
+
+```bash
+./bin/tellstone --enable-audit --audit-log-path /var/log/tellstone --audit-events all
+```
+
+`--audit-log-path` is `stdout` (the default) or a directory. In directory mode the server creates
+rotating files named `<unix-timestamp>_<dir-fingerprint>_tsd.log` with `0600` permissions,
+rotating to a fresh file once a file reaches 50 MiB (history is never truncated or renamed). When
+`--enable-encryption` is set, every record is sealed with the crypto engine before it is flushed.
+The engine is a no-op when audit logging is disabled, so the hot path pays nothing.
+
+`--audit-events` selects which event types are logged (default `auth,acl`; `all` enables every
+type). `connect`, `disconnect`, and `command` are high-volume and must be opted into explicitly:
+
+| Event | Fires on | Fields |
+|-------|----------|--------|
+| `connect` / `disconnect` | TCP connection open/close, both protocols | `remote_addr`, `protocol`, `shard_id` |
+| `auth_success` | successful `AUTH` | `user`, `remote_addr`, `protocol` |
+| `auth_failure` | rejected `AUTH` (bad password, unknown user, malformed request) | `user`, `reason`, `remote_addr`, `protocol` |
+| `acl_deny` | command blocked by RBAC (`-NOPERM`) | `user`, `command`, `key`, `remote_addr`, `protocol` |
+| `command` | every dispatched data/admin command | `command`, `key`, `user`, `remote_addr`, `protocol` |
+
+```json
+{"event":"acl_deny","level":"AUDIT","msg":"command denied by rbac policy","protocol":"binary","remote_addr":"127.0.0.1:51642","command":"SET","key":"config:key","user":"reader","time":"2026-08-05T10:40:32.908569649+02:00"}
+```
 
 ### Native binary protocol (Go client)
 
@@ -440,6 +475,8 @@ Run them locally with `task bench:native` or `task bench:resp:precise`.
 ### Observability
 * **Metrics:** `task run:resp` with `--enable-metrics` exposes Prometheus text at
   `http://<metrics-addr>/metrics` (default `:9100`).
+* **Audit logging:** `--enable-audit` writes structured security events (see
+  [Audit logging](#audit-logging)); run with `--audit-events all` to capture every event type.
 
 ### Profiling
 

--- a/README.md
+++ b/README.md
@@ -46,17 +46,17 @@ workloads. Tellstone offers a **lean, modern, memory‑efficient buffer** that:
 For a detailed description of the package structure, request flow, and design decisions,
 see [ARCHITECTURE.md](ARCHITECTURE.md).
 
-| Layer | Package | Notes |
-|---|---|---|
-| Binary protocol | `internal/network` | `MsgRequest`/`MsgResponse` frames (`GET`/`SET`/`DEL`, TTL, key, value) |
-| RESP2 protocol | `internal/resp` | Redis‑compatible listener reusing the same engine |
-| Request router | `internal/router` | FNV‑1a hash → O(1) shard dispatch |
-| Shard runner | `internal/shard` | Shared‑nothing shard: synchronous `Execute()`, per‑shard `sync.RWMutex` |
-| Storage engine | `internal/storage` | Single‑map engine, TTL eviction via timing wheel |
-| Persistence | `internal/persistence` | Per‑shard append‑only WAL, zero‑alloc write path |
-| Crypto | `internal/crypto` | Optional ChaCha20‑Poly1305 |
-| Audit | `internal/audit` | Structured JSON security events (`connect`, `auth_*`, `acl_deny`, `command`); rotating file writer, optional encryption |
-| Metrics / tracing | `internal/metrics`, `internal/trace` | Prometheus text exporter, OTLP/gRPC tracing |
+| Layer | Package | Notes                                                                                                                                 |
+|---|---|---------------------------------------------------------------------------------------------------------------------------------------|
+| Binary protocol | `internal/network` | `MsgRequest`/`MsgResponse` frames (`GET`/`SET`/`DEL`, TTL, key, value)                                                                |
+| RESP2 protocol | `internal/resp` | Redis‑compatible listener reusing the same engine                                                                                     |
+| Request router | `internal/router` | FNV‑1a hash → O(1) shard dispatch                                                                                                     |
+| Shard runner | `internal/shard` | Shared‑nothing shard: synchronous `Execute()`, per‑shard `sync.RWMutex`                                                               |
+| Storage engine | `internal/storage` | Single‑map engine, TTL eviction via timing wheel                                                                                      |
+| Persistence | `internal/persistence` | Per‑shard append‑only WAL, zero‑alloc write path                                                                                      |
+| Crypto | `internal/crypto` | Optional ChaCha20‑Poly1305                                                                                                            |
+| Audit | `internal/audit` | Structured JSON security events (`connect`, `disconnect`, `auth_*`, `acl_deny`, `command`); rotating file writer, optional encryption |
+| Metrics / tracing | `internal/metrics`, `internal/trace` | Prometheus text exporter, OTLP/gRPC tracing                                                                                           |
 
 ---
 
@@ -254,7 +254,7 @@ end-to-end in `cmd/example/acl`.
 
 ### Audit logging
 
-Opt-in structured audit trail via `--enable-audit`. Every security-relevant operation is written
+Opt-in structured audit trail via `--enable-audit`. Each selected audit event is written
 as one JSON line carrying `"level": "AUDIT"`, so log aggregators can separate it from operational
 INFO/WARN/ERROR output without custom parsing:
 

--- a/cmd/tellstone/main.go
+++ b/cmd/tellstone/main.go
@@ -35,7 +35,7 @@ func initProfiling() {
 	}
 }
 
-func initRuntimeSettings() {
+func initRuntimeSettings(l logger.Logger) {
 	// TSD_GC_PERCENT configures the garbage collection trigger percentage.
 	// Setting this to -1 disables the default percentage-based GC entirely.
 	// This creates a "Zero-GC Hot-Path" where execution is never interrupted
@@ -68,6 +68,12 @@ func initRuntimeSettings() {
 		}
 	}
 	debug.SetMemoryLimit(memLimit)
+	if l.Enabled(logger.LevelInfo) {
+		l.Log(logger.LevelInfo, "runtime settings applied",
+			logger.Int("gc_percent", gcPercent),
+			logger.Int64("memory_limit_bytes", memLimit),
+		)
+	}
 }
 
 func main() {
@@ -77,11 +83,11 @@ func main() {
 			return
 		}
 	}
-	initRuntimeSettings()
-	initProfiling()
 	cfg := config.LoadConfig(os.Args[1:])
 	app := new(tellstone.App)
 	logpkg := logger.NewSlogLogger(cfg.GetLogLevel())
+	initRuntimeSettings(logpkg)
+	initProfiling()
 	app.Start(cfg, logpkg)
 	svr := server.NewServer(app)
 	if err := svr.Run(); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"runtime"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Saxy/Tellstone/internal/log"
@@ -44,6 +45,9 @@ type Config struct {
 	tlsCA             string
 	requirePass       string
 	rbacConfig        string
+	enableAuditLog    bool
+	auditLogPath      string
+	auditLogEvents    string
 }
 
 func getEnv[T any](key string, fallback T) T {
@@ -121,7 +125,10 @@ func getEnv[T any](key string, fallback T) T {
 //		TSD_TLS_KEY          – path to TLS private key file (PEM)
 //		TSD_TLS_CA           – path to CA certificate for client verification (enables mTLS)
 //		TSD_REQUIRE_PASS     – server password required by AUTH (empty = no authentication)
-//		TSD_RBAC_CONFIG     – path to a YAML/JSON RBAC policy file (roles, users, default_role)
+//		TSD_RBAC_CONFIG      – path to a YAML/JSON RBAC policy file (roles, users, default_role)
+//		TSD_ENABLE_AUDIT	 - boolean to enable audit logging (default: false)
+// 		TSD_AUDIT_LOG_PATH	 - path where the audit log file(s) will be created (default: stdout)
+//		TSD_AUDIT_EVENTS	 - comma-seperated event types on which audit events should be logged (default: auth,acl)
 //
 // args are the command-line arguments to parse (typically os.Args[1:]); pass nil for an
 // environment-only / default configuration. A fresh flag.FlagSet is used so LoadConfig is
@@ -216,7 +223,7 @@ func LoadConfig(args []string) *Config {
 		"max-mem-bytes",
 		"Total engine memory ceiling (e.g. 512MiB, 4GiB, 0 = unlimited)",
 	)
-	// Optional RESP2 (Redis-compatible) listener, for benchmarking against Redis/Dragonfly/etc.
+	// Optional RESP2 (Redis-compatible) listener for benchmarking against Redis/Dragonfly/etc.
 	fs.BoolVar(
 		&cfg.enableRESP,
 		"enable-resp",
@@ -298,6 +305,24 @@ func LoadConfig(args []string) *Config {
 		getEnv("TSD_RBAC_CONFIG", ""),
 		"Path to YAML/JSON RBAC policy file (roles, users, default_role); empty disables RBAC (default: none)",
 	)
+	fs.BoolVar(
+		&cfg.enableAuditLog,
+		"enable-audit",
+		getEnv("TSD_ENABLE_AUDIT", false),
+		"Enable Audit logging (default: false)",
+	)
+	fs.StringVar(
+		&cfg.auditLogPath,
+		"audit-log-path",
+		getEnv("TSD_AUDIT_LOG_PATH", "stdout"),
+		"Path where Audit logging files should be created (default: stdout)",
+	)
+	fs.StringVar(
+		&cfg.auditLogEvents,
+		"audit-events",
+		getEnv("TSD_AUDIT_EVENTS", "auth,acl"),
+		"Comma-separated event types which should be logged, possible events: auth, acl, connect, disconnect, command, all for all event logging (default: auth,acl)",
+	)
 	// Custom usage output to guide operators.
 	fs.Usage = func() {
 		println("Tellstone server – high-performance in-memory database")
@@ -353,6 +378,7 @@ func (cfg *Config) GetTLSKey() string                 { return cfg.tlsKey }
 func (cfg *Config) GetTLSCA() string                  { return cfg.tlsCA }
 func (cfg *Config) GetRequirePass() string            { return cfg.requirePass }
 func (cfg *Config) GetRBACConfig() string             { return cfg.rbacConfig }
-func (cfg *Config) MTLSEnabled() bool {
-	return cfg.tlsCert != "" && cfg.tlsKey != "" && cfg.tlsCA != ""
-}
+func (cfg *Config) MTLSEnabled() bool                 { return cfg.tlsCert != "" && cfg.tlsKey != "" && cfg.tlsCA != "" }
+func (cfg *Config) AuditEnabled() bool                { return cfg.enableAuditLog }
+func (cfg *Config) AuditLogPath() string              { return cfg.auditLogPath }
+func (cfg *Config) AuditLogEvents() []string          { return strings.Split(cfg.auditLogEvents, ",") }

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -50,7 +50,7 @@ const (
 )
 
 // allEvents is the complete set of recognized event types. Used by
-// parseEventTypes to validate user input and by the default set builder.
+// ParseEventTypes to validate user input and by the default set builder.
 var allEvents = [6]EventType{
 	EventConnect,
 	EventDisconnect,
@@ -89,11 +89,11 @@ func (s *eventSet) has(eventType EventType) bool {
 	return false
 }
 
-// parseEventTypes builds an eventSet from a comma-separated flag value
+// ParseEventTypes builds an eventSet from a comma-separated flag value
 // (e.g. "auth_success,auth_failure,acl_deny" or "auth,acl,command").
 // Unrecognized tokens are silently ignored, so the flag stays forward-compatible.
 // An empty string yields a set containing only defaultEventTypes.
-func parseEventTypes(raw string) *eventSet {
+func ParseEventTypes(raw string) *eventSet {
 	s := &eventSet{}
 	tokens := strings.Split(raw, ",")
 	if len(tokens) == 1 && tokens[0] == "" {

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -1,0 +1,144 @@
+/*
+Package audit
+Tellstone Cloud-Native In-Memory Database
+File: audit.go
+Description: Audit event type definitions and the per-event filter used by the audit
+engine. Every security-relevant operation maps to exactly one EventType. The filter set
+is parsed once from the --audit-events flag at startup and consulted per Record() call;
+when the engine is nil (audit disabled), no filtering or allocation occurs.
+
+Authors:
+
+	Maximilian Hagen
+*/
+package audit
+
+import "strings"
+
+// EventType identifies a class of security-relevant operations that the audit
+// engine may record. Each constant maps 1:1 to a string emitted in the JSON
+// output and accepted by the --audit-events flag.
+type EventType string
+
+const (
+	// EventConnect fires when a new TCP connection is accepted by either
+	// the binary or RESP listener. Fields: remote_addr, protocol, shard_id.
+	EventConnect EventType = "connect"
+
+	// EventDisconnect fires when a connection is closed. Fields: remote_addr,
+	// duration, bytes_read, bytes_written.
+	EventDisconnect EventType = "disconnect"
+
+	// EventAuthSuccess fires on a successful AUTH handshake. Fields: user,
+	// remote_addr, protocol.
+	EventAuthSuccess EventType = "auth_success"
+
+	// EventAuthFailure fires on a failed AUTH attempt — wrong password,
+	// unknown user, or missing credentials. Fields: user, remote_addr,
+	// reason.
+	EventAuthFailure EventType = "auth_failure"
+
+	// EventACLDeny fires when RBAC rejects a command (NOPERM). Fields: user,
+	// command, key, remote_addr.
+	EventACLDeny EventType = "acl_deny"
+
+	// EventCommand fires for every dispatched data and admin command
+	// (GET, SET, DEL, PING, ROLE, ACL, FLUSH, …). Fields: command, key,
+	// user, remote_addr, and for GET: result (hit/miss). Enabling this
+	// event type adds per-command overhead on the dispatch path.
+	EventCommand EventType = "command"
+)
+
+// allEvents is the complete set of recognized event types. Used by
+// parseEventTypes to validate user input and by the default set builder.
+var allEvents = [6]EventType{
+	EventConnect,
+	EventDisconnect,
+	EventAuthSuccess,
+	EventAuthFailure,
+	EventACLDeny,
+	EventCommand,
+}
+
+// defaultEventTypes is the event filter applied when --audit-events is not
+// set. It includes the security-relevant events that compliance frameworks
+// require (auth + acl) without the high-volume connect/disconnect and
+// command events that operators opt into explicitly.
+var defaultEventTypes = []EventType{EventAuthSuccess, EventAuthFailure, EventACLDeny}
+
+// eventSet is a compact lookup structure for the per-event filter. A nil
+// *eventSet means "log nothing" (audit disabled). An empty non-nil set
+// means "log everything" (future extension; currently unused).
+type eventSet struct {
+	events [len(allEvents)]bool
+	count  int
+}
+
+// has reports whether eventType is in the set. The nil receiver is a
+// deliberate no-op: callers on the hot path check e == nil before calling,
+// so this method is only reached when audit is enabled.
+func (s *eventSet) has(eventType EventType) bool {
+	if s == nil {
+		return false
+	}
+	for i, t := range allEvents {
+		if t == eventType {
+			return s.events[i]
+		}
+	}
+	return false
+}
+
+// parseEventTypes builds an eventSet from a comma-separated flag value
+// (e.g. "auth_success,auth_failure,acl_deny" or "auth,acl,command").
+// Unrecognized tokens are silently ignored, so the flag stays forward-compatible.
+// An empty string yields a set containing only defaultEventTypes.
+func parseEventTypes(raw string) *eventSet {
+	s := &eventSet{}
+	tokens := strings.Split(raw, ",")
+	if len(tokens) == 1 && tokens[0] == "" {
+		// Empty flag value — apply defaults.
+		for _, t := range defaultEventTypes {
+			s.enable(t)
+		}
+		return s
+	}
+	for _, token := range tokens {
+		token = strings.TrimSpace(token)
+		switch token {
+		case "auth":
+			s.enable(EventAuthSuccess)
+			s.enable(EventAuthFailure)
+		case "acl":
+			s.enable(EventACLDeny)
+		case "connect":
+			s.enable(EventConnect)
+		case "disconnect":
+			s.enable(EventDisconnect)
+		case "command":
+			s.enable(EventCommand)
+		case "all":
+			for _, t := range allEvents {
+				s.enable(t)
+			}
+		default:
+			for _, t := range allEvents {
+				if token == string(t) {
+					s.enable(t)
+					break
+				}
+			}
+		}
+	}
+	return s
+}
+
+func (s *eventSet) enable(t EventType) {
+	for i, et := range allEvents {
+		if et == t && !s.events[i] {
+			s.events[i] = true
+			s.count++
+			return
+		}
+	}
+}

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -95,6 +95,10 @@ func (s *eventSet) has(eventType EventType) bool {
 // An empty string yields a set containing only defaultEventTypes.
 func ParseEventTypes(raw string) *eventSet {
 	s := &eventSet{}
+	// Trim before the emptiness check so a whitespace-only value (e.g.
+	// --audit-events "  ") applies the defaults instead of silently yielding
+	// a filter that disables every event.
+	raw = strings.TrimSpace(raw)
 	tokens := strings.Split(raw, ",")
 	if len(tokens) == 1 && tokens[0] == "" {
 		// Empty flag value — apply defaults.

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -1,0 +1,205 @@
+/*
+Package audit
+Tellstone Cloud-Native In-Memory Database
+File: audit_test.go
+Description: Verifies EventType definitions, eventSet filtering, parseEventTypes
+semantics, and the LogEngine record/close lifecycle.
+
+Authors:
+
+	Maximilian Hagen
+*/
+package audit
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Saxy/Tellstone/internal/log"
+)
+
+func TestEventSetNilReceiver(t *testing.T) {
+	var s *eventSet
+	if s.has(EventAuthSuccess) {
+		t.Fatal("nil eventSet.Has should return false")
+	}
+}
+
+func TestParseEventTypesEmpty(t *testing.T) {
+	s := parseEventTypes("")
+	if !s.has(EventAuthSuccess) || !s.has(EventAuthFailure) || !s.has(EventACLDeny) {
+		t.Fatal("empty flag should yield default event set (auth_success, auth_failure, acl_deny)")
+	}
+	if s.has(EventConnect) || s.has(EventDisconnect) || s.has(EventCommand) {
+		t.Fatal("empty flag should not include connect, disconnect, or command")
+	}
+}
+
+func TestParseEventTypesAuthShorthand(t *testing.T) {
+	s := parseEventTypes("auth")
+	if !s.has(EventAuthSuccess) || !s.has(EventAuthFailure) {
+		t.Fatal("'auth' shorthand should enable both auth_success and auth_failure")
+	}
+	if s.has(EventACLDeny) {
+		t.Fatal("'auth' shorthand should not enable acl_deny")
+	}
+}
+
+func TestParseEventTypesACLShorthand(t *testing.T) {
+	s := parseEventTypes("acl")
+	if !s.has(EventACLDeny) {
+		t.Fatal("'acl' shorthand should enable acl_deny")
+	}
+	if s.has(EventAuthSuccess) {
+		t.Fatal("'acl' shorthand should not enable auth_success")
+	}
+}
+
+func TestParseEventTypesAll(t *testing.T) {
+	s := parseEventTypes("all")
+	for _, et := range allEvents {
+		if !s.has(et) {
+			t.Fatalf("'all' should enable every event type, missing %s", et)
+		}
+	}
+}
+
+func TestParseEventTypesExactTokens(t *testing.T) {
+	s := parseEventTypes("auth_success,auth_failure,acl_deny,connect,disconnect,command")
+	for _, et := range allEvents {
+		if !s.has(et) {
+			t.Fatalf("explicit token list should enable %s", et)
+		}
+	}
+}
+
+func TestParseEventTypesUnknownIgnored(t *testing.T) {
+	s := parseEventTypes("auth_success,bogus,acl_deny")
+	if !s.has(EventAuthSuccess) || !s.has(EventACLDeny) {
+		t.Fatal("known tokens should still be enabled when unknowns are present")
+	}
+	if s.has(EventAuthFailure) {
+		t.Fatal("auth_failure should not be enabled when not explicitly listed")
+	}
+}
+
+func TestParseEventTypesWhitespace(t *testing.T) {
+	s := parseEventTypes(" auth_success , acl_deny ")
+	if !s.has(EventAuthSuccess) || !s.has(EventACLDeny) {
+		t.Fatal("whitespace around tokens should be trimmed")
+	}
+}
+
+func TestEventTypesAreDistinct(t *testing.T) {
+	seen := make(map[EventType]bool, len(allEvents))
+	for _, et := range allEvents {
+		if seen[et] {
+			t.Fatalf("duplicate event type constant: %s", et)
+		}
+		seen[et] = true
+	}
+}
+
+func TestDefaultEventTypesExist(t *testing.T) {
+	for _, et := range defaultEventTypes {
+		found := false
+		for _, a := range allEvents {
+			if a == et {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("DefaultEventTypes contains %s which is not in allEvents", et)
+		}
+	}
+}
+
+// --- Engine tests ---
+
+func TestDisabledEngineNoop(t *testing.T) {
+	var buf bytes.Buffer
+	filter := parseEventTypes("all")
+	e := NewLogEngine(false, filter, &buf)
+	e.Record(EventAuthSuccess, "should not appear")
+	if buf.Len() != 0 {
+		t.Fatalf("disabled engine produced output: %s", buf.String())
+	}
+	if err := e.Close(); err != nil {
+		t.Fatal("disabled engine Close should return nil")
+	}
+}
+
+func TestRecordWritesJSON(t *testing.T) {
+	var buf bytes.Buffer
+	filter := parseEventTypes("auth_success")
+	e := NewLogEngine(true, filter, &buf)
+
+	e.Record(EventAuthSuccess, "user logged in",
+		log.String("user", "alice"),
+		log.String("remote_addr", "10.0.0.1:54321"),
+		log.String("protocol", "resp"),
+	)
+
+	line := strings.TrimSpace(buf.String())
+	if line == "" {
+		t.Fatal("expected JSON output, got empty")
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(line), &m); err != nil {
+		t.Fatalf("invalid JSON: %v\nraw: %s", err, line)
+	}
+	if m["level"] != "AUDIT" {
+		t.Fatalf("level = %v, want AUDIT", m["level"])
+	}
+	if m["event"] != "auth_success" {
+		t.Fatalf("event = %v, want auth_success", m["event"])
+	}
+	if m["user"] != "alice" {
+		t.Fatalf("user = %v, want alice", m["user"])
+	}
+	if m["remote_addr"] != "10.0.0.1:54321" {
+		t.Fatalf("remote_addr = %v", m["remote_addr"])
+	}
+	if m["time"] == nil || m["time"] == "" {
+		t.Fatal("time field missing or empty")
+	}
+}
+
+func TestRecordFiltersOutDisabledEvents(t *testing.T) {
+	var buf bytes.Buffer
+	filter := parseEventTypes("auth_success")
+	e := NewLogEngine(true, filter, &buf)
+
+	e.Record(EventACLDeny, "should be filtered")
+	if buf.Len() != 0 {
+		t.Fatalf("filtered event produced output: %s", buf.String())
+	}
+}
+
+func TestRecordMultipleEvents(t *testing.T) {
+	var buf bytes.Buffer
+	filter := parseEventTypes("auth_success,acl_deny")
+	e := NewLogEngine(true, filter, &buf)
+
+	e.Record(EventAuthSuccess, "login", log.String("user", "alice"))
+	e.Record(EventACLDeny, "denied", log.String("user", "bob"))
+	e.Record(EventConnect, "should be filtered")
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d: %s", len(lines), buf.String())
+	}
+}
+
+func TestCloseWithCloser(t *testing.T) {
+	filter := parseEventTypes("all")
+	var buf bytes.Buffer
+	e := NewLogEngine(true, filter, &buf)
+	if err := e.Close(); err != nil {
+		t.Fatalf("Close on bytes.Buffer should not error: %v", err)
+	}
+}

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -12,11 +12,13 @@ Authors:
 package audit
 
 import (
-	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/Saxy/Tellstone/internal/crypto"
 	"github.com/Saxy/Tellstone/internal/log"
 )
 
@@ -119,23 +121,45 @@ func TestDefaultEventTypesExist(t *testing.T) {
 
 // --- Engine tests ---
 
-func TestDisabledEngineNoop(t *testing.T) {
-	var buf bytes.Buffer
-	filter := parseEventTypes("all")
-	e := NewLogEngine(false, filter, &buf)
-	e.Record(EventAuthSuccess, "should not appear")
-	if buf.Len() != 0 {
-		t.Fatalf("disabled engine produced output: %s", buf.String())
+// newTestEngine wires a disabled-crypto engine and a no-op logger, mirroring
+// how the server constructs an audit engine without encryption enabled.
+func newTestEngine(t *testing.T, enabled bool, filter *eventSet, dir string) *LogEngine {
+	t.Helper()
+	return NewLogEngine(enabled, filter, dir, log.NewNoOpLogger(), crypto.Engine{})
+}
+
+// readAuditFiles returns the contents of every *_tsd.log file in dir.
+func readAuditFiles(t *testing.T, dir string) []string {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, "*_tsd.log"))
+	if err != nil {
+		t.Fatal("Glob:", err)
 	}
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		var data []byte
+		data, err = os.ReadFile(m)
+		if err != nil {
+			t.Fatal("ReadFile:", err)
+		}
+		out = append(out, string(data))
+	}
+	return out
+}
+
+func TestDisabledEngineNoop(t *testing.T) {
+	filter := parseEventTypes("all")
+	e := newTestEngine(t, false, filter, "stdout")
+	e.Record(EventAuthSuccess, "should not appear")
 	if err := e.Close(); err != nil {
 		t.Fatal("disabled engine Close should return nil")
 	}
 }
 
 func TestRecordWritesJSON(t *testing.T) {
-	var buf bytes.Buffer
+	dir := t.TempDir()
 	filter := parseEventTypes("auth_success")
-	e := NewLogEngine(true, filter, &buf)
+	e := newTestEngine(t, true, filter, dir)
 
 	e.Record(EventAuthSuccess, "user logged in",
 		log.String("user", "alice"),
@@ -143,7 +167,15 @@ func TestRecordWritesJSON(t *testing.T) {
 		log.String("protocol", "resp"),
 	)
 
-	line := strings.TrimSpace(buf.String())
+	if err := e.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	files := readAuditFiles(t, dir)
+	if len(files) != 1 {
+		t.Fatalf("expected one audit file, got %d", len(files))
+	}
+
+	line := strings.TrimSpace(files[0])
 	if line == "" {
 		t.Fatal("expected JSON output, got empty")
 	}
@@ -170,36 +202,46 @@ func TestRecordWritesJSON(t *testing.T) {
 }
 
 func TestRecordFiltersOutDisabledEvents(t *testing.T) {
-	var buf bytes.Buffer
+	dir := t.TempDir()
 	filter := parseEventTypes("auth_success")
-	e := NewLogEngine(true, filter, &buf)
+	e := newTestEngine(t, true, filter, dir)
 
 	e.Record(EventACLDeny, "should be filtered")
-	if buf.Len() != 0 {
-		t.Fatalf("filtered event produced output: %s", buf.String())
+	if err := e.Close(); err != nil {
+		t.Fatal("Close:", err)
+	}
+	files := readAuditFiles(t, dir)
+	if len(files) != 1 || len(files[0]) != 0 {
+		t.Fatalf("filtered event produced output: %v", files)
 	}
 }
 
 func TestRecordMultipleEvents(t *testing.T) {
-	var buf bytes.Buffer
+	dir := t.TempDir()
 	filter := parseEventTypes("auth_success,acl_deny")
-	e := NewLogEngine(true, filter, &buf)
+	e := newTestEngine(t, true, filter, dir)
 
 	e.Record(EventAuthSuccess, "login", log.String("user", "alice"))
 	e.Record(EventACLDeny, "denied", log.String("user", "bob"))
 	e.Record(EventConnect, "should be filtered")
 
-	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if err := e.Close(); err != nil {
+		t.Fatal("Close:", err)
+	}
+	files := readAuditFiles(t, dir)
+	if len(files) != 1 {
+		t.Fatalf("expected one audit file, got %d", len(files))
+	}
+	lines := strings.Split(strings.TrimSpace(files[0]), "\n")
 	if len(lines) != 2 {
-		t.Fatalf("expected 2 lines, got %d: %s", len(lines), buf.String())
+		t.Fatalf("expected 2 lines, got %d: %s", len(lines), files[0])
 	}
 }
 
 func TestCloseWithCloser(t *testing.T) {
 	filter := parseEventTypes("all")
-	var buf bytes.Buffer
-	e := NewLogEngine(true, filter, &buf)
+	e := newTestEngine(t, true, filter, t.TempDir())
 	if err := e.Close(); err != nil {
-		t.Fatalf("Close on bytes.Buffer should not error: %v", err)
+		t.Fatalf("Close on a file-backed engine should not error: %v", err)
 	}
 }

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -13,6 +13,8 @@ package audit
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -91,6 +93,20 @@ func TestParseEventTypesWhitespace(t *testing.T) {
 	s := ParseEventTypes(" auth_success , acl_deny ")
 	if !s.has(EventAuthSuccess) || !s.has(EventACLDeny) {
 		t.Fatal("whitespace around tokens should be trimmed")
+	}
+}
+
+func TestParseEventTypesWhitespaceOnlyAppliesDefaults(t *testing.T) {
+	for _, raw := range []string{"   ", "\t\n", " \t "} {
+		s := ParseEventTypes(raw)
+		if s.count == 0 {
+			t.Fatalf("whitespace-only filter %q must apply defaults, got an empty set", raw)
+		}
+		for _, d := range defaultEventTypes {
+			if !s.has(d) {
+				t.Fatalf("whitespace-only filter %q must enable default event %q", raw, d)
+			}
+		}
 	}
 }
 
@@ -243,5 +259,48 @@ func TestCloseWithCloser(t *testing.T) {
 	e := newTestEngine(t, true, filter, t.TempDir())
 	if err := e.Close(); err != nil {
 		t.Fatalf("Close on a file-backed engine should not error: %v", err)
+	}
+}
+
+// failingWriter rejects every write with a per-write error, so a test can tell
+// which attempt produced the failure.
+type failingWriter struct {
+	writes int
+}
+
+var errAuditWrite = errors.New("audit: write failed")
+
+func (f *failingWriter) Write(p []byte) (int, error) {
+	f.writes++
+	return 0, fmt.Errorf("%w: attempt %d", errAuditWrite, f.writes)
+}
+
+func TestRecordRetainsFirstWriteError(t *testing.T) {
+	fw := &failingWriter{}
+	e := &LogEngine{
+		enabled: true,
+		filter:  ParseEventTypes("all"),
+		writer:  fw,
+		enc:     json.NewEncoder(fw),
+	}
+
+	e.Record(EventAuthSuccess, "first")
+	e.Record(EventAuthSuccess, "second")
+	e.Record(EventACLDeny, "third")
+
+	err := e.Close()
+	if err == nil {
+		t.Fatal("Close must report the retained write error")
+	}
+	if !errors.Is(err, errAuditWrite) {
+		t.Fatalf("Close error must wrap the write failure, got %v", err)
+	}
+	// Attempt 1 failed first; the later attempts must not replace it, so the
+	// reported error is the original one, not the last write's.
+	if !strings.Contains(err.Error(), "attempt 1") {
+		t.Fatalf("Close must report the first write failure, got %v", err)
+	}
+	if fw.writes != 1 {
+		t.Fatalf("expected one write attempt before the sink was marked broken, got %d", fw.writes)
 	}
 }

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -2,7 +2,7 @@
 Package audit
 Tellstone Cloud-Native In-Memory Database
 File: audit_test.go
-Description: Verifies EventType definitions, eventSet filtering, parseEventTypes
+Description: Verifies EventType definitions, eventSet filtering, ParseEventTypes
 semantics, and the LogEngine record/close lifecycle.
 
 Authors:
@@ -30,7 +30,7 @@ func TestEventSetNilReceiver(t *testing.T) {
 }
 
 func TestParseEventTypesEmpty(t *testing.T) {
-	s := parseEventTypes("")
+	s := ParseEventTypes("")
 	if !s.has(EventAuthSuccess) || !s.has(EventAuthFailure) || !s.has(EventACLDeny) {
 		t.Fatal("empty flag should yield default event set (auth_success, auth_failure, acl_deny)")
 	}
@@ -40,7 +40,7 @@ func TestParseEventTypesEmpty(t *testing.T) {
 }
 
 func TestParseEventTypesAuthShorthand(t *testing.T) {
-	s := parseEventTypes("auth")
+	s := ParseEventTypes("auth")
 	if !s.has(EventAuthSuccess) || !s.has(EventAuthFailure) {
 		t.Fatal("'auth' shorthand should enable both auth_success and auth_failure")
 	}
@@ -50,7 +50,7 @@ func TestParseEventTypesAuthShorthand(t *testing.T) {
 }
 
 func TestParseEventTypesACLShorthand(t *testing.T) {
-	s := parseEventTypes("acl")
+	s := ParseEventTypes("acl")
 	if !s.has(EventACLDeny) {
 		t.Fatal("'acl' shorthand should enable acl_deny")
 	}
@@ -60,7 +60,7 @@ func TestParseEventTypesACLShorthand(t *testing.T) {
 }
 
 func TestParseEventTypesAll(t *testing.T) {
-	s := parseEventTypes("all")
+	s := ParseEventTypes("all")
 	for _, et := range allEvents {
 		if !s.has(et) {
 			t.Fatalf("'all' should enable every event type, missing %s", et)
@@ -69,7 +69,7 @@ func TestParseEventTypesAll(t *testing.T) {
 }
 
 func TestParseEventTypesExactTokens(t *testing.T) {
-	s := parseEventTypes("auth_success,auth_failure,acl_deny,connect,disconnect,command")
+	s := ParseEventTypes("auth_success,auth_failure,acl_deny,connect,disconnect,command")
 	for _, et := range allEvents {
 		if !s.has(et) {
 			t.Fatalf("explicit token list should enable %s", et)
@@ -78,7 +78,7 @@ func TestParseEventTypesExactTokens(t *testing.T) {
 }
 
 func TestParseEventTypesUnknownIgnored(t *testing.T) {
-	s := parseEventTypes("auth_success,bogus,acl_deny")
+	s := ParseEventTypes("auth_success,bogus,acl_deny")
 	if !s.has(EventAuthSuccess) || !s.has(EventACLDeny) {
 		t.Fatal("known tokens should still be enabled when unknowns are present")
 	}
@@ -88,7 +88,7 @@ func TestParseEventTypesUnknownIgnored(t *testing.T) {
 }
 
 func TestParseEventTypesWhitespace(t *testing.T) {
-	s := parseEventTypes(" auth_success , acl_deny ")
+	s := ParseEventTypes(" auth_success , acl_deny ")
 	if !s.has(EventAuthSuccess) || !s.has(EventACLDeny) {
 		t.Fatal("whitespace around tokens should be trimmed")
 	}
@@ -148,7 +148,7 @@ func readAuditFiles(t *testing.T, dir string) []string {
 }
 
 func TestDisabledEngineNoop(t *testing.T) {
-	filter := parseEventTypes("all")
+	filter := ParseEventTypes("all")
 	e := newTestEngine(t, false, filter, "stdout")
 	e.Record(EventAuthSuccess, "should not appear")
 	if err := e.Close(); err != nil {
@@ -158,7 +158,7 @@ func TestDisabledEngineNoop(t *testing.T) {
 
 func TestRecordWritesJSON(t *testing.T) {
 	dir := t.TempDir()
-	filter := parseEventTypes("auth_success")
+	filter := ParseEventTypes("auth_success")
 	e := newTestEngine(t, true, filter, dir)
 
 	e.Record(EventAuthSuccess, "user logged in",
@@ -203,7 +203,7 @@ func TestRecordWritesJSON(t *testing.T) {
 
 func TestRecordFiltersOutDisabledEvents(t *testing.T) {
 	dir := t.TempDir()
-	filter := parseEventTypes("auth_success")
+	filter := ParseEventTypes("auth_success")
 	e := newTestEngine(t, true, filter, dir)
 
 	e.Record(EventACLDeny, "should be filtered")
@@ -218,7 +218,7 @@ func TestRecordFiltersOutDisabledEvents(t *testing.T) {
 
 func TestRecordMultipleEvents(t *testing.T) {
 	dir := t.TempDir()
-	filter := parseEventTypes("auth_success,acl_deny")
+	filter := ParseEventTypes("auth_success,acl_deny")
 	e := newTestEngine(t, true, filter, dir)
 
 	e.Record(EventAuthSuccess, "login", log.String("user", "alice"))
@@ -239,7 +239,7 @@ func TestRecordMultipleEvents(t *testing.T) {
 }
 
 func TestCloseWithCloser(t *testing.T) {
-	filter := parseEventTypes("all")
+	filter := ParseEventTypes("all")
 	e := newTestEngine(t, true, filter, t.TempDir())
 	if err := e.Close(); err != nil {
 		t.Fatalf("Close on a file-backed engine should not error: %v", err)

--- a/internal/audit/engine.go
+++ b/internal/audit/engine.go
@@ -19,8 +19,11 @@ package audit
 import (
 	"encoding/json"
 	"io"
+	"os"
+	"sync"
 	"time"
 
+	"github.com/Saxy/Tellstone/internal/crypto"
 	"github.com/Saxy/Tellstone/internal/log"
 )
 
@@ -37,25 +40,40 @@ type LogEngine struct {
 	filter  *eventSet
 	writer  io.Writer
 	enc     *json.Encoder
+	closeFn func() error
+	mu      sync.Mutex
 }
 
 // NewLogEngine creates an audit engine. When enabled is false, the engine is
 // a lightweight no-op: no writer opened, no encoder created, Record() is a
-// single bool check. When enabled is true, structured JSON is written to
-// a writer. Pass nil for the writer to discard output (useful for tests).
-func NewLogEngine(enabled bool, filter *eventSet, writer io.Writer) *LogEngine {
+// single bool check. When enabled, the destination is chosen from the audit
+// log path: "stdout" writes JSON to os.Stdout, any other value is treated as
+// a directory whose audit files are created and rotated automatically. The
+// path is only inspected when enabled, so a disabled engine pays nothing.
+func NewLogEngine(enabled bool, filter *eventSet, auditLogPath string, logger log.Logger, engine crypto.Engine) *LogEngine {
 	if !enabled {
 		return &LogEngine{enabled: false}
 	}
-	var enc *json.Encoder
-	if writer != nil {
-		enc = json.NewEncoder(writer)
+	writer := io.Writer(os.Stdout)
+	var closeFn func() error
+	if auditLogPath != "" && auditLogPath != "stdout" {
+		f, err := newFile(auditLogPath, engine, logger)
+		if err != nil {
+			// fallback to stdout in case of error with a file
+			if logger.Enabled(log.LevelError) {
+				logger.Log(log.LevelError, "audit: initial file creation failed -- activate fallback to stdout", log.String("error", err.Error()))
+			}
+		} else {
+			writer = f
+			closeFn = f.Close
+		}
 	}
 	return &LogEngine{
 		enabled: true,
 		filter:  filter,
 		writer:  writer,
-		enc:     enc,
+		enc:     json.NewEncoder(writer),
+		closeFn: closeFn,
 	}
 }
 
@@ -67,6 +85,8 @@ func (e *LogEngine) Record(event EventType, msg string, fields ...log.Field) {
 	if !e.enabled || !e.filter.has(event) {
 		return
 	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
 	entry := map[string]any{
 		"time":  time.Now().Format(time.RFC3339Nano),
 		"level": auditLevel,
@@ -90,15 +110,15 @@ func (e *LogEngine) Record(event EventType, msg string, fields ...log.Field) {
 	_ = e.enc.Encode(entry)
 }
 
-// Close closes the underlying writer if it implements io.Closer.
-// Returns nil when the engine is not enabled or the writer does not
-// implement io.Closer (e.g. os.Stdout).
+// Close closes the file backing a non-stdout audit log. Returns nil when the
+// engine is not enabled or the destination is stdout — os.Stdout is never
+// closed, it is owned by the process. The mutex serializes Close against any
+// in-flight Record, so the underlying file is never closed mid-write.
 func (e *LogEngine) Close() error {
-	if !e.enabled {
+	if !e.enabled || e.closeFn == nil {
 		return nil
 	}
-	if closer, ok := e.writer.(io.Closer); ok {
-		return closer.Close()
-	}
-	return nil
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.closeFn()
 }

--- a/internal/audit/engine.go
+++ b/internal/audit/engine.go
@@ -1,0 +1,104 @@
+/*
+Package audit
+Tellstone Cloud-Native In-Memory Database
+File: engine.go
+Description: Concrete audit log engine. Writes structured JSON to an io.Writer,
+event-type-gated via eventSet, independent of the operational log level. A server
+running at --log-level fatal still emits a full audit trail when --enable-audit
+is set.
+
+Every JSON line carries "level": "AUDIT" so log aggregators can distinguish audit
+entries from operational log lines (INFO/WARN/ERROR/FATAL) without any custom parsing.
+
+Authors:
+
+	Maximilian Hagen
+*/
+package audit
+
+import (
+	"encoding/json"
+	"io"
+	"time"
+
+	"github.com/Saxy/Tellstone/internal/log"
+)
+
+// auditLevel is the fixed severity label emitted in every JSON audit line.
+const auditLevel = "AUDIT"
+
+// LogEngine is the concrete audit logger. When enabled is false (--enable-audit
+// not set), Record() returns immediately with a single bool comparison — no
+// writer, no encoder allocated. When enabled, Record() checks the event against
+// the filter and writes one JSON line to the writer. History is retrieved from
+// the log files directly — no in-memory buffer is maintained.
+type LogEngine struct {
+	enabled bool
+	filter  *eventSet
+	writer  io.Writer
+	enc     *json.Encoder
+}
+
+// NewLogEngine creates an audit engine. When enabled is false, the engine is
+// a lightweight no-op: no writer opened, no encoder created, Record() is a
+// single bool check. When enabled is true, structured JSON is written to
+// a writer. Pass nil for the writer to discard output (useful for tests).
+func NewLogEngine(enabled bool, filter *eventSet, writer io.Writer) *LogEngine {
+	if !enabled {
+		return &LogEngine{enabled: false}
+	}
+	var enc *json.Encoder
+	if writer != nil {
+		enc = json.NewEncoder(writer)
+	}
+	return &LogEngine{
+		enabled: true,
+		filter:  filter,
+		writer:  writer,
+		enc:     enc,
+	}
+}
+
+// Record writes one audit event. When the engine is not enabled, this is a
+// single bool comparison — zero overhead. When enabled, the event is checked
+// against the filter; filtered-out events return immediately. Passing events
+// write one JSON line with "level": "AUDIT".
+func (e *LogEngine) Record(event EventType, msg string, fields ...log.Field) {
+	if !e.enabled || !e.filter.has(event) {
+		return
+	}
+	entry := map[string]any{
+		"time":  time.Now().Format(time.RFC3339Nano),
+		"level": auditLevel,
+		"event": event,
+		"msg":   msg,
+	}
+	for _, f := range fields {
+		switch f.Type {
+		case log.TypeString:
+			entry[f.Key] = f.StrVal
+		case log.TypeInt:
+			entry[f.Key] = f.IntVal
+		case log.TypeBool:
+			entry[f.Key] = f.BoolVal
+		case log.TypeFloat:
+			entry[f.Key] = f.FloatVal
+		case log.TypeUint:
+			entry[f.Key] = f.UintVal
+		}
+	}
+	_ = e.enc.Encode(entry)
+}
+
+// Close closes the underlying writer if it implements io.Closer.
+// Returns nil when the engine is not enabled or the writer does not
+// implement io.Closer (e.g. os.Stdout).
+func (e *LogEngine) Close() error {
+	if !e.enabled {
+		return nil
+	}
+	if closer, ok := e.writer.(io.Closer); ok {
+		return closer.Close()
+	}
+	return nil
+}

--- a/internal/audit/engine.go
+++ b/internal/audit/engine.go
@@ -42,6 +42,10 @@ type LogEngine struct {
 	enc     *json.Encoder
 	closeFn func() error
 	mu      sync.Mutex
+	// firstErr is the first failed Encode, retained so Close can report it.
+	// Once set, later records are dropped instead of overwriting the original
+	// cause, which would hide the root failure from the operator.
+	firstErr error
 }
 
 // NewLogEngine creates an audit engine. When enabled is false, the engine is
@@ -80,13 +84,20 @@ func NewLogEngine(enabled bool, filter *eventSet, auditLogPath string, logger lo
 // Record writes one audit event. When the engine is not enabled, this is a
 // single bool comparison — zero overhead. When enabled, the event is checked
 // against the filter; filtered-out events return immediately. Passing events
-// write one JSON line with "level": "AUDIT".
+// write one JSON line with "level": "AUDIT". A failing write is retained as
+// the engine's first error and reported by Close; subsequent records are
+// dropped rather than masking it.
 func (e *LogEngine) Record(event EventType, msg string, fields ...log.Field) {
 	if !e.enabled || !e.filter.has(event) {
 		return
 	}
 	e.mu.Lock()
 	defer e.mu.Unlock()
+	// A broken sink keeps failing; stop attempting writes once the first
+	// failure is recorded so Close reports the original error, not the last one.
+	if e.firstErr != nil {
+		return
+	}
 	entry := map[string]any{
 		"time":  time.Now().Format(time.RFC3339Nano),
 		"level": auditLevel,
@@ -107,18 +118,30 @@ func (e *LogEngine) Record(event EventType, msg string, fields ...log.Field) {
 			entry[f.Key] = f.UintVal
 		}
 	}
-	_ = e.enc.Encode(entry)
+	if err := e.enc.Encode(entry); err != nil && e.firstErr == nil {
+		e.firstErr = err
+	}
 }
 
-// Close closes the file backing a non-stdout audit log. Returns nil when the
-// engine is not enabled or the destination is stdout — os.Stdout is never
-// closed, it is owned by the process. The mutex serializes Close against any
-// in-flight Record, so the underlying file is never closed mid-write.
+// Close closes the file backing a non-stdout audit log and reports the first
+// write failure, if any. Returns nil when the engine is not enabled — the
+// disabled engine never records, so it can have no write error. The first
+// failed write outranks a close error: it happened first and is the root
+// cause the operator needs. os.Stdout is never closed — it is owned by the
+// process. The mutex serializes Close against any in-flight Record, so the
+// underlying file is never closed mid-write.
 func (e *LogEngine) Close() error {
-	if !e.enabled || e.closeFn == nil {
+	if !e.enabled {
 		return nil
 	}
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	return e.closeFn()
+	var closeErr error
+	if e.closeFn != nil {
+		closeErr = e.closeFn()
+	}
+	if e.firstErr != nil {
+		return e.firstErr
+	}
+	return closeErr
 }

--- a/internal/audit/file.go
+++ b/internal/audit/file.go
@@ -84,7 +84,7 @@ func open(dir string) (*os.File, string, error) {
 // cannot collide; the hash fingerprint separates instances sharing a directory.
 func fileName(dir string) string {
 	h := sha256.Sum256([]byte(dir))
-	return fmt.Sprintf("%d_%x_tsd.log", time.Now().UnixNano(), h[:4])
+	return fmt.Sprintf("%d_%x_%d_tsd.log", time.Now().UnixNano(), h[:4], os.Getpid())
 }
 
 // Write encrypts the record when enabled, flushes it to the current file, and

--- a/internal/audit/file.go
+++ b/internal/audit/file.go
@@ -121,17 +121,18 @@ func (f *file) Write(p []byte) (int, error) {
 // the same directory, resetting the byte counter. The previous file is left
 // untouched on disk — rotation never truncates or renames history.
 func (f *file) rotate() error {
-	if err := f.file.Close(); err != nil {
-		return err
-	}
 	osFile, path, err := open(f.dir)
 	if err != nil {
 		if f.logger.Enabled(log.LevelError) {
-			f.logger.Log(log.LevelError, "audit: failed to rotate log file", log.String("filename", f.file.Name()), log.String("error", err.Error()))
+			f.logger.Log(log.LevelError, "audit: failed to rotate log file", log.String("current", f.path), log.String("error", err.Error()))
 		}
 		return err
 	}
 	previous := f.path
+	if err = f.file.Close(); err != nil {
+		_ = osFile.Close()
+		return err
+	}
 	f.file = osFile
 	f.path = path
 	f.bytesWritten = 0

--- a/internal/audit/file.go
+++ b/internal/audit/file.go
@@ -18,6 +18,7 @@ package audit
 
 import (
 	"crypto/sha256"
+	"encoding/binary"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -103,6 +104,17 @@ func (f *file) Write(p []byte) (int, error) {
 			return 0, err
 		}
 		f.buf = out
+		// Prepend a 4-byte big-endian length prefix counting the sealed bytes
+		// (nonce + ciphertext + tag) so every blob is self-delimiting: a
+		// completed file decodes sequentially without knowing plaintext lengths
+		// or reading between records. The prefix is plaintext metadata, never
+		// part of the record itself.
+		var prefix [4]byte
+		binary.BigEndian.PutUint32(prefix[:], uint32(len(out)))
+		if _, err := f.file.Write(prefix[:]); err != nil {
+			return 0, err
+		}
+		f.bytesWritten += 4
 	}
 	n, err := f.file.Write(out)
 	if err != nil {

--- a/internal/audit/file.go
+++ b/internal/audit/file.go
@@ -1,0 +1,153 @@
+/*
+Package audit
+Tellstone Cloud-Native In-Memory Database
+File: file.go
+Description: File-backed audit log writer. The on-disk file name is generated,
+never supplied: a unix timestamp, the first 8 hex chars of a SHA-256 of the
+destination directory (a stable per-instance fingerprint), and the "tsd" marker.
+Bytes written are tracked and once the threshold (50 MiB) is crossed the writer
+rotates to a freshly named file in the same directory. When encryption is
+enabled, every record is sealed with the crypto engine before being flushed.
+
+Authors:
+
+	Maximilian Hagen
+*/
+package audit
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/Saxy/Tellstone/internal/crypto"
+	"github.com/Saxy/Tellstone/internal/log"
+)
+
+// rotateAfterBytes is the writing volume after which the audit file rotates.
+// 50 MiB keeps a single file small enough to inspect or ingest in one piece
+// while making rotation rare enough not to matter operationally.
+const rotateAfterBytes = 50 << 20
+
+// file is a rotating, optionally encrypted audit log. bytesWritten counts the
+// bytes flushed to the current file; when it reaches maxSize, Write rotates.
+type file struct {
+	dir          string
+	path         string
+	isEncrypted  bool
+	ce           crypto.Engine
+	file         *os.File
+	bytesWritten uint64
+	maxSize      uint64
+	buf          []byte
+	logger       log.Logger
+}
+
+// newFile opens the first audit file inside dir. When engine.Enabled() is
+// false, records are written as plaintext; otherwise every record is sealed.
+func newFile(dir string, engine crypto.Engine, logger log.Logger) (*file, error) {
+	f := &file{dir: dir, maxSize: rotateAfterBytes}
+	if engine.Enabled() {
+		f.isEncrypted = true
+		f.ce = engine
+	}
+	if logger == nil {
+		logger = log.NewNoOpLogger()
+	}
+	f.logger = logger
+	osFile, path, err := open(dir)
+	if err != nil {
+		return nil, err
+	}
+	f.file = osFile
+	f.path = path
+	if f.logger.Enabled(log.LevelInfo) {
+		f.logger.Log(log.LevelInfo, "audit: initialized log file", log.String("filename", f.file.Name()))
+	}
+	return f, nil
+}
+
+// open generates a fresh file name in dir and opens it for append.
+func open(dir string) (*os.File, string, error) {
+	path := filepath.Join(dir, fileName(dir))
+	osFile, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return nil, "", err
+	}
+	return osFile, path, nil
+}
+
+// fileName builds a unique audit file name: <unix-nanoseconds>_<hash>_tsd.log.
+// Nanoseconds (rather than seconds) guarantee two rotations in the same second
+// cannot collide; the hash fingerprint separates instances sharing a directory.
+func fileName(dir string) string {
+	h := sha256.Sum256([]byte(dir))
+	return fmt.Sprintf("%d_%x_tsd.log", time.Now().UnixNano(), h[:4])
+}
+
+// Write encrypts the record when enabled, flushes it to the current file, and
+// advances the byte counter. Once maxSize bytes have been written the file
+// rotates, so every record lands in exactly one file.
+func (f *file) Write(p []byte) (int, error) {
+	out := p
+	if f.isEncrypted {
+		// Reuse one scratch buffer across records
+		var err error
+		out, err = f.ce.EncryptInPlace(f.buf, p)
+		if err != nil {
+			return 0, err
+		}
+		f.buf = out
+	}
+	n, err := f.file.Write(out)
+	if err != nil {
+		if f.logger.Enabled(log.LevelError) {
+			f.logger.Log(log.LevelError, "audit: failed to write log", log.String("filename", f.file.Name()), log.String("error", err.Error()))
+		}
+		return n, err
+	}
+	f.bytesWritten += uint64(n)
+	if f.bytesWritten >= f.maxSize {
+		if err = f.rotate(); err != nil {
+			return n, err
+		}
+	}
+	return len(p), nil
+}
+
+// rotate closes the current file and switches to a freshly generated name in
+// the same directory, resetting the byte counter. The previous file is left
+// untouched on disk — rotation never truncates or renames history.
+func (f *file) rotate() error {
+	if err := f.file.Close(); err != nil {
+		return err
+	}
+	osFile, path, err := open(f.dir)
+	if err != nil {
+		if f.logger.Enabled(log.LevelError) {
+			f.logger.Log(log.LevelError, "audit: failed to rotate log file", log.String("filename", f.file.Name()), log.String("error", err.Error()))
+		}
+		return err
+	}
+	previous := f.path
+	f.file = osFile
+	f.path = path
+	f.bytesWritten = 0
+	if f.logger.Enabled(log.LevelInfo) {
+		f.logger.Log(log.LevelInfo, "audit: rotated log file", log.String("filename", path), log.String("previous", previous))
+	}
+	return nil
+}
+
+// Close closes the current file. After a successful close the handle is
+// cleared, so a second call is a harmless no-op.
+func (f *file) Close() error {
+	if f.file == nil {
+		return nil
+	}
+	err := f.file.Close()
+	f.file = nil
+	return err
+}

--- a/internal/audit/file.go
+++ b/internal/audit/file.go
@@ -4,10 +4,11 @@ Tellstone Cloud-Native In-Memory Database
 File: file.go
 Description: File-backed audit log writer. The on-disk file name is generated,
 never supplied: a unix timestamp, the first 8 hex chars of a SHA-256 of the
-destination directory (a stable per-instance fingerprint), and the "tsd" marker.
-Bytes written are tracked and once the threshold (50 MiB) is crossed the writer
-rotates to a freshly named file in the same directory. When encryption is
-enabled, every record is sealed with the crypto engine before being flushed.
+destination directory (a stable per-instance fingerprint), the writing process's
+PID, and the "tsd" marker. Bytes written are tracked and once the threshold
+(50 MiB) is crossed the writer rotates to a freshly named file in the same
+directory. When encryption is enabled, every record is sealed with the crypto
+engine before being flushed.
 
 Authors:
 
@@ -79,9 +80,11 @@ func open(dir string) (*os.File, string, error) {
 	return osFile, path, nil
 }
 
-// fileName builds a unique audit file name: <unix-nanoseconds>_<hash>_tsd.log.
-// Nanoseconds (rather than seconds) guarantee two rotations in the same second
-// cannot collide; the hash fingerprint separates instances sharing a directory.
+// fileName builds a unique audit file name:
+// <unix-nanoseconds>_<hash>_<pid>_tsd.log. Nanoseconds (rather than seconds)
+// guarantee two rotations in the same second cannot collide; the hash
+// fingerprint separates instances sharing a directory; the PID separates
+// processes writing to the same directory.
 func fileName(dir string) string {
 	h := sha256.Sum256([]byte(dir))
 	return fmt.Sprintf("%d_%x_%d_tsd.log", time.Now().UnixNano(), h[:4], os.Getpid())

--- a/internal/audit/file_test.go
+++ b/internal/audit/file_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -82,14 +83,21 @@ func TestFileNameContainsTimestampHashAndMarker(t *testing.T) {
 		t.Fatalf("file name %q missing the tsd marker", base)
 	}
 	parts := strings.Split(strings.TrimSuffix(base, "_tsd.log"), "_")
-	if len(parts) != 2 {
-		t.Fatalf("expected <timestamp>_<hash>_tsd.log, got %q", base)
+	if len(parts) != 3 {
+		t.Fatalf("expected <timestamp>_<hash>_<pid>_tsd.log, got %q", base)
 	}
 	if _, err := fmt.Sscanf(parts[0], "%d", new(int64)); err != nil {
 		t.Fatalf("timestamp segment %q is not numeric: %v", parts[0], err)
 	}
 	if len(parts[1]) != 8 {
 		t.Fatalf("hash segment %q should be 8 hex chars", parts[1])
+	}
+	pid, err := strconv.Atoi(parts[2])
+	if err != nil {
+		t.Fatalf("pid segment %q is not numeric: %v", parts[2], err)
+	}
+	if pid != os.Getpid() {
+		t.Fatalf("pid segment %q must match the writing process (%d)", parts[2], os.Getpid())
 	}
 }
 

--- a/internal/audit/file_test.go
+++ b/internal/audit/file_test.go
@@ -139,7 +139,7 @@ func TestFileRotation(t *testing.T) {
 
 func TestFileAuditLoggingPlaintext(t *testing.T) {
 	dir := t.TempDir()
-	e := newTestEngine(t, true, parseEventTypes("all"), dir)
+	e := newTestEngine(t, true, ParseEventTypes("all"), dir)
 
 	e.Record(EventAuthSuccess, "user logged in", log.String("user", "alice"))
 	e.Record(EventACLDeny, "command denied", log.String("user", "bob"))
@@ -166,7 +166,7 @@ func TestFileAuditLoggingEncrypted(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	e := NewLogEngine(true, parseEventTypes("all"), dir, log.NewNoOpLogger(), *ce)
+	e := NewLogEngine(true, ParseEventTypes("all"), dir, log.NewNoOpLogger(), *ce)
 
 	records := []struct {
 		event EventType
@@ -221,7 +221,7 @@ func TestFileAuditLoggingEncrypted(t *testing.T) {
 
 func TestFileRotationThroughEngine(t *testing.T) {
 	dir := t.TempDir()
-	e := newTestEngine(t, true, parseEventTypes("all"), dir)
+	e := newTestEngine(t, true, ParseEventTypes("all"), dir)
 	e.writer.(*file).maxSize = 1 // rotate after every record
 
 	const n = 10
@@ -254,7 +254,7 @@ func TestFileRotationThroughEngine(t *testing.T) {
 
 func TestEngineConcurrentRecords(t *testing.T) {
 	dir := t.TempDir()
-	e := newTestEngine(t, true, parseEventTypes("all"), dir)
+	e := newTestEngine(t, true, ParseEventTypes("all"), dir)
 
 	// The gnet listeners and bcrypt workers record from many goroutines at
 	// once; run under -race this proves Record and Close are serialized.

--- a/internal/audit/file_test.go
+++ b/internal/audit/file_test.go
@@ -15,6 +15,7 @@ package audit
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -185,23 +186,34 @@ func TestFileAuditLoggingEncrypted(t *testing.T) {
 		{EventAuthFailure, "bad password"},
 	}
 
-	// Each record is sealed as one contiguous blob. Track the file growth so
-	// every blob is sliced out individually and decrypted back to its JSON line.
-	var before []byte
-	for i, r := range records {
+	// Every record is written up front; the completed file is decoded only
+	// afterwards, walking the length prefixes sequentially with no reads
+	// between Record calls.
+	for _, r := range records {
 		e.Record(r.event, r.msg, log.String("user", "alice"))
-		after, err := os.ReadFile(singleAuditFile(t, dir))
-		if err != nil {
-			t.Fatal(err)
+	}
+	if err := e.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(singleAuditFile(t, dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "AUDIT") {
+		t.Fatal("encrypted audit file contains plaintext AUDIT marker")
+	}
+
+	for i, r := range records {
+		if len(data) < 4 {
+			t.Fatalf("record %d: truncated length prefix (%d bytes left)", i, len(data))
 		}
-		if len(after) <= len(before) {
-			t.Fatalf("record %d did not grow the audit file", i)
+		blobLen := int(binary.BigEndian.Uint32(data[:4]))
+		data = data[4:]
+		if blobLen == 0 || blobLen > len(data) {
+			t.Fatalf("record %d: invalid blob length %d (remaining %d)", i, blobLen, len(data))
 		}
-		sealed := after[len(before):]
-		if strings.Contains(string(sealed), r.msg) || strings.Contains(string(sealed), "AUDIT") {
-			t.Fatalf("record %d is stored as plaintext: %q", i, sealed)
-		}
-		plain, err := ce.DecryptInPlace(sealed)
+		plain, err := ce.DecryptInPlace(data[:blobLen])
 		if err != nil {
 			t.Fatalf("record %d failed to decrypt: %v", i, err)
 		}
@@ -212,18 +224,10 @@ func TestFileAuditLoggingEncrypted(t *testing.T) {
 		if m["level"] != "AUDIT" || m["event"] != string(r.event) || m["msg"] != r.msg {
 			t.Fatalf("record %d does not survive the encrypted round trip: %v", i, m)
 		}
-		before = after
+		data = data[blobLen:]
 	}
-
-	if err := e.Close(); err != nil {
-		t.Fatal(err)
-	}
-	data, err := os.ReadFile(singleAuditFile(t, dir))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if strings.Contains(string(data), "AUDIT") {
-		t.Fatal("encrypted audit file contains plaintext AUDIT marker")
+	if len(data) != 0 {
+		t.Fatalf("file holds %d trailing bytes beyond the last record", len(data))
 	}
 }
 

--- a/internal/audit/file_test.go
+++ b/internal/audit/file_test.go
@@ -1,0 +1,283 @@
+/*
+Package audit
+Tellstone Cloud-Native In-Memory Database
+File: file_test.go
+Description: End-to-end proof that file-backed audit logging works. Records made
+through the LogEngine reach the *_tsd.log file as valid JSON lines, survive a
+full encrypt/decrypt round trip when the crypto engine is enabled, and rotation
+splits history across multiple files without losing or reordering a single record.
+
+Authors:
+
+	Maximilian Hagen
+*/
+package audit
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/Saxy/Tellstone/internal/crypto"
+	"github.com/Saxy/Tellstone/internal/log"
+)
+
+// auditFilePaths lists every *_tsd.log file in dir. Sorted order equals
+// creation order because the file name embeds its creation timestamp.
+func auditFilePaths(t *testing.T, dir string) []string {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, "*_tsd.log"))
+	if err != nil {
+		t.Fatal("Glob:", err)
+	}
+	sort.Strings(matches)
+	return matches
+}
+
+// a singleAuditFile returns the one and only audit file in dir.
+func singleAuditFile(t *testing.T, dir string) string {
+	t.Helper()
+	paths := auditFilePaths(t, dir)
+	if len(paths) != 1 {
+		t.Fatalf("expected exactly one audit file, got %d: %v", len(paths), paths)
+	}
+	return paths[0]
+}
+
+// auditLines returns every non-empty line across all audit files in dir,
+// in creation order.
+func auditLines(t *testing.T, dir string) []string {
+	t.Helper()
+	var lines []string
+	for _, p := range auditFilePaths(t, dir) {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatal("ReadFile:", err)
+		}
+		for _, l := range strings.Split(string(data), "\n") {
+			if l != "" {
+				lines = append(lines, l)
+			}
+		}
+	}
+	return lines
+}
+
+func TestFileNameContainsTimestampHashAndMarker(t *testing.T) {
+	dir := t.TempDir()
+	f, err := newFile(dir, crypto.Engine{}, log.NewNoOpLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	base := filepath.Base(f.path)
+	if !strings.HasSuffix(base, "_tsd.log") {
+		t.Fatalf("file name %q missing the tsd marker", base)
+	}
+	parts := strings.Split(strings.TrimSuffix(base, "_tsd.log"), "_")
+	if len(parts) != 2 {
+		t.Fatalf("expected <timestamp>_<hash>_tsd.log, got %q", base)
+	}
+	if _, err := fmt.Sscanf(parts[0], "%d", new(int64)); err != nil {
+		t.Fatalf("timestamp segment %q is not numeric: %v", parts[0], err)
+	}
+	if len(parts[1]) != 8 {
+		t.Fatalf("hash segment %q should be 8 hex chars", parts[1])
+	}
+}
+
+func TestFileRotation(t *testing.T) {
+	dir := t.TempDir()
+	f, err := newFile(dir, crypto.Engine{}, log.NewNoOpLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	first := f.path
+	f.maxSize = 20
+
+	if _, err := f.Write([]byte("0123456789")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte("abcdefghij")); err != nil {
+		t.Fatal(err)
+	}
+	if f.path == first {
+		t.Fatal("expected rotation to switch to a new file")
+	}
+
+	data, err := os.ReadFile(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "0123456789abcdefghij" {
+		t.Fatalf("previous file holds %q, want both writes", data)
+	}
+
+	if _, err := f.Write([]byte("xyz")); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	data, err = os.ReadFile(f.path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "xyz" {
+		t.Fatalf("rotated file holds %q, want xyz", data)
+	}
+}
+
+func TestFileAuditLoggingPlaintext(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEngine(t, true, parseEventTypes("all"), dir)
+
+	e.Record(EventAuthSuccess, "user logged in", log.String("user", "alice"))
+	e.Record(EventACLDeny, "command denied", log.String("user", "bob"))
+	if err := e.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	lines := auditLines(t, dir)
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 audit records in the file, got %d", len(lines))
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &m); err != nil {
+		t.Fatalf("first line is not valid audit JSON: %v\n%s", err, lines[0])
+	}
+	if m["level"] != "AUDIT" || m["event"] != "auth_success" || m["user"] != "alice" {
+		t.Fatalf("first record does not round trip to the file: %v", m)
+	}
+}
+
+func TestFileAuditLoggingEncrypted(t *testing.T) {
+	dir := t.TempDir()
+	ce, err := crypto.NewEngine(bytes.Repeat([]byte{0x42}, 32), log.NewNoOpLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := NewLogEngine(true, parseEventTypes("all"), dir, log.NewNoOpLogger(), *ce)
+
+	records := []struct {
+		event EventType
+		msg   string
+	}{
+		{EventAuthSuccess, "user logged in"},
+		{EventACLDeny, "command denied"},
+		{EventAuthFailure, "bad password"},
+	}
+
+	// Each record is sealed as one contiguous blob. Track the file growth so
+	// every blob is sliced out individually and decrypted back to its JSON line.
+	var before []byte
+	for i, r := range records {
+		e.Record(r.event, r.msg, log.String("user", "alice"))
+		after, err := os.ReadFile(singleAuditFile(t, dir))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(after) <= len(before) {
+			t.Fatalf("record %d did not grow the audit file", i)
+		}
+		sealed := after[len(before):]
+		if strings.Contains(string(sealed), r.msg) || strings.Contains(string(sealed), "AUDIT") {
+			t.Fatalf("record %d is stored as plaintext: %q", i, sealed)
+		}
+		plain, err := ce.DecryptInPlace(sealed)
+		if err != nil {
+			t.Fatalf("record %d failed to decrypt: %v", i, err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal(plain, &m); err != nil {
+			t.Fatalf("record %d is not valid JSON after decryption: %v\n%s", i, err, plain)
+		}
+		if m["level"] != "AUDIT" || m["event"] != string(r.event) || m["msg"] != r.msg {
+			t.Fatalf("record %d does not survive the encrypted round trip: %v", i, m)
+		}
+		before = after
+	}
+
+	if err := e.Close(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(singleAuditFile(t, dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "AUDIT") {
+		t.Fatal("encrypted audit file contains plaintext AUDIT marker")
+	}
+}
+
+func TestFileRotationThroughEngine(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEngine(t, true, parseEventTypes("all"), dir)
+	e.writer.(*file).maxSize = 1 // rotate after every record
+
+	const n = 10
+	for i := 0; i < n; i++ {
+		e.Record(EventAuthSuccess, fmt.Sprintf("record %d", i))
+	}
+	if err := e.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if paths := auditFilePaths(t, dir); len(paths) < 2 {
+		t.Fatalf("expected rotation to produce multiple files, got %d", len(paths))
+	}
+
+	lines := auditLines(t, dir)
+	if len(lines) != n {
+		t.Fatalf("expected %d records across rotated files, got %d", n, len(lines))
+	}
+	for i, l := range lines {
+		var m map[string]any
+		if err := json.Unmarshal([]byte(l), &m); err != nil {
+			t.Fatalf("line %d is not valid audit JSON: %v", i, err)
+		}
+		want := fmt.Sprintf("record %d", i)
+		if m["msg"] != want {
+			t.Fatalf("line %d msg = %v, want %s", i, m["msg"], want)
+		}
+	}
+}
+
+func TestEngineConcurrentRecords(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEngine(t, true, parseEventTypes("all"), dir)
+
+	// The gnet listeners and bcrypt workers record from many goroutines at
+	// once; run under -race this proves Record and Close are serialized.
+	const workers = 8
+	const perWorker = 200
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < perWorker; i++ {
+				e.Record(EventAuthSuccess, "login",
+					log.String("user", fmt.Sprintf("user-%d-%d", id, i)))
+			}
+		}(w)
+	}
+	wg.Wait()
+	if err := e.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	lines := auditLines(t, dir)
+	if len(lines) != workers*perWorker {
+		t.Fatalf("expected %d records, got %d", workers*perWorker, len(lines))
+	}
+}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -6,10 +6,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Saxy/Tellstone/internal/audit"
+	"github.com/Saxy/Tellstone/internal/crypto"
 	"github.com/Saxy/Tellstone/internal/log"
 	"github.com/Saxy/Tellstone/internal/network"
 	"github.com/Saxy/Tellstone/internal/storage"
 )
+
+// newNoOpAudit returns a disabled audit engine so the listener harness
+// exercises the unguarded Record() hooks with zero audit output.
+func newNoOpAudit() *audit.LogEngine {
+	return audit.NewLogEngine(false, nil, "stdout", log.NewNoOpLogger(), crypto.Engine{})
+}
 
 // TestCollectorEngineSnapshot verifies that the engine snapshot reflects
 // the values reported by the storage engine after a few operations.
@@ -112,7 +120,7 @@ func TestCollectorEngineSnapshot(t *testing.T) {
 		t.Fatalf("expected key to exist after Set")
 	}
 	// Create a dummy network server (no handler, no activity).
-	srv := network.NewServer("", 0, nil, nil, log.NewNoOpLogger(), nil, "", nil)
+	srv := network.NewServer("", 0, nil, nil, log.NewNoOpLogger(), nil, "", nil, newNoOpAudit())
 
 	col := NewCollector(eng, srv, log.NewNoOpLogger())
 	snap := col.GetEngineSnapshot()

--- a/internal/network/acl_test.go
+++ b/internal/network/acl_test.go
@@ -220,7 +220,7 @@ func startACLNetworkServer(t *testing.T) (addr string, store *rbac.Store) {
 	}
 	addr = l.Addr().String()
 	_ = l.Close()
-	store = rbac.NewStore(rbacNetworkPolicy(t))
+	store = rbac.NewStore(rbacNetworkPolicy(t), log.NewNoOpLogger())
 	srv := NewServer(addr, 0, nil, aclTestHandler(store), log.NewNoOpLogger(), nil, "", store)
 	go func() { _ = srv.ListenAndServe() }()
 	t.Cleanup(func() {

--- a/internal/network/acl_test.go
+++ b/internal/network/acl_test.go
@@ -221,7 +221,7 @@ func startACLNetworkServer(t *testing.T) (addr string, store *rbac.Store) {
 	addr = l.Addr().String()
 	_ = l.Close()
 	store = rbac.NewStore(rbacNetworkPolicy(t), log.NewNoOpLogger())
-	srv := NewServer(addr, 0, nil, aclTestHandler(store), log.NewNoOpLogger(), nil, "", store)
+	srv := NewServer(addr, 0, nil, aclTestHandler(store), log.NewNoOpLogger(), nil, "", store, newNoOpAudit())
 	go func() { _ = srv.ListenAndServe() }()
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)

--- a/internal/network/benchmark_tls_test.go
+++ b/internal/network/benchmark_tls_test.go
@@ -39,7 +39,7 @@ func startBenchServer(b *testing.B, handler func(msg *Message) ([]byte, MessageT
 	addr := l.Addr().String()
 	l.Close()
 
-	srv := NewServer(addr, 0, nil, handler, log.NewNoOpLogger(), nil, "", nil)
+	srv := NewServer(addr, 0, nil, handler, log.NewNoOpLogger(), nil, "", nil, newNoOpAudit())
 	go func() { _ = srv.ListenAndServe() }()
 	if err := waitForServer(addr, 2*time.Second); err != nil {
 		b.Fatalf("server not ready: %v", err)
@@ -92,7 +92,7 @@ func startBenchTLSServer(b *testing.B, handler func(msg *Message) ([]byte, Messa
 	addr := l.Addr().String()
 	l.Close()
 
-	srv := NewServer(addr, 0, nil, handler, log.NewNoOpLogger(), tlsConfigs, "", nil)
+	srv := NewServer(addr, 0, nil, handler, log.NewNoOpLogger(), tlsConfigs, "", nil, newNoOpAudit())
 	go func() {
 		_ = srv.ListenAndServe()
 	}()

--- a/internal/network/client.go
+++ b/internal/network/client.go
@@ -54,7 +54,9 @@ func DialWithLogger(addr string, timeout time.Duration, logger log.Logger) (*Cli
 	if tcpConn, ok := conn.(*net.TCPConn); ok {
 		_ = tcpConn.SetNoDelay(true)
 	}
-	logger.Log(log.LevelInfo, "client: connected", log.String("addr", addr))
+	if logger.Enabled(log.LevelInfo) {
+		logger.Log(log.LevelInfo, "client: connected", log.String("addr", addr))
+	}
 	return &Client{conn: conn, logger: logger}, nil
 }
 
@@ -106,7 +108,9 @@ func DialTLSWithLogger(addr string, certPath, keyPath, caPath string, timeout ti
 	if err != nil {
 		return nil, err
 	}
-	logger.Log(log.LevelInfo, "client: connected", log.String("addr", addr))
+	if logger.Enabled(log.LevelInfo) {
+		logger.Log(log.LevelInfo, "client: connected", log.String("addr", addr))
+	}
 	return &Client{conn: conn, logger: logger}, nil
 }
 
@@ -115,8 +119,10 @@ func (c *Client) Close() error {
 	err := c.conn.Close()
 	if c.logger != nil {
 		if err != nil {
-			c.logger.Log(log.LevelWarn, "client: close failed", log.String("error", err.Error()))
-		} else {
+			if c.logger.Enabled(log.LevelWarn) {
+				c.logger.Log(log.LevelWarn, "client: close failed", log.String("error", err.Error()))
+			}
+		} else if c.logger.Enabled(log.LevelInfo) {
 			c.logger.Log(log.LevelInfo, "client: connection closed")
 		}
 	}

--- a/internal/network/protocol_test.go
+++ b/internal/network/protocol_test.go
@@ -19,7 +19,7 @@ const benchAddr = "127.0.0.1:9988"
 func TestMain(m *testing.M) {
 	srv := NewServer(benchAddr, 0, nil, func(msg *Message) ([]byte, MessageType, error) {
 		return msg.Payload, MsgResponse, nil
-	}, nil, nil, "", nil)
+	}, nil, nil, "", nil, newNoOpAudit())
 
 	go func() {
 		_ = srv.ListenAndServe()

--- a/internal/network/role_test.go
+++ b/internal/network/role_test.go
@@ -258,7 +258,7 @@ func startRBACNetworkServer(t *testing.T) (addr string, store *rbac.Store) {
 	}
 	addr = l.Addr().String()
 	_ = l.Close()
-	store = rbac.NewStore(rbacNetworkPolicy(t))
+	store = rbac.NewStore(rbacNetworkPolicy(t), log.NewNoOpLogger())
 	srv := NewServer(addr, 0, nil, rbacTestHandler(store), log.NewNoOpLogger(), nil, "", store)
 	go func() { _ = srv.ListenAndServe() }()
 	t.Cleanup(func() {

--- a/internal/network/role_test.go
+++ b/internal/network/role_test.go
@@ -259,7 +259,7 @@ func startRBACNetworkServer(t *testing.T) (addr string, store *rbac.Store) {
 	addr = l.Addr().String()
 	_ = l.Close()
 	store = rbac.NewStore(rbacNetworkPolicy(t), log.NewNoOpLogger())
-	srv := NewServer(addr, 0, nil, rbacTestHandler(store), log.NewNoOpLogger(), nil, "", store)
+	srv := NewServer(addr, 0, nil, rbacTestHandler(store), log.NewNoOpLogger(), nil, "", store, newNoOpAudit())
 	go func() { _ = srv.ListenAndServe() }()
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)

--- a/internal/network/server.go
+++ b/internal/network/server.go
@@ -213,13 +213,30 @@ func (s *Server) OnOpen(c gnet.Conn) (out []byte, action gnet.Action) {
 		st.readBuf = make([]byte, 0, 4096)
 	}
 	c.SetContext(st)
+	if s.logger.Enabled(log.LevelDebug) {
+		s.logger.Log(log.LevelDebug, "network: client connected",
+			log.String("remote_addr", st.remoteAddr),
+			log.Uint64("shard_id", sid),
+		)
+	}
 	return nil, gnet.None
 }
 
 func (s *Server) OnClose(c gnet.Conn, err error) (action gnet.Action) {
 	atomic.AddUint64(&s.connectedClients, ^uint64(0))
-	if st, ok := c.Context().(*connState); ok && int(st.shardID) < len(s.shards) {
-		s.shards[st.shardID].DecConnectedClients()
+	var remoteAddr string
+	if st, ok := c.Context().(*connState); ok {
+		remoteAddr = st.remoteAddr
+		if int(st.shardID) < len(s.shards) {
+			s.shards[st.shardID].DecConnectedClients()
+		}
+	}
+	if s.logger.Enabled(log.LevelDebug) {
+		fields := []log.Field{log.String("remote_addr", remoteAddr)}
+		if err != nil {
+			fields = append(fields, log.String("error", err.Error()))
+		}
+		s.logger.Log(log.LevelDebug, "network: client disconnected", fields...)
 	}
 	return gnet.None
 }
@@ -385,10 +402,23 @@ func (s *Server) gateMessage(c gnet.Conn, st *connState, msg *Message) (respType
 		return result.respType, result.respPayload, true, false
 	}
 	if !st.authenticated && msg.Type != MsgPing {
+		if s.logger.Enabled(log.LevelWarn) {
+			s.logger.Log(log.LevelWarn, "network: command rejected, client not authenticated",
+				log.String("remote_addr", st.remoteAddr),
+				log.String("command", msg.Op.String()),
+			)
+		}
 		return MsgAuthErr, ResponseAuthErr, true, false
 	}
 	if s.policy != nil && !s.opAuthorized(*msg, st) {
 		s.policy.IncDenied()
+		if s.logger.Enabled(log.LevelWarn) {
+			s.logger.Log(log.LevelWarn, "network: command denied by rbac policy",
+				log.String("remote_addr", st.remoteAddr),
+				log.String("command", msg.Op.String()),
+				log.String("key", string(msg.Key)),
+			)
+		}
 		return MsgError, ResponseNotAuthorized, true, false
 	}
 	return 0, nil, false, false
@@ -617,6 +647,11 @@ func (s *Server) dispatchAuth(c gnet.Conn, username, reason string, password, pa
 	case s.authJobs <- authJob{c: c, password: password, passHash: passHash, session: session, username: username, reason: reason}:
 		return true
 	default:
+		if s.logger.Enabled(log.LevelWarn) {
+			s.logger.Log(log.LevelWarn, "network: auth worker pool saturated, rejecting AUTH",
+				log.String("remote_addr", c.RemoteAddr().String()),
+			)
+		}
 		return false
 	}
 }
@@ -629,6 +664,8 @@ func (s *Server) opAuthorized(msg Message, st *connState) bool {
 	switch msg.Type {
 	case MsgPing, MsgAuth:
 		return true
+	default:
+		break
 	}
 	if st.session == nil {
 		return false

--- a/internal/network/server.go
+++ b/internal/network/server.go
@@ -119,7 +119,16 @@ type Server struct {
 // otherwise AUTH resolves per-user credentials and sessions gate data ops.
 // audit is the shared audit engine; it must be non-nil (pass a disabled engine when
 // audit logging is off) and is always called without a nil guard.
-func NewServer(addr string, maxMsgSize uint64, shards []*shard.Shard, handler func(msg *Message) ([]byte, MessageType, error), logger log.Logger, tlsConfigs *tlslib.ConfigStore, requirePass string, policy *rbac.Store, audit *audit.LogEngine) *Server {
+func NewServer(
+	addr string,
+	maxMsgSize uint64,
+	shards []*shard.Shard,
+	handler func(msg *Message) ([]byte, MessageType, error),
+	logger log.Logger,
+	tlsConfigs *tlslib.ConfigStore,
+	requirePass string,
+	policy *rbac.Store,
+	audit *audit.LogEngine) *Server {
 	if logger == nil {
 		logger = log.NewNoOpLogger()
 	}
@@ -435,11 +444,10 @@ func (s *Server) gateMessage(c gnet.Conn, st *connState, msg *Message) (respType
 		if st.session != nil {
 			user = st.session.Username
 		}
-		keyStr := string(msg.Key)
 		s.audit.Record(audit.EventACLDeny, "command denied by rbac policy",
 			log.String("user", user),
 			log.String("command", msg.Op.String()),
-			log.String("key", keyStr),
+			log.String("key", string(msg.Key)),
 			log.String("remote_addr", st.remoteAddr),
 			log.String("protocol", "binary"),
 		)
@@ -447,7 +455,7 @@ func (s *Server) gateMessage(c gnet.Conn, st *connState, msg *Message) (respType
 			s.logger.Log(log.LevelWarn, "network: command denied by rbac policy",
 				log.String("remote_addr", st.remoteAddr),
 				log.String("command", msg.Op.String()),
-				log.String("key", keyStr),
+				log.String("key", string(msg.Key)),
 			)
 		}
 		return MsgError, ResponseNotAuthorized, true, false

--- a/internal/network/server.go
+++ b/internal/network/server.go
@@ -17,7 +17,9 @@ import (
 	"io"
 	"sync"
 	"sync/atomic"
+	"unsafe"
 
+	"github.com/Saxy/Tellstone/internal/audit"
 	"github.com/Saxy/Tellstone/internal/log"
 	"github.com/Saxy/Tellstone/internal/rbac"
 	"github.com/Saxy/Tellstone/internal/shard"
@@ -97,6 +99,11 @@ type Server struct {
 	// per-user bcrypt hashes and every data op is gated by the session.
 	policy *rbac.Store
 
+	// audit is the shared audit engine. Always non-nil: without --enable-audit
+	// it is a disabled no-op whose Record() costs one bool comparison, so the
+	// hooks below call it without a nil guard.
+	audit *audit.LogEngine
+
 	authJobs chan authJob
 	workerWg sync.WaitGroup
 }
@@ -110,7 +117,9 @@ type Server struct {
 // otherwise it is hashed at startup and clients must AUTH before issuing data commands.
 // policy is optional — if nil, RBAC is disabled and every authenticated op is allowed;
 // otherwise AUTH resolves per-user credentials and sessions gate data ops.
-func NewServer(addr string, maxMsgSize uint64, shards []*shard.Shard, handler func(msg *Message) ([]byte, MessageType, error), logger log.Logger, tlsConfigs *tlslib.ConfigStore, requirePass string, policy *rbac.Store) *Server {
+// audit is the shared audit engine; it must be non-nil (pass a disabled engine when
+// audit logging is off) and is always called without a nil guard.
+func NewServer(addr string, maxMsgSize uint64, shards []*shard.Shard, handler func(msg *Message) ([]byte, MessageType, error), logger log.Logger, tlsConfigs *tlslib.ConfigStore, requirePass string, policy *rbac.Store, audit *audit.LogEngine) *Server {
 	if logger == nil {
 		logger = log.NewNoOpLogger()
 	}
@@ -141,6 +150,7 @@ func NewServer(addr string, maxMsgSize uint64, shards []*shard.Shard, handler fu
 		shards:          shards,
 		requirePassHash: passHash,
 		policy:          policy,
+		audit:           audit,
 	}
 	if passHash != nil || policy != nil {
 		s.authJobs = make(chan authJob, 256)
@@ -213,6 +223,11 @@ func (s *Server) OnOpen(c gnet.Conn) (out []byte, action gnet.Action) {
 		st.readBuf = make([]byte, 0, 4096)
 	}
 	c.SetContext(st)
+	s.audit.Record(audit.EventConnect, "client connected",
+		log.String("remote_addr", st.remoteAddr),
+		log.String("protocol", "binary"),
+		log.Uint64("shard_id", sid),
+	)
 	if s.logger.Enabled(log.LevelDebug) {
 		s.logger.Log(log.LevelDebug, "network: client connected",
 			log.String("remote_addr", st.remoteAddr),
@@ -231,6 +246,10 @@ func (s *Server) OnClose(c gnet.Conn, err error) (action gnet.Action) {
 			s.shards[st.shardID].DecConnectedClients()
 		}
 	}
+	s.audit.Record(audit.EventDisconnect, "client disconnected",
+		log.String("remote_addr", remoteAddr),
+		log.String("protocol", "binary"),
+	)
 	if s.logger.Enabled(log.LevelDebug) {
 		fields := []log.Field{log.String("remote_addr", remoteAddr)}
 		if err != nil {
@@ -412,11 +431,23 @@ func (s *Server) gateMessage(c gnet.Conn, st *connState, msg *Message) (respType
 	}
 	if s.policy != nil && !s.opAuthorized(*msg, st) {
 		s.policy.IncDenied()
+		user := ""
+		if st.session != nil {
+			user = st.session.Username
+		}
+		keyStr := string(msg.Key)
+		s.audit.Record(audit.EventACLDeny, "command denied by rbac policy",
+			log.String("user", user),
+			log.String("command", msg.Op.String()),
+			log.String("key", keyStr),
+			log.String("remote_addr", st.remoteAddr),
+			log.String("protocol", "binary"),
+		)
 		if s.logger.Enabled(log.LevelWarn) {
 			s.logger.Log(log.LevelWarn, "network: command denied by rbac policy",
 				log.String("remote_addr", st.remoteAddr),
 				log.String("command", msg.Op.String()),
-				log.String("key", string(msg.Key)),
+				log.String("key", keyStr),
 			)
 		}
 		return MsgError, ResponseNotAuthorized, true, false
@@ -436,6 +467,22 @@ func (s *Server) runHandler(w io.Writer, st *connState, msg *Message, respType M
 		if s.policy != nil && st.session != nil && msg.Type != MsgPing {
 			st.session.CountCommand()
 		}
+		// The key is converted zero-copy (aliasing the gnet buffer) and consumed
+		// synchronously by the encoder, mirroring the dispatch path in server.go.
+		// The unsafe string holds a slice header over the buffer that stays valid
+		// until the frame is discarded below.
+		keyStr := *(*string)(unsafe.Pointer(&msg.Key))
+		user := "default"
+		if st.session != nil {
+			user = st.session.Username
+		}
+		s.audit.Record(audit.EventCommand, "command dispatched",
+			log.String("command", msg.Op.String()),
+			log.String("key", keyStr),
+			log.String("user", user),
+			log.String("remote_addr", st.remoteAddr),
+			log.String("protocol", "binary"),
+		)
 		var err error
 		respPayload, respType, err = s.handler(msg)
 		if err != nil {
@@ -485,12 +532,18 @@ func (s *Server) discardFrame(c gnet.Conn, totalPacketLen int) {
 	}
 }
 
-// authFailed logs a rejected AUTH attempt, increments the per-connection fail
-// counter, and marks the connection for closure when the rate limit is exceeded.
-// The store-wide ACL counter and log entry are recorded by the caller via
-// LogAuthFailure, which carries the username and reason.
-func (s *Server) authFailed(st *connState) []byte {
+// authFailed logs a rejected AUTH attempt to the audit trail, increments the
+// per-connection fail counter, and marks the connection for closure when the
+// rate limit is exceeded. The store-wide ACL counter and log entry are recorded
+// by the caller via LogAuthFailure, which carries the username and reason.
+func (s *Server) authFailed(st *connState, username, reason string) []byte {
 	st.authFails++
+	s.audit.Record(audit.EventAuthFailure, "authentication failed",
+		log.String("user", username),
+		log.String("remote_addr", st.remoteAddr),
+		log.String("reason", reason),
+		log.String("protocol", "binary"),
+	)
 	if s.logger.Enabled(log.LevelWarn) {
 		s.logger.Log(log.LevelWarn, "network: failed AUTH attempt",
 			log.String("remote_addr", st.remoteAddr),
@@ -529,7 +582,7 @@ func (s *Server) handleAuthMessage(c gnet.Conn, st *connState, value []byte) aut
 		if s.policy != nil {
 			s.policy.LogAuthFailure("", st.remoteAddr, "malformed request")
 		}
-		return authResult{respPayload: s.authFailed(st), respType: MsgAuthErr}
+		return authResult{respPayload: s.authFailed(st, "", "malformed request"), respType: MsgAuthErr}
 	}
 	var (
 		passHash []byte
@@ -551,7 +604,7 @@ func (s *Server) handleAuthMessage(c gnet.Conn, st *connState, value []byte) aut
 			// Unknown usernames fail synchronously; the worker only records
 			// failures for real users, so log the attempt here for ACL LOG.
 			s.policy.LogAuthFailure(name, st.remoteAddr, "unknown user")
-			return authResult{respPayload: s.authFailed(st), respType: MsgAuthErr}
+			return authResult{respPayload: s.authFailed(st, name, "unknown user"), respType: MsgAuthErr}
 		}
 		// Empty hash marks a nopass user that accepts any password (Redis
 		// ACL semantics). The session is built from the same snapshot that
@@ -562,7 +615,7 @@ func (s *Server) handleAuthMessage(c gnet.Conn, st *connState, value []byte) aut
 		reason = "invalid password"
 	} else {
 		if len(username) > 0 && string(username) != "default" {
-			return authResult{respPayload: s.authFailed(st), respType: MsgAuthErr}
+			return authResult{respPayload: s.authFailed(st, string(username), "unknown user"), respType: MsgAuthErr}
 		}
 		passHash = s.requirePassHash
 	}
@@ -596,6 +649,17 @@ func (s *Server) authWorker() {
 			if success {
 				st.authenticated = true
 				st.session = job.session
+				// Single-password mode never sets job.username; the implicit
+				// identity there is "default", mirroring the AUTH payload rule.
+				user := job.username
+				if user == "" {
+					user = "default"
+				}
+				s.audit.Record(audit.EventAuthSuccess, "client authenticated",
+					log.String("user", user),
+					log.String("remote_addr", st.remoteAddr),
+					log.String("protocol", "binary"),
+				)
 				respPayload, respType = ResponseOK, MsgAuthOk
 				if s.logger.Enabled(log.LevelDebug) {
 					s.logger.Log(log.LevelDebug, "network: client authenticated",
@@ -608,7 +672,7 @@ func (s *Server) authWorker() {
 				if s.policy != nil {
 					s.policy.LogAuthFailure(job.username, st.remoteAddr, job.reason)
 				}
-				respPayload, respType = s.authFailed(st), MsgAuthErr
+				respPayload, respType = s.authFailed(st, job.username, job.reason), MsgAuthErr
 			}
 			var writeErr error
 			if st.tlsConn != nil {

--- a/internal/network/server_test.go
+++ b/internal/network/server_test.go
@@ -13,9 +13,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Saxy/Tellstone/internal/audit"
+	"github.com/Saxy/Tellstone/internal/crypto"
 	"github.com/Saxy/Tellstone/internal/log"
 	tlslib "github.com/Saxy/Tellstone/internal/tls"
 )
+
+// newNoOpAudit returns a disabled audit engine so listener tests exercise the
+// unguarded Record() hooks with zero audit output.
+func newNoOpAudit() *audit.LogEngine {
+	return audit.NewLogEngine(false, nil, "stdout", log.NewNoOpLogger(), crypto.Engine{})
+}
 
 // fakeStore is a minimal in-memory key-value store for testing binary protocol handlers.
 type fakeStore struct {
@@ -123,7 +131,7 @@ func TestServerEcho(t *testing.T) {
 		}
 		return nil, 0, nil
 	}
-	srv := NewServer(addr, 0, nil, handler, log.NewNoOpLogger(), nil, "", nil)
+	srv := NewServer(addr, 0, nil, handler, log.NewNoOpLogger(), nil, "", nil, newNoOpAudit())
 	go func() { _ = srv.ListenAndServe() }()
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -196,7 +204,7 @@ func TestServerTLSConfigRotation(t *testing.T) {
 	}
 	addr := listener.Addr().String()
 	_ = listener.Close()
-	srv := NewServer(addr, 0, nil, pingHandler, log.NewNoOpLogger(), configs, "", nil)
+	srv := NewServer(addr, 0, nil, pingHandler, log.NewNoOpLogger(), configs, "", nil, newNoOpAudit())
 	go func() { _ = srv.ListenAndServe() }()
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -260,7 +268,7 @@ func startAuthServer(t *testing.T, requirePass string, handler func(msg *Message
 	}
 	addr := l.Addr().String()
 	l.Close()
-	srv := NewServer(addr, 0, nil, handler, log.NewNoOpLogger(), nil, requirePass, nil)
+	srv := NewServer(addr, 0, nil, handler, log.NewNoOpLogger(), nil, requirePass, nil, newNoOpAudit())
 	go func() { _ = srv.ListenAndServe() }()
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)

--- a/internal/persistence/persistence.go
+++ b/internal/persistence/persistence.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -53,7 +54,7 @@ type Storage struct {
 }
 
 // NewStorage creates a new persistence Storage. If enabled is false, a pass-through
-// (no-op) instance is returned. If dir is empty, the platform-specific default is used.
+// (no-op) instance is returned. If the dir is empty, the platform-specific default is used.
 // Returns an error if enabled is true and the data directory cannot be created.
 func NewStorage(enabled bool, logger log.Logger, dir string) (*Storage, error) {
 	if logger == nil {
@@ -110,7 +111,7 @@ func (s *Storage) getShard(shardID uint32) *shardHandle {
 	return h
 }
 
-// appendRecord is the shared write path for both SET and tombstone records.
+// appendRecord is the shared writing path for both SET and tombstone records.
 // It acquires the shard mutex, writes the header, key, value, and syncs.
 func (s *Storage) appendRecord(shardID uint32, header [16]byte, key string, value []byte, op string) error {
 	h := s.getShard(shardID)
@@ -152,7 +153,7 @@ func (s *Storage) appendRecord(shardID uint32, header [16]byte, key string, valu
 
 // Write appends a SET record to the shard's WAL file. The record includes a
 // 16-byte header (key length, value length, TTL), followed by key and value bytes.
-// The write and trailing Sync are serialized under the shard's own mutex.
+// The writing and trailing Sync are serialized under the shard's own mutex.
 // Returns nil immediately when persistence is disabled.
 func (s *Storage) Write(shardID uint32, key string, value []byte, ttl time.Time) error {
 	if !s.enabled {
@@ -245,7 +246,7 @@ func (s *Storage) OpenShard(shardID uint32) error {
 
 // LoadShard replays all records from the shard's WAL file into the given engine,
 // skipping expired keys and applying tombstones as deletions. Truncated records
-// from a crash mid-write are detected and the WAL is truncated to the last valid
+// from a crash mid-write are detected, and the WAL is truncated to the last valid
 // offset so future loads resume from a clean end.
 func (s *Storage) LoadShard(shardID uint32, engine *storage.Engine) error {
 	h := s.getShard(shardID)
@@ -292,14 +293,14 @@ func (s *Storage) LoadShard(shardID uint32, engine *storage.Engine) error {
 		}
 		keyBuf := make([]byte, keyLen)
 		if _, err = io.ReadFull(f, keyBuf); err != nil {
-			if err == io.EOF || err == io.ErrUnexpectedEOF {
+			if err == io.EOF || errors.Is(err, io.ErrUnexpectedEOF) {
 				break
 			}
 			return fmt.Errorf("persistence: read key: %w", err)
 		}
 		valBuf := make([]byte, valLen)
 		if _, err = io.ReadFull(f, valBuf); err != nil {
-			if err == io.EOF || err == io.ErrUnexpectedEOF {
+			if err == io.EOF || errors.Is(err, io.ErrUnexpectedEOF) {
 				break
 			}
 			return fmt.Errorf("persistence: read value: %w", err)

--- a/internal/persistence/persistence.go
+++ b/internal/persistence/persistence.go
@@ -293,14 +293,14 @@ func (s *Storage) LoadShard(shardID uint32, engine *storage.Engine) error {
 		}
 		keyBuf := make([]byte, keyLen)
 		if _, err = io.ReadFull(f, keyBuf); err != nil {
-			if err == io.EOF || errors.Is(err, io.ErrUnexpectedEOF) {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 				break
 			}
 			return fmt.Errorf("persistence: read key: %w", err)
 		}
 		valBuf := make([]byte, valLen)
 		if _, err = io.ReadFull(f, valBuf); err != nil {
-			if err == io.EOF || errors.Is(err, io.ErrUnexpectedEOF) {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 				break
 			}
 			return fmt.Errorf("persistence: read value: %w", err)
@@ -337,7 +337,7 @@ func (s *Storage) LoadShard(shardID uint32, engine *storage.Engine) error {
 	}
 	if validOffset < fileSize {
 		h.mu.Lock()
-		if err := f.Truncate(validOffset); err != nil {
+		if err = f.Truncate(validOffset); err != nil {
 			h.mu.Unlock()
 			if s.logger.Enabled(log.LevelWarn) {
 				s.logger.Log(log.LevelWarn, "persistence: failed to truncate corrupted tail",

--- a/internal/rbac/log_test.go
+++ b/internal/rbac/log_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/Saxy/Tellstone/internal/log"
 )
 
 // itoa is a tiny alias so the eviction test's expected usernames read clearly.
@@ -13,7 +15,7 @@ func itoa(i int) string { return strconv.Itoa(i) }
 // TestACLLogOrder verifies the auth-failure buffer returns entries in
 // chronological order and that overflowing it evicts the oldest entries.
 func TestACLLogOrder(t *testing.T) {
-	s := NewStore(&PolicyStore{})
+	s := NewStore(&PolicyStore{}, log.NewNoOpLogger())
 	for i := 0; i < 5; i++ {
 		s.LogAuthFailure("alice", "1.2.3.4:5", "invalid password")
 	}
@@ -37,7 +39,7 @@ func TestACLLogOrder(t *testing.T) {
 // TestACLLogEviction overflows the default capacity and verifies the oldest
 // entries are dropped while order is preserved and capacity stays bounded.
 func TestACLLogEviction(t *testing.T) {
-	s := NewStore(&PolicyStore{})
+	s := NewStore(&PolicyStore{}, log.NewNoOpLogger())
 	total := DefaultAuthLogCap + 7
 	for i := 0; i < total; i++ {
 		s.LogAuthFailure("u"+itoa(i), "addr", "reason")
@@ -61,7 +63,7 @@ func TestACLLogEviction(t *testing.T) {
 
 // TestACLLogEmpty verifies an untouched store reports no entries.
 func TestACLLogEmpty(t *testing.T) {
-	s := NewStore(&PolicyStore{})
+	s := NewStore(&PolicyStore{}, log.NewNoOpLogger())
 	if entries := s.AuthLog(); entries != nil {
 		t.Fatalf("AuthLog = %v, want nil", entries)
 	}
@@ -70,7 +72,7 @@ func TestACLLogEmpty(t *testing.T) {
 // TestACLLogConcurrent exercises the mutex-protected buffer from many
 // goroutines; run with -race to prove no data race on append/read.
 func TestACLLogConcurrent(t *testing.T) {
-	s := NewStore(&PolicyStore{})
+	s := NewStore(&PolicyStore{}, log.NewNoOpLogger())
 	var wg sync.WaitGroup
 	for g := 0; g < 8; g++ {
 		wg.Add(1)

--- a/internal/rbac/manager.go
+++ b/internal/rbac/manager.go
@@ -12,7 +12,11 @@ Authors:
 */
 package rbac
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/Saxy/Tellstone/internal/log"
+)
 
 // CreateRole adds a role built from rule tokens (+GET, +@read, ~prefix).
 // Fails when the role already exists or the rules are invalid. Existing
@@ -36,6 +40,9 @@ func (s *Store) CreateRole(name string, rules []string) error {
 	}
 	p.Roles[name] = role
 	s.Store(p)
+	if s.logger.Enabled(log.LevelInfo) {
+		s.logger.Log(log.LevelInfo, "rbac: role created", log.String("role", name))
+	}
 	return nil
 }
 
@@ -59,6 +66,12 @@ func (s *Store) SetUser(username, roleName string, passHash []byte) error {
 	}
 	p.Users[username] = &User{Role: roleName, PasswordHash: passHash}
 	s.Store(p)
+	if s.logger.Enabled(log.LevelInfo) {
+		s.logger.Log(log.LevelInfo, "rbac: user set",
+			log.String("username", username),
+			log.String("role", roleName),
+		)
+	}
 	return nil
 }
 
@@ -84,6 +97,9 @@ func (s *Store) DelUser(username string) error {
 	p = p.Clone()
 	delete(p.Users, username)
 	s.Store(p)
+	if s.logger.Enabled(log.LevelInfo) {
+		s.logger.Log(log.LevelInfo, "rbac: user deleted", log.String("username", username))
+	}
 	return nil
 }
 
@@ -123,5 +139,8 @@ func (s *Store) DeleteRole(name string) error {
 	}
 	delete(p.Roles, name)
 	s.Store(p)
+	if s.logger.Enabled(log.LevelInfo) {
+		s.logger.Log(log.LevelInfo, "rbac: role deleted", log.String("role", name))
+	}
 	return nil
 }

--- a/internal/rbac/manager.go
+++ b/internal/rbac/manager.go
@@ -89,10 +89,14 @@ func (s *Store) DelUser(username string) error {
 	if p == nil {
 		return nil
 	}
-	if _, ok := p.Users[username]; ok {
-		if r := p.RoleFor(username); r != nil && r.Permissions.Has(CmdACL) && !p.hasOtherAdmin(username) {
-			return fmt.Errorf("rbac: cannot delete %q: last user with ACL management rights", username)
-		}
+	if _, ok := p.Users[username]; !ok {
+		// Unknown user: nothing to delete. Return before cloning, republishing,
+		// or logging so an absent name never fakes a deletion event against an
+		// unchanged policy.
+		return nil
+	}
+	if r := p.RoleFor(username); r != nil && r.Permissions.Has(CmdACL) && !p.hasOtherAdmin(username) {
+		return fmt.Errorf("rbac: cannot delete %q: last user with ACL management rights", username)
 	}
 	p = p.Clone()
 	delete(p.Users, username)

--- a/internal/rbac/manager_test.go
+++ b/internal/rbac/manager_test.go
@@ -14,6 +14,18 @@ import (
 	"github.com/Saxy/Tellstone/internal/log"
 )
 
+// recordingLogger captures every Log call so tests can assert on the exact set
+// of events emitted (or not emitted) by the Store mutation helpers.
+type recordingLogger struct {
+	msgs []string
+}
+
+func (r *recordingLogger) Enabled(level log.Level) bool { return true }
+
+func (r *recordingLogger) Log(level log.Level, msg string, fields ...log.Field) {
+	r.msgs = append(r.msgs, msg)
+}
+
 func TestStoreCreateRole(t *testing.T) {
 	store := NewStore(&PolicyStore{Roles: map[string]*Role{}, Users: map[string]*User{}}, log.NewNoOpLogger())
 	if err := store.CreateRole("reader", []string{"+@read", "~*"}); err != nil {
@@ -70,6 +82,52 @@ func TestStoreDelUserAndDeleteRole(t *testing.T) {
 	}
 	if store.Load().UserFor("alice") != nil {
 		t.Fatal("deleted user must be gone")
+	}
+}
+
+func TestStoreDelUserAbsentUserLogsNothing(t *testing.T) {
+	rec := &recordingLogger{}
+	store := NewStore(&PolicyStore{Roles: map[string]*Role{}, Users: map[string]*User{}}, rec)
+	snapshot := store.Load()
+
+	if err := store.DelUser("ghost"); err != nil {
+		t.Fatalf("DelUser on an absent user must succeed as a no-op: %v", err)
+	}
+	// No republish: Load must return the exact snapshot published before the call.
+	if store.Load() != snapshot {
+		t.Fatal("absent-user DelUser must not republish the policy")
+	}
+	for _, msg := range rec.msgs {
+		if msg == "rbac: user deleted" {
+			t.Fatal("absent-user DelUser must not emit a deletion event")
+		}
+	}
+
+	// Contrast: deleting an existing user still republishes and logs, so the
+	// early return above only short-circuits the genuinely absent case.
+	rec2 := &recordingLogger{}
+	role, err := ParseRole("r", "+GET")
+	if err != nil {
+		t.Fatalf("ParseRole: %v", err)
+	}
+	store2 := NewStore(&PolicyStore{
+		Roles: map[string]*Role{"r": role},
+		Users: map[string]*User{"alice": {Role: "r"}},
+	}, rec2)
+	if err := store2.DelUser("alice"); err != nil {
+		t.Fatalf("DelUser on an existing user: %v", err)
+	}
+	if store2.Load().UserFor("alice") != nil {
+		t.Fatal("existing user must be deleted")
+	}
+	seen := false
+	for _, msg := range rec2.msgs {
+		if msg == "rbac: user deleted" {
+			seen = true
+		}
+	}
+	if !seen {
+		t.Fatal("deleting an existing user must still emit the deletion event")
 	}
 }
 

--- a/internal/rbac/manager_test.go
+++ b/internal/rbac/manager_test.go
@@ -8,10 +8,14 @@ visible to later Load calls while never mutating the previously published snapsh
 */
 package rbac
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/Saxy/Tellstone/internal/log"
+)
 
 func TestStoreCreateRole(t *testing.T) {
-	store := NewStore(&PolicyStore{Roles: map[string]*Role{}, Users: map[string]*User{}})
+	store := NewStore(&PolicyStore{Roles: map[string]*Role{}, Users: map[string]*User{}}, log.NewNoOpLogger())
 	if err := store.CreateRole("reader", []string{"+@read", "~*"}); err != nil {
 		t.Fatalf("CreateRole: %v", err)
 	}
@@ -27,7 +31,7 @@ func TestStoreCreateRole(t *testing.T) {
 }
 
 func TestStoreSetUserValidatesRole(t *testing.T) {
-	store := NewStore(&PolicyStore{Roles: map[string]*Role{}, Users: map[string]*User{}})
+	store := NewStore(&PolicyStore{Roles: map[string]*Role{}, Users: map[string]*User{}}, log.NewNoOpLogger())
 	_ = store.CreateRole("reader", []string{"+@read"})
 	if err := store.SetUser("alice", "reader", []byte("hash")); err != nil {
 		t.Fatalf("SetUser: %v", err)
@@ -42,7 +46,7 @@ func TestStoreSetUserValidatesRole(t *testing.T) {
 }
 
 func TestStoreDelUserAndDeleteRole(t *testing.T) {
-	store := NewStore(&PolicyStore{Roles: map[string]*Role{}, Users: map[string]*User{}})
+	store := NewStore(&PolicyStore{Roles: map[string]*Role{}, Users: map[string]*User{}}, log.NewNoOpLogger())
 	_ = store.CreateRole("r", []string{"+GET"})
 	_ = store.SetUser("alice", "r", nil)
 
@@ -86,7 +90,7 @@ func TestStoreDelUserLastAdminGuard(t *testing.T) {
 			"limited": {Role: "limited"},
 		},
 		Default: limited,
-	})
+	}, log.NewNoOpLogger())
 
 	// Deleting the last user whose effective role grants CmdACL is rejected.
 	if err := store.DelUser("admin"); err == nil {
@@ -122,7 +126,7 @@ func TestStoreDeleteRoleClearsDefault(t *testing.T) {
 		Roles:   map[string]*Role{"r": role},
 		Users:   map[string]*User{"alice": {Role: "r"}},
 		Default: role,
-	})
+	}, log.NewNoOpLogger())
 	if err := store.DeleteRole("r"); err != nil {
 		t.Fatalf("DeleteRole: %v", err)
 	}
@@ -136,7 +140,7 @@ func TestStoreDeleteRoleClearsDefault(t *testing.T) {
 }
 
 func TestStoreMutationsDoNotMutatePublishedSnapshot(t *testing.T) {
-	store := NewStore(&PolicyStore{Roles: map[string]*Role{}, Users: map[string]*User{}})
+	store := NewStore(&PolicyStore{Roles: map[string]*Role{}, Users: map[string]*User{}}, log.NewNoOpLogger())
 	_ = store.CreateRole("r", []string{"+GET"})
 	snapshot := store.Load()
 	_ = store.CreateRole("s", []string{"+SET"})

--- a/internal/rbac/policy.go
+++ b/internal/rbac/policy.go
@@ -14,6 +14,8 @@ package rbac
 import (
 	"sync"
 	"sync/atomic"
+
+	"github.com/Saxy/Tellstone/internal/log"
 )
 
 // PolicyStore is an immutable snapshot of the authorization state: role
@@ -88,6 +90,10 @@ func (p *PolicyStore) Clone() *PolicyStore {
 type Store struct {
 	active atomic.Pointer[PolicyStore]
 	mu     sync.Mutex
+	// logger reports policy mutations (CreateRole, SetUser, DelUser, DeleteRole)
+	// so operators see admin changes in the server log. Set via NewStore; nil
+	// falls back to the no-op logger so RBAC never depends on logging being on.
+	logger log.Logger
 	// authFailures counts rejected AUTH attempts, deniedCommands counts
 	// authorization-denied command attempts. Unlike the per-role command
 	// counter, both are store-wide: a denial can happen without a pinned role
@@ -103,10 +109,15 @@ type Store struct {
 	logLen  int            // number of valid entries
 }
 
-// NewStore returns a Store seeded with policy.
-func NewStore(policy *PolicyStore) *Store {
+// NewStore returns a Store seeded with policy. A nil logger falls back to the
+// no-op logger, so RBAC keeps working with logging disabled.
+func NewStore(policy *PolicyStore, logger log.Logger) *Store {
 	s := new(Store)
 	s.active.Store(policy)
+	if logger == nil {
+		logger = log.NewNoOpLogger()
+	}
+	s.logger = logger
 	return s
 }
 

--- a/internal/rbac/policy_test.go
+++ b/internal/rbac/policy_test.go
@@ -6,7 +6,11 @@ Description: Verifies user→role resolution (explicit, default, fail-closed) an
 */
 package rbac
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/Saxy/Tellstone/internal/log"
+)
 
 func TestPolicyStoreRoleFor(t *testing.T) {
 	readonly, err := ParseRole("readonly", "+@read")
@@ -42,7 +46,7 @@ func TestStoreAtomicSwap(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseRole v2: %v", err)
 	}
-	store := NewStore(&PolicyStore{Roles: map[string]*Role{"v1": v1}})
+	store := NewStore(&PolicyStore{Roles: map[string]*Role{"v1": v1}}, log.NewNoOpLogger())
 	if got := store.Load().Roles["v1"]; got != v1 {
 		t.Fatal("initial policy must be visible")
 	}

--- a/internal/rbac/session_test.go
+++ b/internal/rbac/session_test.go
@@ -6,7 +6,11 @@ Description: Verifies the SessionContext hot path: command + namespace checks, f
 */
 package rbac
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/Saxy/Tellstone/internal/log"
+)
 
 func TestSessionContextIsAllowed(t *testing.T) {
 	role, err := ParseRole("readonly", "+@read")
@@ -58,7 +62,7 @@ func TestSessionPinnedAcrossPolicySwap(t *testing.T) {
 	store := NewStore(&PolicyStore{
 		Roles: map[string]*Role{"old": oldRole, "new": newRole},
 		Users: map[string]*User{"alice": {Role: "old"}},
-	})
+	}, log.NewNoOpLogger())
 
 	session := NewSessionContext("alice", store.Load().RoleFor("alice"))
 	store.Store(&PolicyStore{

--- a/internal/resp/acl_test.go
+++ b/internal/resp/acl_test.go
@@ -15,7 +15,7 @@ func startACLServer(t *testing.T) (addr string, store *rbac.Store) {
 	t.Helper()
 	addr = freeAddr(t)
 	store = rbac.NewStore(rbacTestPolicy(t), log.NewNoOpLogger())
-	srv := NewServer(addr, newFakeStore(), nil, log.NewNoOpLogger(), nil, "", false, store)
+	srv := NewServer(addr, newFakeStore(), nil, log.NewNoOpLogger(), nil, "", false, store, newNoOpAudit())
 	go func() { _ = srv.ListenAndServe() }()
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -29,7 +29,7 @@ func startACLServer(t *testing.T) (addr string, store *rbac.Store) {
 // when RBAC is disabled, mirroring the ROLE command's guard.
 func TestRESPServer_ACLNotEnabled(t *testing.T) {
 	addr := freeAddr(t)
-	srv := NewServer(addr, newFakeStore(), nil, log.NewNoOpLogger(), nil, "", false, nil)
+	srv := NewServer(addr, newFakeStore(), nil, log.NewNoOpLogger(), nil, "", false, nil, newNoOpAudit())
 	go func() { _ = srv.ListenAndServe() }()
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)

--- a/internal/resp/acl_test.go
+++ b/internal/resp/acl_test.go
@@ -14,7 +14,7 @@ import (
 func startACLServer(t *testing.T) (addr string, store *rbac.Store) {
 	t.Helper()
 	addr = freeAddr(t)
-	store = rbac.NewStore(rbacTestPolicy(t))
+	store = rbac.NewStore(rbacTestPolicy(t), log.NewNoOpLogger())
 	srv := NewServer(addr, newFakeStore(), nil, log.NewNoOpLogger(), nil, "", false, store)
 	go func() { _ = srv.ListenAndServe() }()
 	t.Cleanup(func() {

--- a/internal/resp/role_test.go
+++ b/internal/resp/role_test.go
@@ -44,7 +44,7 @@ func startRBACServer(t *testing.T) (addr string) {
 	t.Helper()
 	addr = freeAddr(t)
 	srv := NewServer(addr, newFakeStore(), nil, log.NewNoOpLogger(), nil, "", false,
-		rbac.NewStore(rbacTestPolicy(t)))
+		rbac.NewStore(rbacTestPolicy(t), log.NewNoOpLogger()))
 	go func() { _ = srv.ListenAndServe() }()
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -187,7 +187,7 @@ func TestRESPServer_RBACNamespacePrefix(t *testing.T) {
 // the per-role executed counter.
 func TestRESPServer_RBACMetrics(t *testing.T) {
 	addr := freeAddr(t)
-	store := rbac.NewStore(rbacTestPolicy(t))
+	store := rbac.NewStore(rbacTestPolicy(t), log.NewNoOpLogger())
 	srv := NewServer(addr, newFakeStore(), nil, log.NewNoOpLogger(), nil, "", false, store)
 	go func() { _ = srv.ListenAndServe() }()
 	t.Cleanup(func() {

--- a/internal/resp/role_test.go
+++ b/internal/resp/role_test.go
@@ -44,7 +44,7 @@ func startRBACServer(t *testing.T) (addr string) {
 	t.Helper()
 	addr = freeAddr(t)
 	srv := NewServer(addr, newFakeStore(), nil, log.NewNoOpLogger(), nil, "", false,
-		rbac.NewStore(rbacTestPolicy(t), log.NewNoOpLogger()))
+		rbac.NewStore(rbacTestPolicy(t), log.NewNoOpLogger()), newNoOpAudit())
 	go func() { _ = srv.ListenAndServe() }()
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -188,7 +188,7 @@ func TestRESPServer_RBACNamespacePrefix(t *testing.T) {
 func TestRESPServer_RBACMetrics(t *testing.T) {
 	addr := freeAddr(t)
 	store := rbac.NewStore(rbacTestPolicy(t), log.NewNoOpLogger())
-	srv := NewServer(addr, newFakeStore(), nil, log.NewNoOpLogger(), nil, "", false, store)
+	srv := NewServer(addr, newFakeStore(), nil, log.NewNoOpLogger(), nil, "", false, store, newNoOpAudit())
 	go func() { _ = srv.ListenAndServe() }()
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)

--- a/internal/resp/server.go
+++ b/internal/resp/server.go
@@ -258,13 +258,27 @@ func (s *Server) OnOpen(c gnet.Conn) (out []byte, action gnet.Action) {
 		st.handshakeDeadline = time.Now().Add(tlsHandshakeTimeout)
 	}
 	c.SetContext(st)
+	if s.logger.Enabled(log.LevelDebug) {
+		s.logger.Log(log.LevelDebug, "resp: client connected", log.String("remote_addr", st.remoteAddr))
+	}
 	return nil, gnet.None
 }
 
 func (s *Server) OnClose(c gnet.Conn, err error) (action gnet.Action) {
 	atomic.AddUint64(&s.connectedClients, ^uint64(0))
-	if st, ok := c.Context().(*connState); ok && st.shardID >= 0 && st.shardID < len(s.shards) {
-		s.shards[st.shardID].DecConnectedClients()
+	var remoteAddr string
+	if st, ok := c.Context().(*connState); ok {
+		remoteAddr = st.remoteAddr
+		if st.shardID >= 0 && st.shardID < len(s.shards) {
+			s.shards[st.shardID].DecConnectedClients()
+		}
+	}
+	if s.logger.Enabled(log.LevelDebug) {
+		fields := []log.Field{log.String("remote_addr", remoteAddr)}
+		if err != nil {
+			fields = append(fields, log.String("error", err.Error()))
+		}
+		s.logger.Log(log.LevelDebug, "resp: client disconnected", fields...)
 	}
 	return gnet.None
 }
@@ -550,6 +564,12 @@ func (s *Server) dispatch(st *connState, c gnet.Conn, args [][]byte, out []byte)
 		}
 		// Unauthenticated connections may only issue AUTH, PING, and QUIT (Redis semantics).
 		if !EqualFold(cmd, shard.CmdPing) && !EqualFold(cmd, "QUIT") {
+			if s.logger.Enabled(log.LevelWarn) {
+				s.logger.Log(log.LevelWarn, "resp: command rejected, client not authenticated",
+					log.String("remote_addr", st.remoteAddr),
+					log.String("command", string(cmd)),
+				)
+			}
 			return AppendError(out, "NOAUTH Authentication required"), false
 		}
 	}
@@ -559,8 +579,7 @@ func (s *Server) dispatch(st *connState, c gnet.Conn, args [][]byte, out []byte)
 			return AppendError(out, "ERR wrong number of arguments for 'get' command"), false
 		}
 		if !s.authorized(st, rbac.CmdGet, args[1]) {
-			s.countDenied()
-			return AppendError(out, "NOPERM no permission for 'get' command on this key"), false
+			return s.deniedReply(st, "get", false, out), false
 		}
 		s.countCommand(st)
 		key := *(*string)(unsafe.Pointer(&args[1]))
@@ -575,8 +594,7 @@ func (s *Server) dispatch(st *connState, c gnet.Conn, args [][]byte, out []byte)
 			return AppendError(out, "ERR wrong number of arguments for 'set' command"), false
 		}
 		if !s.authorized(st, rbac.CmdSet, args[1]) {
-			s.countDenied()
-			return AppendError(out, "NOPERM no permission for 'set' command on this key"), false
+			return s.deniedReply(st, "set", false, out), false
 		}
 		s.countCommand(st)
 		key := *(*string)(unsafe.Pointer(&args[1]))
@@ -595,8 +613,7 @@ func (s *Server) dispatch(st *connState, c gnet.Conn, args [][]byte, out []byte)
 		}
 		for _, k := range args[1:] {
 			if !s.authorized(st, rbac.CmdDel, k) {
-				s.countDenied()
-				return AppendError(out, "NOPERM no permission for 'del' command on this key"), false
+				return s.deniedReply(st, "del", false, out), false
 			}
 		}
 		s.countCommand(st)
@@ -623,16 +640,14 @@ func (s *Server) dispatch(st *connState, c gnet.Conn, args [][]byte, out []byte)
 
 	case EqualFold(cmd, shard.CmdRole):
 		if !s.authorizedCmd(st, rbac.CmdRole) {
-			s.countDenied()
-			return AppendError(out, "NOPERM no permission for 'role' command"), false
+			return s.deniedReply(st, "role", true, out), false
 		}
 		s.countCommand(st)
 		return s.role(st, args, out), false
 
 	case EqualFold(cmd, shard.CmdACL):
 		if !s.authorizedCmd(st, rbac.CmdACL) {
-			s.countDenied()
-			return AppendError(out, "NOPERM no permission for 'acl' command"), false
+			return s.deniedReply(st, "acl", true, out), false
 		}
 		s.countCommand(st)
 		return s.acl(st, args, out), false
@@ -683,6 +698,27 @@ func (s *Server) countDenied() {
 	if s.policy != nil {
 		s.policy.IncDenied()
 	}
+}
+
+// deniedReply records one RBAC denial (NOPERM) and logs the blocked command with
+// the pinned user identity so operators see who was denied. keyless omits the
+// key-scoped suffix from the reply (ROLE/ACL have no key scope).
+func (s *Server) deniedReply(st *connState, cmd string, keyless bool, out []byte) []byte {
+	s.countDenied()
+	if s.logger.Enabled(log.LevelWarn) {
+		fields := []log.Field{
+			log.String("remote_addr", st.remoteAddr),
+			log.String("command", cmd),
+		}
+		if st.session != nil {
+			fields = append(fields, log.String("username", st.session.Username))
+		}
+		s.logger.Log(log.LevelWarn, "resp: command denied by rbac policy", fields...)
+	}
+	if keyless {
+		return AppendError(out, "NOPERM no permission for '"+cmd+"' command")
+	}
+	return AppendError(out, "NOPERM no permission for '"+cmd+"' command on this key")
 }
 
 func (s *Server) dispatchSTARTTLS(st *connState, args [][]byte, out []byte) []byte {
@@ -758,6 +794,12 @@ func (s *Server) authRBAC(st *connState, c gnet.Conn, args [][]byte, out []byte)
 		// nopass user: authentication succeeds without any hashing.
 		st.authenticated = true
 		st.session = rbac.NewSessionContext(username, p.RoleFor(username))
+		if s.logger.Enabled(log.LevelDebug) {
+			s.logger.Log(log.LevelDebug, "resp: client authenticated",
+				log.String("remote_addr", st.remoteAddr),
+				log.String("username", username),
+			)
+		}
 		return append(out, respOK...), false
 	}
 	// The session is built from the same snapshot that yielded the hash; the
@@ -801,6 +843,11 @@ func (s *Server) dispatchAuth(c gnet.Conn, username, reason string, password, pa
 	case s.authJobs <- authJob{c: c, password: password, passHash: passHash, session: session, username: username, reason: reason}:
 		return true
 	default:
+		if s.logger.Enabled(log.LevelWarn) {
+			s.logger.Log(log.LevelWarn, "resp: auth worker pool saturated, rejecting AUTH",
+				log.String("remote_addr", c.RemoteAddr().String()),
+			)
+		}
 		return false
 	}
 }
@@ -825,6 +872,12 @@ func (s *Server) authWorker() {
 			if success {
 				st.authenticated = true
 				st.session = job.session
+				if s.logger.Enabled(log.LevelDebug) {
+					s.logger.Log(log.LevelDebug, "resp: client authenticated",
+						log.String("remote_addr", st.remoteAddr),
+						log.String("username", job.username),
+					)
+				}
 				reply = append(reply, respOK...)
 			} else {
 				reply = s.authFailed(st, job.username, job.reason, nil)

--- a/internal/resp/server.go
+++ b/internal/resp/server.go
@@ -25,6 +25,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/Saxy/Tellstone/internal/audit"
 	"github.com/Saxy/Tellstone/internal/log"
 	"github.com/Saxy/Tellstone/internal/rbac"
 	"github.com/Saxy/Tellstone/internal/shard"
@@ -131,6 +132,11 @@ type Server struct {
 	// consume authJobs off the event loop; workerWg lets Shutdown drain them.
 	authJobs chan authJob
 	workerWg sync.WaitGroup
+
+	// audit is the shared audit engine. Always non-nil: without --enable-audit
+	// it is a disabled no-op whose Record() costs one bool comparison, so the
+	// hooks below call it without a nil guard.
+	audit *audit.LogEngine
 }
 
 // NewServer creates a RESP server bound to addr that dispatches commands to store.
@@ -142,7 +148,9 @@ type Server struct {
 // startTLS keeps the RESP listener plaintext until a client successfully issues STARTTLS.
 // policy is optional — if nil, RBAC is disabled and every authenticated command is allowed;
 // otherwise AUTH resolves per-user credentials and sessions gate data commands.
-func NewServer(addr string, store Store, shards []*shard.Shard, logger log.Logger, tlsConfigs *tlslib.ConfigStore, requirePass string, startTLS bool, policy *rbac.Store) *Server {
+// audit is the shared audit engine; it must be non-nil (pass a disabled engine when
+// audit logging is off) and is always called without a nil guard.
+func NewServer(addr string, store Store, shards []*shard.Shard, logger log.Logger, tlsConfigs *tlslib.ConfigStore, requirePass string, startTLS bool, policy *rbac.Store, audit *audit.LogEngine) *Server {
 	if logger == nil {
 		logger = log.NewNoOpLogger()
 	}
@@ -166,6 +174,7 @@ func NewServer(addr string, store Store, shards []*shard.Shard, logger log.Logge
 		requirePassHash: passHash,
 		policy:          policy,
 		ready:           make(chan struct{}),
+		audit:           audit,
 	}
 	// The worker pool exists only when authentication is actually required, so
 	// the zero-overhead no-password path spawns no goroutines.
@@ -258,6 +267,11 @@ func (s *Server) OnOpen(c gnet.Conn) (out []byte, action gnet.Action) {
 		st.handshakeDeadline = time.Now().Add(tlsHandshakeTimeout)
 	}
 	c.SetContext(st)
+	s.audit.Record(audit.EventConnect, "client connected",
+		log.String("remote_addr", st.remoteAddr),
+		log.String("protocol", "resp"),
+		log.Int("shard_id", shardID),
+	)
 	if s.logger.Enabled(log.LevelDebug) {
 		s.logger.Log(log.LevelDebug, "resp: client connected", log.String("remote_addr", st.remoteAddr))
 	}
@@ -273,6 +287,10 @@ func (s *Server) OnClose(c gnet.Conn, err error) (action gnet.Action) {
 			s.shards[st.shardID].DecConnectedClients()
 		}
 	}
+	s.audit.Record(audit.EventDisconnect, "client disconnected",
+		log.String("remote_addr", remoteAddr),
+		log.String("protocol", "resp"),
+	)
 	if s.logger.Enabled(log.LevelDebug) {
 		fields := []log.Field{log.String("remote_addr", remoteAddr)}
 		if err != nil {
@@ -573,13 +591,30 @@ func (s *Server) dispatch(st *connState, c gnet.Conn, args [][]byte, out []byte)
 			return AppendError(out, "NOAUTH Authentication required"), false
 		}
 	}
+	// The command and key are converted zero-copy over the gnet buffer and
+	// consumed synchronously by the audit encoder before the buffer advances.
+	user := "default"
+	if st.session != nil {
+		user = st.session.Username
+	}
+	key := ""
+	if len(args) >= 2 {
+		key = *(*string)(unsafe.Pointer(&args[1]))
+	}
+	s.audit.Record(audit.EventCommand, "command dispatched",
+		log.String("command", *(*string)(unsafe.Pointer(&cmd))),
+		log.String("key", key),
+		log.String("user", user),
+		log.String("remote_addr", st.remoteAddr),
+		log.String("protocol", "resp"),
+	)
 	switch {
 	case EqualFold(cmd, shard.CmdGet):
 		if len(args) != 2 {
 			return AppendError(out, "ERR wrong number of arguments for 'get' command"), false
 		}
 		if !s.authorized(st, rbac.CmdGet, args[1]) {
-			return s.deniedReply(st, "get", false, out), false
+			return s.deniedReply(st, "get", args[1], false, out), false
 		}
 		s.countCommand(st)
 		key := *(*string)(unsafe.Pointer(&args[1]))
@@ -594,7 +629,7 @@ func (s *Server) dispatch(st *connState, c gnet.Conn, args [][]byte, out []byte)
 			return AppendError(out, "ERR wrong number of arguments for 'set' command"), false
 		}
 		if !s.authorized(st, rbac.CmdSet, args[1]) {
-			return s.deniedReply(st, "set", false, out), false
+			return s.deniedReply(st, "set", args[1], false, out), false
 		}
 		s.countCommand(st)
 		key := *(*string)(unsafe.Pointer(&args[1]))
@@ -613,7 +648,7 @@ func (s *Server) dispatch(st *connState, c gnet.Conn, args [][]byte, out []byte)
 		}
 		for _, k := range args[1:] {
 			if !s.authorized(st, rbac.CmdDel, k) {
-				return s.deniedReply(st, "del", false, out), false
+				return s.deniedReply(st, "del", k, false, out), false
 			}
 		}
 		s.countCommand(st)
@@ -640,14 +675,14 @@ func (s *Server) dispatch(st *connState, c gnet.Conn, args [][]byte, out []byte)
 
 	case EqualFold(cmd, shard.CmdRole):
 		if !s.authorizedCmd(st, rbac.CmdRole) {
-			return s.deniedReply(st, "role", true, out), false
+			return s.deniedReply(st, "role", nil, true, out), false
 		}
 		s.countCommand(st)
 		return s.role(st, args, out), false
 
 	case EqualFold(cmd, shard.CmdACL):
 		if !s.authorizedCmd(st, rbac.CmdACL) {
-			return s.deniedReply(st, "acl", true, out), false
+			return s.deniedReply(st, "acl", nil, true, out), false
 		}
 		s.countCommand(st)
 		return s.acl(st, args, out), false
@@ -700,11 +735,25 @@ func (s *Server) countDenied() {
 	}
 }
 
-// deniedReply records one RBAC denial (NOPERM) and logs the blocked command with
-// the pinned user identity so operators see who was denied. keyless omits the
-// key-scoped suffix from the reply (ROLE/ACL have no key scope).
-func (s *Server) deniedReply(st *connState, cmd string, keyless bool, out []byte) []byte {
+// deniedReply records one RBAC denial (NOPERM), writes it to the audit trail,
+// and logs the blocked command with the pinned user identity so operators see
+// who was denied. key holds the offending key for keyed commands and is nil for
+// keyless ones (ROLE/ACL have no key scope); keyless omits the key-scoped
+// suffix from the reply.
+func (s *Server) deniedReply(st *connState, cmd string, key []byte, keyless bool, out []byte) []byte {
 	s.countDenied()
+	user := ""
+	if st.session != nil {
+		user = st.session.Username
+	}
+	keyStr := *(*string)(unsafe.Pointer(&key))
+	s.audit.Record(audit.EventACLDeny, "command denied by rbac policy",
+		log.String("user", user),
+		log.String("command", cmd),
+		log.String("key", keyStr),
+		log.String("remote_addr", st.remoteAddr),
+		log.String("protocol", "resp"),
+	)
 	if s.logger.Enabled(log.LevelWarn) {
 		fields := []log.Field{
 			log.String("remote_addr", st.remoteAddr),
@@ -794,6 +843,11 @@ func (s *Server) authRBAC(st *connState, c gnet.Conn, args [][]byte, out []byte)
 		// nopass user: authentication succeeds without any hashing.
 		st.authenticated = true
 		st.session = rbac.NewSessionContext(username, p.RoleFor(username))
+		s.audit.Record(audit.EventAuthSuccess, "client authenticated",
+			log.String("user", username),
+			log.String("remote_addr", st.remoteAddr),
+			log.String("protocol", "resp"),
+		)
 		if s.logger.Enabled(log.LevelDebug) {
 			s.logger.Log(log.LevelDebug, "resp: client authenticated",
 				log.String("remote_addr", st.remoteAddr),
@@ -815,13 +869,19 @@ func (s *Server) authRBAC(st *connState, c gnet.Conn, args [][]byte, out []byte)
 }
 
 // authFailed records a rejected AUTH attempt — bumping the store-wide counter
-// and appending to the ACL LOG buffer when RBAC is enabled — counts it against
-// the per-connection maxAuthFails limit (closing the connection when reached),
-// logs it, and appends the RESP error reply.
+// and appending to the ACL LOG buffer when RBAC is enabled — writes it to the
+// audit trail, counts it against the per-connection maxAuthFails limit (closing
+// the connection when reached), logs it, and appends the RESP error reply.
 func (s *Server) authFailed(st *connState, username, reason string, out []byte) []byte {
 	if s.policy != nil {
 		s.policy.LogAuthFailure(username, st.remoteAddr, reason)
 	}
+	s.audit.Record(audit.EventAuthFailure, "authentication failed",
+		log.String("user", username),
+		log.String("remote_addr", st.remoteAddr),
+		log.String("reason", reason),
+		log.String("protocol", "resp"),
+	)
 	st.authFails++
 	if s.logger.Enabled(log.LevelWarn) {
 		s.logger.Log(log.LevelWarn, "resp: failed AUTH attempt",
@@ -872,6 +932,11 @@ func (s *Server) authWorker() {
 			if success {
 				st.authenticated = true
 				st.session = job.session
+				s.audit.Record(audit.EventAuthSuccess, "client authenticated",
+					log.String("user", job.username),
+					log.String("remote_addr", st.remoteAddr),
+					log.String("protocol", "resp"),
+				)
 				if s.logger.Enabled(log.LevelDebug) {
 					s.logger.Log(log.LevelDebug, "resp: client authenticated",
 						log.String("remote_addr", st.remoteAddr),

--- a/internal/resp/server_test.go
+++ b/internal/resp/server_test.go
@@ -8,9 +8,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Saxy/Tellstone/internal/audit"
+	"github.com/Saxy/Tellstone/internal/crypto"
 	"github.com/Saxy/Tellstone/internal/log"
 	"github.com/panjf2000/gnet/v2"
 )
+
+// newNoOpAudit returns a disabled audit engine so listener tests exercise the
+// unguarded Record() hooks with zero audit output.
+func newNoOpAudit() *audit.LogEngine {
+	return audit.NewLogEngine(false, nil, "stdout", log.NewNoOpLogger(), crypto.Engine{})
+}
 
 // fakeStore is a minimal in-memory Store. Like the real engine, it must COPY the key and
 // value because the arguments handed to Set alias the server's network read buffer.
@@ -54,7 +62,7 @@ func freeAddr(t *testing.T) string {
 
 func TestRESPServer_GetSetPingPipeline(t *testing.T) {
 	addr := freeAddr(t)
-	srv := NewServer(addr, newFakeStore(), nil, log.NewNoOpLogger(), nil, "", false, nil)
+	srv := NewServer(addr, newFakeStore(), nil, log.NewNoOpLogger(), nil, "", false, nil, newNoOpAudit())
 	go func() { _ = srv.ListenAndServe() }()
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -109,7 +117,7 @@ func expectReply(t *testing.T, conn net.Conn, name, send, want string) {
 func startServer(t *testing.T, requirePass string) (addr string) {
 	t.Helper()
 	addr = freeAddr(t)
-	srv := NewServer(addr, newFakeStore(), nil, log.NewNoOpLogger(), nil, requirePass, false, nil)
+	srv := NewServer(addr, newFakeStore(), nil, log.NewNoOpLogger(), nil, requirePass, false, nil, newNoOpAudit())
 	go func() { _ = srv.ListenAndServe() }()
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)

--- a/internal/resp/starttls_test.go
+++ b/internal/resp/starttls_test.go
@@ -155,7 +155,7 @@ func startRESPTLSServer(t *testing.T, startTLS bool, requirePass string) (string
 
 	addr := freeAddr(t)
 	store := newFakeStore()
-	srv := NewServer(addr, store, nil, log.NewNoOpLogger(), configs, requirePass, startTLS, nil)
+	srv := NewServer(addr, store, nil, log.NewNoOpLogger(), configs, requirePass, startTLS, nil, newNoOpAudit())
 	go func() { _ = srv.ListenAndServe() }()
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)

--- a/internal/shard/runner.go
+++ b/internal/shard/runner.go
@@ -119,8 +119,10 @@ func (s *Shard) Execute(op string, key string, value []byte, ttl time.Duration) 
 		if err := s.Engine.Set(key, value, ttl); err != nil {
 			if s.Persistence.Enabled() && !keyExisted {
 				if delErr := s.Persistence.Delete(uint32(s.ID), key); delErr != nil {
-					s.Logger.Log(log.LevelError, "persistence: compensation delete failed after engine rejection",
-						log.String("key", key), log.String("error", delErr.Error()))
+					if s.Logger.Enabled(log.LevelError) {
+						s.Logger.Log(log.LevelError, "persistence: compensation delete failed after engine rejection",
+							log.String("key", key), log.String("error", delErr.Error()))
+					}
 				}
 			}
 			return Response{Err: err}
@@ -135,6 +137,12 @@ func (s *Shard) Execute(op string, key string, value []byte, ttl time.Duration) 
 		s.Engine.Delete(key)
 		return Response{OK: true}
 	default:
+		if s.Logger.Enabled(log.LevelError) {
+			s.Logger.Log(log.LevelError, "shard: unknown operation",
+				log.String("op", op),
+				log.String("key", key),
+			)
+		}
 		return Response{Err: ErrShardStopped}
 	}
 }

--- a/internal/storage/engine.go
+++ b/internal/storage/engine.go
@@ -111,6 +111,13 @@ func (e *Engine) Set(key string, value []byte, ttl time.Duration) error {
 	if e.maxBytes > 0 {
 		totalEntrySize := uint64(len(key) + neededSize)
 		if atomic.LoadUint64(&e.allocatedBytes)+totalEntrySize > e.maxBytes {
+			if e.logger.Enabled(log.LevelWarn) {
+				e.logger.Log(log.LevelWarn, "storage engine memory ceiling reached, write rejected",
+					log.String("key", key),
+					log.Uint64("allocated_bytes", atomic.LoadUint64(&e.allocatedBytes)),
+					log.Uint64("max_bytes", e.maxBytes),
+				)
+			}
 			return ErrEngineFull
 		}
 	}
@@ -182,10 +189,7 @@ func (e *Engine) Delete(key string) {
 	}
 	delete(e.items, key)
 	e.mu.Unlock()
-	releasedBytes := uint64(len(key) + len(item.Value))
-	atomic.AddUint64(&e.allocatedBytes, ^(releasedBytes - 1))
-	atomic.AddUint64(&e.totalCommands, 1)
-	atomic.AddUint64(&e.keyCount, ^uint64(0))
+	e.releaseKey(key, item)
 	if e.logger.Enabled(log.LevelDebug) {
 		e.logger.Log(log.LevelDebug, "key deleted from engine state",
 			log.String("key", key),
@@ -202,11 +206,17 @@ func (e *Engine) deleteIfExpired(key string) bool {
 	}
 	delete(e.items, key)
 	e.mu.Unlock()
+	e.releaseKey(key, item)
+	return true
+}
+
+// releaseKey adjusts the memory, command, and key counters after a successful
+// in-memory deletion. It must be called with the item that was just removed.
+func (e *Engine) releaseKey(key string, item Item) {
 	releasedBytes := uint64(len(key) + len(item.Value))
 	atomic.AddUint64(&e.allocatedBytes, ^(releasedBytes - 1))
 	atomic.AddUint64(&e.totalCommands, 1)
 	atomic.AddUint64(&e.keyCount, ^uint64(0))
-	return true
 }
 
 func (e *Engine) Get(key string) ([]byte, bool) {

--- a/server/server.go
+++ b/server/server.go
@@ -156,6 +156,9 @@ func (s *Server) Run() error {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), cfg.GetShutdownTimeout())
 		defer cancel()
 		s.shutdown(shutdownCtx)
+		if logger.Enabled(log.LevelInfo) {
+			logger.Log(log.LevelInfo, "server shutdown complete")
+		}
 	}()
 
 	if err = s.netSrv.ListenAndServe(); err != nil {
@@ -190,7 +193,7 @@ func (s *Server) initRBAC() error {
 		}
 		return err
 	}
-	s.policy = rbac.NewStore(policy)
+	s.policy = rbac.NewStore(policy, logger)
 	if logger.Enabled(log.LevelInfo) {
 		logger.Log(log.LevelInfo, "rbac policy loaded", log.String("path", path))
 	}
@@ -300,6 +303,16 @@ func (s *Server) initShards(cryptoEngine *crypto.Engine) error {
 		s.shards[i] = sh
 	}
 	s.router = router.New(s.shards)
+	if logger.Enabled(log.LevelInfo) {
+		persistence := "disabled"
+		if store != nil {
+			persistence = "enabled"
+		}
+		logger.Log(log.LevelInfo, "shards initialized",
+			log.Int("num_shards", numShards),
+			log.String("persistence", persistence),
+		)
+	}
 	return nil
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -19,11 +19,13 @@ import (
 	"os"
 	"os/signal"
 	"sort"
+	"strings"
 	"syscall"
 	"time"
 	"unsafe"
 
 	"github.com/Saxy/Tellstone/internal/app/tellstone"
+	"github.com/Saxy/Tellstone/internal/audit"
 	"github.com/Saxy/Tellstone/internal/crypto"
 	"github.com/Saxy/Tellstone/internal/log"
 	"github.com/Saxy/Tellstone/internal/metrics"
@@ -67,6 +69,10 @@ type Server struct {
 	// listeners. nil means RBAC is disabled and both servers keep their
 	// legacy zero-overhead paths. SIGHUP swaps a fresh snapshot into it.
 	policy *rbac.Store
+	// audit is the shared audit engine. It is always non-nil: when
+	// --enable-audit is not set it is a disabled no-op whose Record() costs a
+	// single bool comparison, so listeners never guard the call.
+	audit *audit.LogEngine
 }
 
 func NewServer(app *tellstone.App) *Server {
@@ -101,6 +107,7 @@ func (s *Server) Run() error {
 	if err = s.initShards(cryptoEngine); err != nil {
 		return fmt.Errorf("shard init: %w", err)
 	}
+	s.initAudit(cryptoEngine)
 	s.netSrv = network.NewServer(
 		cfg.GetAddr(),
 		cfg.GetMaxMsgSize(),
@@ -110,6 +117,7 @@ func (s *Server) Run() error {
 		s.tlsConfigs,
 		cfg.GetRequirePass(),
 		s.policy,
+		s.audit,
 	)
 	if cfg.MetricsEnabled() {
 		s.startMetricsServer(s.netSrv)
@@ -255,6 +263,11 @@ func (s *Server) shutdown(ctx context.Context) {
 			}
 		}
 	}
+	// Both listeners are stopped above, so no Record() call can race the
+	// file close. A disabled engine's Close() is a no-op returning nil.
+	if err := s.audit.Close(); err != nil && logger.Enabled(log.LevelError) {
+		logger.Log(log.LevelError, "audit log close error", log.String("error", err.Error()))
+	}
 }
 
 func (s *Server) initCrypto() (*crypto.Engine, error) {
@@ -271,6 +284,27 @@ func (s *Server) initCrypto() (*crypto.Engine, error) {
 		return nil, fmt.Errorf("crypto engine initialization: %w", err)
 	}
 	return cryptoEngine, nil
+}
+
+// initAudit constructs the shared audit engine from the --enable-audit,
+// --audit-log-path, and --audit-events flags. The engine is always non-nil: a
+// disabled --enable-audit yields the no-op engine, so every listener hook can
+// call Record() unconditionally. cryptoEngine is nil when encryption is off;
+// the zero-value crypto.Engine keeps the file writer's encryption path inert.
+func (s *Server) initAudit(cryptoEngine *crypto.Engine) {
+	cfg := s.app.GetConfig()
+	logger := s.app.GetLogger()
+	var engine crypto.Engine
+	if cryptoEngine != nil {
+		engine = *cryptoEngine
+	}
+	s.audit = audit.NewLogEngine(
+		cfg.AuditEnabled(),
+		audit.ParseEventTypes(strings.Join(cfg.AuditLogEvents(), ",")),
+		cfg.AuditLogPath(),
+		logger,
+		engine,
+	)
 }
 
 func (s *Server) initShards(cryptoEngine *crypto.Engine) error {
@@ -304,13 +338,13 @@ func (s *Server) initShards(cryptoEngine *crypto.Engine) error {
 	}
 	s.router = router.New(s.shards)
 	if logger.Enabled(log.LevelInfo) {
-		persistence := "disabled"
+		p := "disabled"
 		if store != nil {
-			persistence = "enabled"
+			p = "enabled"
 		}
 		logger.Log(log.LevelInfo, "shards initialized",
 			log.Int("num_shards", numShards),
-			log.String("persistence", persistence),
+			log.String("persistence", p),
 		)
 	}
 	return nil
@@ -373,6 +407,7 @@ func (s *Server) startRESPServer() {
 		cfg.GetRequirePass(),
 		cfg.RESPStartTLSEnabled(),
 		s.policy,
+		s.audit,
 	)
 	s.respSrv = respSrv
 	go func() {


### PR DESCRIPTION
**Component:** 
Networking / Audit Logging (binary + RESP listeners, server wiring)

**Type of Change:**
- [x] New feature (non-breaking change which adds functionality)

---

## Related Issue

#11 

---

## Technical Deep Dive & Context

Adds structured audit logging as an opt-in feature, wired through both listeners. All work is in the new `internal/audit` package plus hook points in `internal/network` and `internal/resp`:

**Event model.** Six event types — `connect`, `disconnect`, `auth_success`, `auth_failure`, `acl_deny`, `command` — each mapped to a JSON line carrying `level: "AUDIT"` plus type-specific fields (`user`, `command`, `key`, `reason`, `remote_addr`, `shard_id`). The filter set is parsed once at startup from `--audit-events` and consulted per `Record()`.

**Zero hot-path cost when disabled.** `server.initAudit` always constructs a non-nil engine; without `--enable-audit` it is a no-op whose `Record()` returns on a single bool comparison — no writer, no encoder allocated. This is why the listeners call `s.audit.Record(...)` *unconditionally*, with no `if s.audit != nil` guard on the dispatch path, matching the codebase's no-guard/no-alloc conventions. The `command` event is explicitly documented as the one that adds per-command overhead, and it is off by default.

**Concurrency.** `Record()` and `Close()` are serialized by a mutex, so a gnet event loop can never race file rotation or the shutdown close. The shared engine is closed in `shutdown()` only after both listeners are stopped, so no in-flight write can race the file close.

**Zero-copy keys/commands.** Command and key strings alias the gnet buffer via the `unsafe` slice-header pattern already used on the dispatch paths, and are consumed synchronously by the encoder before the frame is discarded — no allocation on the audit path.

**File writer.** File-backed output uses generated names (`<unix-nanos>_<8-hex-dir-hash>_tsd.log`, perms `0600`), rotates at 50 MiB by closing and reopening a fresh file in the same directory (never truncating history), and seals each record with the `crypto.Engine` when encryption is enabled. File-creation failure falls back to stdout with an error log.

**Config.** `--enable-audit` (default off), `--audit-log-path` (`stdout` or a directory), `--audit-events` (default `auth,acl`; accepts `auth`, `acl`, `connect`, `disconnect`, `command`, `all`, or exact type names). Env equivalents `TSD_ENABLE_AUDIT`, `TSD_AUDIT_LOG_PATH`, `TSD_AUDIT_EVENTS`. Unrecognized event tokens are silently ignored so the flag stays forward-compatible.

---

## How Has This Been Tested?

- 21 new unit tests in `internal/audit`: event-filter parsing (defaults, `auth`/`acl` shorthand, `all`, exact tokens, whitespace, unknown tokens ignored), disabled-engine no-op, JSON output shape, per-event filtering, concurrent `Record()`s (race detector), file naming, rotation, and plaintext + encrypted file output.
- `go build ./...` and `go vet ./...` pass.
- `go test -race -count=1 ./...` passes across all packages (network 14s, resp 19s under `-race`).
- Manual end-to-end: server started with `--enable-audit --audit-log-path <dir> --audit-events all --rbac-config <policy>`; ran binary-protocol traffic as `admin`/`reader`/`readwrite`/`writer`, including deliberate RBAC denials (reader writing, readwrite `ROLE LIST`, writer out-of-namespace keys) and AUTH failures (wrong password, unknown user). Confirmed all six event types appear in the on-disk audit file (plaintext, `0600` perms) and that SIGTERM triggers a clean shutdown with the file closed.

---

## Checklist

- [x] My code follows the existing code style of this project
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally (`go test ./...` and `go test -race ./...`)
- [x] I have updated the documentation (README, comments, or any relevant docs)
- [x] My changes generate no new `go vet` warnings
- [x] Any breaking changes are documented and communicated (none — purely additive/opt-in)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable audit logging for connections, authentication, commands, and access-control decisions.
  - Supports event filtering, standard output or file storage, optional encryption, and automatic log rotation.
  - Added startup and operational logging for runtime settings, shard status, role changes, and resource limits.

- **Bug Fixes**
  - Improved recovery when persistence records are truncated.
  - Improved handling and visibility of expired data and rejected writes.

- **Documentation**
  - Added audit logging configuration and usage guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->