### PR TITLE
fix(benchmark): added missing auditlog to newServer for auditLog

### DIFF
--- a/internal/resp/benchmark_test.go
+++ b/internal/resp/benchmark_test.go
@@ -63,7 +63,7 @@ func BenchmarkParsePipeline(b *testing.B) {
 func BenchmarkDispatchGetHit(b *testing.B) {
 	store := newFakeStore()
 	_ = store.Set("k", []byte("benchmark_value"), 0)
-	srv := &Server{store: store, logger: log.NewNoOpLogger()}
+	srv := &Server{store: store, logger: log.NewNoOpLogger(), audit: newNoOpAudit()}
 	st := &connState{authenticated: true}
 	args := [][]byte{[]byte("GET"), []byte("k")}
 	out := make([]byte, 0, 128)
@@ -76,7 +76,7 @@ func BenchmarkDispatchGetHit(b *testing.B) {
 // BenchmarkDispatchSet measures Server.dispatch for a plain (no-TTL) SET.
 func BenchmarkDispatchSet(b *testing.B) {
 	store := newFakeStore()
-	srv := &Server{store: store, logger: log.NewNoOpLogger()}
+	srv := &Server{store: store, logger: log.NewNoOpLogger(), audit: newNoOpAudit()}
 	st := &connState{authenticated: true}
 	args := [][]byte{[]byte("SET"), []byte("k"), []byte("benchmark_value")}
 	out := make([]byte, 0, 128)
@@ -90,7 +90,7 @@ func BenchmarkDispatchSet(b *testing.B) {
 // single mutex, mirroring how many gnet event-loop goroutines would hammer a shared store.
 func BenchmarkDispatchSetParallel(b *testing.B) {
 	store := newFakeStore()
-	srv := &Server{store: store, logger: log.NewNoOpLogger()}
+	srv := &Server{store: store, logger: log.NewNoOpLogger(), audit: newNoOpAudit()}
 	b.ReportAllocs()
 	b.RunParallel(func(pb *testing.PB) {
 		st := &connState{authenticated: true}


### PR DESCRIPTION
## Description

fixed benchmarks broken by auditLog implementation 
missing audit log inside new server constructor

**Component:** 
Benchmarks

**Type of Change:**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance optimization (no change in behavior, improved speed/memory)
- [ ] Refactoring (no functional changes, code cleanup)
- [ ] Build / CI / Documentation

---

## Related Issue
none


---

## How Has This Been Tested?

go test -bench=. -benchmem 

---

## Checklist

- [x] My code follows the existing code style of this project
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally (`go test ./...` and `go test -race ./...`)
- [ ] I have updated the documentation (README, comments, or any relevant docs)
- [ ] My changes generate no new `go vet` warnings
- [ ] Any breaking changes are documented and communicated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated dispatch benchmarks to include audit support during setup.
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->