### PR TITLE
feat(resp): enforce TLS handshake deadline from the engine ticker

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,10 @@ RESP listener plaintext until a client sends `STARTTLS`; Tellstone replies `+OK`
 then requires an immediate TLS 1.3 handshake on the same socket. `STARTTLS` is allowed before
 `AUTH` so credentials need not cross plaintext. The command must not be pipelined with any other
 plaintext bytes. The binary listener always retains implicit TLS, and each RESP upgrade loads the
-latest rotated certificate configuration.
+latest rotated certificate configuration. Once a RESP connection is handed to the TLS state machine
+— on accept for implicit TLS, or after a `STARTTLS` acceptance — it must complete the handshake
+within 10 seconds; the listener closes it at the deadline even if the client sends nothing further,
+so stalled connections cannot pile up.
 
 ---
 

--- a/internal/resp/handshake.go
+++ b/internal/resp/handshake.go
@@ -1,0 +1,117 @@
+/*
+Package resp
+Tellstone Redis-Compatible Wire Protocol
+File: handshake.go
+Description: Traffic-independent enforcement of the TLS handshake deadline. Connections handed to
+the TLS state machine — on accept for implicit TLS, on upgrade for STARTTLS — are registered here
+and swept from the gnet engine ticker, so a client that stops sending after the transition cannot
+hold a socket, its read buffer, and its TLS state past the deadline.
+
+Authors:
+
+	Surafel Workayehu
+*/
+package resp
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/Saxy/Tellstone/internal/log"
+	tlslib "github.com/Saxy/Tellstone/internal/tls"
+	"github.com/panjf2000/gnet/v2"
+)
+
+// pendingHandshake tracks one connection that has been handed to the TLS state machine but has
+// not completed its handshake yet.
+//
+// c, tlsConn, and deadline are published once by the event loop that owns the connection and are
+// never mutated afterwards, so the sweeper goroutine only ever reads immutable fields plus two
+// concurrency-safe calls: gnet.Conn.Close enqueues the close on the owning event loop, and
+// tlslib.Conn.HandshakeCompleted is a single atomic load. *connState is deliberately absent here —
+// it is owned by its event loop and must not be read from the ticker.
+type pendingHandshake struct {
+	c        gnet.Conn
+	tlsConn  *tlslib.Conn
+	deadline time.Time
+	// done is set by the event loop in OnClose so the sweeper forgets a connection that died
+	// before handshaking instead of reporting it as a timeout. TCP health probes and port
+	// scanners take exactly that path, and they must not produce a warning per probe.
+	done atomic.Bool
+}
+
+// handshakeSweeper enforces the TLS handshake deadline independently of inbound traffic. Checking
+// the deadline in OnTraffic alone is not enough: a client that completes the STARTTLS exchange (or
+// opens an implicit-TLS connection) and then sends nothing never triggers another event, so its
+// socket, read buffer, and TLS state are held until the client gives up — an unauthenticated
+// resource-exhaustion path. gnet v2.10 has no per-connection timer, and its unix connections
+// reject SetReadDeadline with ErrUnsupportedOp, which leaves the engine ticker as the only place a
+// silent socket can be reaped from.
+//
+// Event loops only append; the sweeper is the only remover. That keeps the accept path to a single
+// append under an uncontended mutex, and the backing array is reused across sweeps, so a steady
+// state of n concurrent handshakes settles at zero allocations per tick.
+type handshakeSweeper struct {
+	mu      sync.Mutex
+	pending []*pendingHandshake
+}
+
+// track registers c for deadline enforcement and returns the entry so the connection can mark
+// itself done when it closes. Called once per TLS connection — on accept for implicit TLS, on
+// upgrade for STARTTLS — never per request.
+func (h *handshakeSweeper) track(c gnet.Conn, tlsConn *tlslib.Conn, deadline time.Time) *pendingHandshake {
+	p := &pendingHandshake{c: c, tlsConn: tlsConn, deadline: deadline}
+	h.mu.Lock()
+	h.pending = append(h.pending, p)
+	h.mu.Unlock()
+	return p
+}
+
+// sweep closes every tracked connection that has not completed its handshake by now, drops the
+// entries that no longer need watching, and returns how many connections it closed.
+//
+// A completed handshake is forgotten by the first sweep that observes it, which is why an
+// established connection can never be closed by a later sweep. Closing an already-closed gnet
+// connection is a no-op — the event loop ignores stale connections — so losing the race against a
+// concurrent close costs nothing.
+func (h *handshakeSweeper) sweep(now time.Time) int {
+	closed := 0
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for i := 0; i < len(h.pending); {
+		p := h.pending[i]
+		switch {
+		case p.done.Load() || p.tlsConn.HandshakeCompleted():
+			// Nothing left to enforce; the entry is dropped below.
+		case now.Before(p.deadline):
+			i++
+			continue
+		default:
+			// Close only enqueues the close on the owning event loop, so the sweeper never
+			// waits on a socket while holding the mutex.
+			_ = p.c.Close()
+			closed++
+		}
+		// Swap-delete: sweep order carries no meaning, so a removal must not shift the tail.
+		// Clearing the vacated slot drops the last reference to the connection.
+		last := len(h.pending) - 1
+		h.pending[i] = h.pending[last]
+		h.pending[last] = nil
+		h.pending = h.pending[:last]
+	}
+	return closed
+}
+
+// OnTick sweeps the pre-handshake registry. gnet runs it on a dedicated goroutine started
+// alongside the event loops, never on one of them, so it must touch only concurrency-safe state —
+// see handshakeSweeper. The interval is a tenth of the deadline: a stalled socket is then reaped
+// within 10% of it, and a single knob (handshakeTimeout) shrinks both for tests.
+func (s *Server) OnTick() (time.Duration, gnet.Action) {
+	if n := s.handshakes.sweep(time.Now()); n > 0 && s.logger.Enabled(log.LevelWarn) {
+		s.logger.Log(log.LevelWarn, "resp: closing connections that missed the TLS handshake deadline",
+			log.Int("connections", n),
+		)
+	}
+	return s.handshakeTimeout / 10, gnet.None
+}

--- a/internal/resp/handshake_test.go
+++ b/internal/resp/handshake_test.go
@@ -1,0 +1,237 @@
+/*
+Package resp
+Tellstone Redis-Compatible Wire Protocol
+File: handshake_test.go
+Description: Coverage for enforcing the TLS handshake deadline without inbound traffic: silent
+implicit-TLS connections, connections stalled after a STARTTLS acceptance, and connections stalled
+mid-ClientHello are all reaped, while an established session survives well past the deadline.
+
+Authors:
+
+	Surafel Workayehu
+*/
+package resp
+
+import (
+	"context"
+	stdtls "crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Saxy/Tellstone/internal/log"
+	tlslib "github.com/Saxy/Tellstone/internal/tls"
+)
+
+// sweepTestTimeout is the handshake deadline used by these tests. It is long enough that a loaded
+// CI runner cannot mistake scheduling delay for a timeout, and short enough that four sequential
+// tests stay well inside the package timeout. The sweep interval derives from it (deadline/10).
+const sweepTestTimeout = 400 * time.Millisecond
+
+func TestRESPServer_StalledSTARTTLSTimesOut(t *testing.T) {
+	addr, _ := startHandshakeServer(t, true)
+	raw := dialWithRetry(t, addr)
+	defer raw.Close()
+
+	expectReply(t, raw, "STARTTLS", startTLSRequest, "+OK\r\n")
+	// The upgrade is accepted and then the client goes silent: no ClientHello, no further
+	// bytes, so nothing will ever call OnTraffic for this connection again.
+	start := time.Now()
+	assertClosedByServer(t, raw, "connection stalled after STARTTLS")
+	if elapsed := time.Since(start); elapsed < sweepTestTimeout {
+		t.Fatalf("closed after %v, before the %v deadline", elapsed, sweepTestTimeout)
+	}
+}
+
+func TestRESPServer_StalledClientHelloTimesOut(t *testing.T) {
+	addr, _ := startHandshakeServer(t, false)
+	raw := dialWithRetry(t, addr)
+	defer raw.Close()
+
+	// A handshake record announcing 512 bytes of ClientHello, followed by two of them: the TLS
+	// state machine parks on ErrNotEnough waiting for the rest, which never arrives.
+	partialHello := []byte{0x16, 0x03, 0x01, 0x02, 0x00, 0x01, 0x00}
+	if _, err := raw.Write(partialHello); err != nil {
+		t.Fatalf("write partial ClientHello: %v", err)
+	}
+	assertClosedByServer(t, raw, "connection stalled mid-ClientHello")
+}
+
+func TestRESPServer_SilentImplicitTLSTimesOut(t *testing.T) {
+	addr, _ := startHandshakeServer(t, false)
+	raw := dialWithRetry(t, addr)
+	defer raw.Close()
+
+	// Not a single byte is sent, so the deadline set at accept time is the only thing that can
+	// release the socket and its 4 KiB TLS read buffer.
+	assertClosedByServer(t, raw, "silent implicit-TLS connection")
+}
+
+func TestRESPServer_EstablishedConnectionSurvivesDeadline(t *testing.T) {
+	addr, certPEM := startHandshakeServer(t, false)
+	conn, err := stdtls.Dial("tcp", addr, startTLSClientConfig(t, certPEM))
+	if err != nil {
+		t.Fatalf("implicit TLS dial: %v", err)
+	}
+	defer conn.Close()
+
+	expectReply(t, conn, "PING before the deadline", "*1\r\n$4\r\nPING\r\n", "+PONG\r\n")
+	// Idle across several sweeps: a completed handshake must be forgotten by the sweeper, not
+	// closed by it.
+	time.Sleep(3 * sweepTestTimeout)
+	expectReply(t, conn, "PING after the deadline", "*1\r\n$4\r\nPING\r\n", "+PONG\r\n")
+}
+
+func TestRESPServer_ConcurrentHandshakesUnderSweep(t *testing.T) {
+	// Enough connections to spread across every event loop, so `track` runs on several loops
+	// while the ticker goroutine sweeps. One connection at a time would leave the registry
+	// boundary — the whole risk of this design — unexercised under -race.
+	const stalledConns, liveConns = 24, 8
+	addr, certPEM := startHandshakeServer(t, false)
+	clientCfg := startTLSClientConfig(t, certPEM) // built here: the helper may call t.Fatal
+
+	errs := make(chan error, stalledConns+liveConns)
+	var wg sync.WaitGroup
+
+	for i := 0; i < stalledConns; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+			if err != nil {
+				errs <- fmt.Errorf("dial stalled connection: %w", err)
+				return
+			}
+			defer conn.Close()
+			_ = conn.SetReadDeadline(time.Now().Add(5 * sweepTestTimeout))
+			var b [1]byte
+			_, err = conn.Read(b[:])
+			var netErr net.Error
+			switch {
+			case err == nil:
+				errs <- fmt.Errorf("stalled connection got a reply %q instead of a close", b[:])
+			case errors.As(err, &netErr) && netErr.Timeout():
+				errs <- errors.New("stalled connection still open past the deadline")
+			}
+		}()
+	}
+
+	for i := 0; i < liveConns; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			conn, err := stdtls.Dial("tcp", addr, clientCfg)
+			if err != nil {
+				errs <- fmt.Errorf("dial established connection: %w", err)
+				return
+			}
+			defer conn.Close()
+			if err := pingOnce(conn); err != nil {
+				errs <- fmt.Errorf("ping before the deadline: %w", err)
+				return
+			}
+			time.Sleep(3 * sweepTestTimeout)
+			if err := pingOnce(conn); err != nil {
+				errs <- fmt.Errorf("established session died while idle: %w", err)
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+}
+
+// pingOnce round-trips one PING. Unlike expectReply it returns the error instead of calling
+// t.Fatalf, so it is safe to use from a goroutine other than the test's own.
+func pingOnce(conn net.Conn) error {
+	if _, err := conn.Write([]byte("*1\r\n$4\r\nPING\r\n")); err != nil {
+		return err
+	}
+	if err := conn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		return err
+	}
+	var got [7]byte
+	if _, err := io.ReadFull(conn, got[:]); err != nil {
+		return err
+	}
+	if string(got[:]) != "+PONG\r\n" {
+		return fmt.Errorf("got %q want %q", got[:], "+PONG\r\n")
+	}
+	return nil
+}
+
+// startHandshakeServer starts a TLS-enabled RESP server whose handshake deadline is
+// sweepTestTimeout, returning its address and the certificate a client should trust. The deadline
+// is installed before ListenAndServe because the sweeper goroutine reads it.
+func startHandshakeServer(t *testing.T, startTLS bool) (string, []byte) {
+	t.Helper()
+	certPEM, keyPEM := generateStartTLSCertificate(t)
+	configs, err := tlslib.NewConfigStore(buildStartTLSConfig(t, certPEM, keyPEM))
+	if err != nil {
+		t.Fatalf("create TLS config store: %v", err)
+	}
+
+	addr := freeAddr(t)
+	srv := NewServer(addr, newFakeStore(), nil, log.NewNoOpLogger(), configs, "", startTLS, nil, newNoOpAudit())
+	srv.handshakeTimeout = sweepTestTimeout
+	go func() { _ = srv.ListenAndServe() }()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	})
+	probe := dialWithRetry(t, addr)
+	_ = probe.Close()
+	return addr, certPEM
+}
+
+// assertClosedByServer fails unless the server closes conn on its own. The read deadline allows
+// several sweep intervals of slack so a busy runner cannot fail the test.
+func assertClosedByServer(t *testing.T, conn net.Conn, name string) {
+	t.Helper()
+	if err := conn.SetReadDeadline(time.Now().Add(5 * sweepTestTimeout)); err != nil {
+		t.Fatalf("%s: set read deadline: %v", name, err)
+	}
+	var b [1]byte
+	n, err := conn.Read(b[:])
+	if n != 0 {
+		t.Fatalf("%s: server replied %q instead of closing", name, b[:n])
+	}
+	if err == nil {
+		t.Fatalf("%s: read returned no data and no error", name)
+	}
+	// Any non-timeout error means the peer went away (EOF on a graceful close, ECONNRESET when
+	// the kernel discards a half-open socket); only the read deadline expiring proves the
+	// server still holds the connection.
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		t.Fatalf("%s: still open after %v (deadline %v)", name, 5*sweepTestTimeout, sweepTestTimeout)
+	}
+}
+
+// BenchmarkHandshakeSweep measures the steady-state scan: entries whose handshake has neither
+// completed nor expired, which is what every tick walks while connections are negotiating. The
+// backing array is reused, so the sweep must not allocate.
+func BenchmarkHandshakeSweep(b *testing.B) {
+	const tracked = 1024
+	h := &handshakeSweeper{}
+	deadline := time.Now().Add(time.Hour)
+	for i := 0; i < tracked; i++ {
+		// A Conn that never completes its handshake. sweep reads only the atomic flag, so it
+		// needs neither a socket nor a configuration.
+		h.track(nil, tlslib.Server(nil, nil), deadline)
+	}
+	now := time.Now()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		h.sweep(now)
+	}
+}

--- a/internal/resp/handshake_test.go
+++ b/internal/resp/handshake_test.go
@@ -37,18 +37,21 @@ func TestRESPServer_StalledSTARTTLSTimesOut(t *testing.T) {
 	raw := dialWithRetry(t, addr)
 	defer raw.Close()
 
+	// Timed from before the upgrade request: the server starts its deadline inside
+	// upgradeToTLS, which cannot happen before this point, so a correct close can never look
+	// early. Timing from after the +OK arrives would leave the assertion racing the round trip.
+	start := time.Now()
 	expectReply(t, raw, "STARTTLS", startTLSRequest, "+OK\r\n")
 	// The upgrade is accepted and then the client goes silent: no ClientHello, no further
 	// bytes, so nothing will ever call OnTraffic for this connection again.
-	start := time.Now()
-	assertClosedByServer(t, raw, "connection stalled after STARTTLS")
-	if elapsed := time.Since(start); elapsed < sweepTestTimeout {
-		t.Fatalf("closed after %v, before the %v deadline", elapsed, sweepTestTimeout)
-	}
+	assertClosedAfterDeadline(t, raw, "connection stalled after STARTTLS", start)
 }
 
 func TestRESPServer_StalledClientHelloTimesOut(t *testing.T) {
 	addr, _ := startHandshakeServer(t, false)
+	// Implicit TLS is tracked in OnOpen, so the deadline starts at accept — time from before
+	// the dial.
+	start := time.Now()
 	raw := dialWithRetry(t, addr)
 	defer raw.Close()
 
@@ -58,17 +61,18 @@ func TestRESPServer_StalledClientHelloTimesOut(t *testing.T) {
 	if _, err := raw.Write(partialHello); err != nil {
 		t.Fatalf("write partial ClientHello: %v", err)
 	}
-	assertClosedByServer(t, raw, "connection stalled mid-ClientHello")
+	assertClosedAfterDeadline(t, raw, "connection stalled mid-ClientHello", start)
 }
 
 func TestRESPServer_SilentImplicitTLSTimesOut(t *testing.T) {
 	addr, _ := startHandshakeServer(t, false)
+	start := time.Now()
 	raw := dialWithRetry(t, addr)
 	defer raw.Close()
 
 	// Not a single byte is sent, so the deadline set at accept time is the only thing that can
 	// release the socket and its 4 KiB TLS read buffer.
-	assertClosedByServer(t, raw, "silent implicit-TLS connection")
+	assertClosedAfterDeadline(t, raw, "silent implicit-TLS connection", start)
 }
 
 func TestRESPServer_EstablishedConnectionSurvivesDeadline(t *testing.T) {
@@ -190,6 +194,19 @@ func startHandshakeServer(t *testing.T, startTLS bool) (string, []byte) {
 	probe := dialWithRetry(t, addr)
 	_ = probe.Close()
 	return addr, certPEM
+}
+
+// assertClosedAfterDeadline fails unless the server closed conn on its own and waited out the
+// deadline first. start must be taken before whatever begins handshake tracking, so that the
+// server's clock starts at or after it — otherwise a correct close can appear early and the test
+// flakes. Without the lower bound, a regression that closed every TLS connection on accept would
+// still pass.
+func assertClosedAfterDeadline(t *testing.T, conn net.Conn, name string, start time.Time) {
+	t.Helper()
+	assertClosedByServer(t, conn, name)
+	if elapsed := time.Since(start); elapsed < sweepTestTimeout {
+		t.Fatalf("%s: closed after %v, before the %v deadline", name, elapsed, sweepTestTimeout)
+	}
 }
 
 // assertClosedByServer fails unless the server closes conn on its own. The read deadline allows

--- a/internal/resp/server.go
+++ b/internal/resp/server.go
@@ -73,13 +73,16 @@ type authJob struct {
 // connState holds per-connection scratch buffers reused across OnTraffic calls so the hot
 // path stays allocation-free, plus the assigned shard index for per-shard metrics.
 type connState struct {
-	out               []byte
-	args              [][]byte
-	shardID           int
-	tlsConn           *tlslib.Conn
-	readBuf           []byte
-	handshakeDeadline time.Time
-	authenticated     bool
+	out     []byte
+	args    [][]byte
+	shardID int
+	tlsConn *tlslib.Conn
+	readBuf []byte
+	// pending is the sweeper entry enforcing this connection's handshake deadline without
+	// inbound traffic. It is non-nil whenever tlsConn is non-nil — both are installed
+	// together, on accept for implicit TLS and in upgradeToTLS for STARTTLS.
+	pending       *pendingHandshake
+	authenticated bool
 	// session is the RBAC context pinned at AUTH time. nil when RBAC is
 	// disabled (the zero-overhead no-op path) or before authentication.
 	session    *rbac.SessionContext
@@ -137,6 +140,12 @@ type Server struct {
 	// it is a disabled no-op whose Record() costs one bool comparison, so the
 	// hooks below call it without a nil guard.
 	audit *audit.LogEngine
+
+	// handshakes enforces handshakeTimeout on connections that stop sending after being handed
+	// to the TLS state machine (see handshake.go). handshakeTimeout is tlsHandshakeTimeout;
+	// tests shrink it to keep the sweep observable without waiting out the production deadline.
+	handshakes       handshakeSweeper
+	handshakeTimeout time.Duration
 }
 
 // NewServer creates a RESP server bound to addr that dispatches commands to store.
@@ -175,6 +184,8 @@ func NewServer(addr string, store Store, shards []*shard.Shard, logger log.Logge
 		policy:          policy,
 		ready:           make(chan struct{}),
 		audit:           audit,
+
+		handshakeTimeout: tlsHandshakeTimeout,
 	}
 	// The worker pool exists only when authentication is actually required, so
 	// the zero-overhead no-password path spawns no goroutines.
@@ -193,7 +204,13 @@ func (s *Server) ListenAndServe() error {
 	if s.logger.Enabled(log.LevelInfo) {
 		s.logger.Log(log.LevelInfo, "resp: event-driven engine initializing", log.String("address", s.addr))
 	}
-	return gnet.Run(s, "tcp://"+s.addr, gnet.WithMulticore(true), gnet.WithLogger(log.NewGnetAdapter(s.logger)))
+	opts := []gnet.Option{gnet.WithMulticore(true), gnet.WithLogger(log.NewGnetAdapter(s.logger))}
+	if s.tlsConfigs.Load() != nil {
+		// The ticker exists only to enforce the TLS handshake deadline, so a plaintext listener
+		// keeps the original configuration: no ticker goroutine, no timer, no OnTick calls.
+		opts = append(opts, gnet.WithTicker(true))
+	}
+	return gnet.Run(s, "tcp://"+s.addr, opts...)
 }
 
 // Shutdown gracefully stops the event loop, waiting for in-flight connections to drain or
@@ -264,7 +281,7 @@ func (s *Server) OnOpen(c gnet.Conn) (out []byte, action gnet.Action) {
 		adapter := tlslib.NewGnetConnAdapter(c)
 		st.tlsConn = tlslib.Server(adapter, tlsCfg)
 		st.readBuf = make([]byte, 0, 4096)
-		st.handshakeDeadline = time.Now().Add(tlsHandshakeTimeout)
+		st.pending = s.handshakes.track(c, st.tlsConn, time.Now().Add(s.handshakeTimeout))
 	}
 	c.SetContext(st)
 	s.audit.Record(audit.EventConnect, "client connected",
@@ -283,6 +300,12 @@ func (s *Server) OnClose(c gnet.Conn, err error) (action gnet.Action) {
 	var remoteAddr string
 	if st, ok := c.Context().(*connState); ok {
 		remoteAddr = st.remoteAddr
+		if st.pending != nil {
+			// Let the sweeper forget this connection instead of reporting it as a handshake
+			// timeout once the deadline passes: a client is free to hang up mid-handshake,
+			// and TCP health probes do it on every check.
+			st.pending.done.Store(true)
+		}
 		if st.shardID >= 0 && st.shardID < len(s.shards) {
 			s.shards[st.shardID].DecConnectedClients()
 		}
@@ -319,7 +342,9 @@ func (s *Server) OnTraffic(c gnet.Conn) gnet.Action {
 	}
 
 	if st.tlsConn != nil {
-		if !st.tlsConn.HandshakeCompleted() && time.Now().After(st.handshakeDeadline) {
+		// The sweeper enforces the same deadline without traffic; this keeps closing a
+		// stalled handshake on the spot when the client does send something.
+		if !st.tlsConn.HandshakeCompleted() && time.Now().After(st.pending.deadline) {
 			return gnet.Close
 		}
 		return s.onTrafficTLS(c, st)
@@ -552,7 +577,7 @@ func (s *Server) upgradeToTLS(c gnet.Conn, st *connState, consumed int) gnet.Act
 	adapter := tlslib.NewGnetConnAdapter(c)
 	st.tlsConn = tlslib.Server(adapter, tlsCfg)
 	st.readBuf = make([]byte, 0, 4096)
-	st.handshakeDeadline = time.Now().Add(tlsHandshakeTimeout)
+	st.pending = s.handshakes.track(c, st.tlsConn, time.Now().Add(s.handshakeTimeout))
 	st.upgradeTLS = false
 	return gnet.None
 }


### PR DESCRIPTION
## Description

`tlsHandshakeTimeout` was only compared inside `OnTraffic`, so it could only fire when a client sent more bytes. A client that completed the STARTTLS exchange — or opened an implicit-TLS connection — and then went silent held its socket, its 4 KiB TLS read buffer, and its TLS state until it chose to hang up. The deadline expired without anything closing the connection, so an unauthenticated client could accumulate stalled connections.

This adds active enforcement: connections handed to the TLS state machine are registered in a sweeper that the gnet engine ticker drains, closing whatever is past its deadline regardless of inbound traffic.

**Component:** Networking/RESP

**Type of Change:**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance optimization (no change in behavior, improved speed/memory)
- [ ] Refactoring (no functional changes, code cleanup)
- [ ] Build / CI / Documentation

---

## Related Issue

Closes #25

---

## Technical Deep Dive & Context

**Why the ticker.** Two alternatives are unavailable in gnet v2.10, which is what the issue already anticipated and I confirmed against the vendored source:

* `(*conn).SetReadDeadline` returns `errorx.ErrUnsupportedOp` on unix (`connection_unix.go`), so socket deadlines cannot carry this.
* There is no per-connection timer, and per-connection `time.AfterFunc` would mean one timer per accepted connection — scheduler pressure proportional to connection churn, for a deadline that only matters to connections that never finish handshaking.

`OnTick` is the only engine-driven callback, so the sweep lives there.

**The concurrency contract.** gnet runs the ticker on a **dedicated goroutine** — `engine_unix.go` starts `el0.ticker` (reuseport) or `eng.ingress.ticker` (default multi-reactor) via `concurrency.Go` — not inside an event loop. That is the constraint the whole design is shaped around: the tick handler must not touch `*connState`, which is owned by its event loop and read/written there without synchronisation.

So a registry entry (`pendingHandshake`) holds only:

* `c gnet.Conn` — `Close` is documented concurrency-safe; it enqueues the close on the owning loop via `poller.Trigger`, and `eventloop.close` ignores stale connections (`!c.opened || connections.getConn(c.fd) == nil`), so racing a real close is a harmless no-op rather than a double-close.
* `tlsConn *tlslib.Conn` — only `HandshakeCompleted()` is called, a single `atomic.Bool` load.
* `deadline time.Time` — written once before publication, never mutated.
* `done atomic.Bool` — set by the event loop in `OnClose`.

No pointer to `connState` is reachable from an entry, by construction.

**Why `done` exists.** Without it, a connection that hangs up mid-handshake stays in the registry until its deadline and is then reported as a timeout. TCP health probes and port scanners do exactly that on every check, so the log would fill with false positives. It also keeps deregistration O(1) on the event loop instead of an O(n) scan under the mutex.

**Registry shape.** Event loops only append; the sweeper is the only remover, using swap-delete (sweep order carries no meaning) over a reused backing array. So a steady state of *n* negotiating connections settles at zero allocations per tick. A completed handshake is dropped by the first sweep that observes it — which is precisely why an established connection can never be closed by a later sweep, since it is no longer tracked. Entries therefore linger at most one tick past completion; removing them the instant the handshake finishes would require the registry lock on the TLS request path, which is not a trade worth making for one tick of memory.

**Opt-in preserved.** `gnet.WithTicker(true)` is passed only when `tlsConfigs.Load() != nil`. A plaintext listener keeps exactly today's engine configuration: no ticker goroutine, no timer, no `OnTick` calls.

**Tick interval** is `handshakeTimeout / 10`, so a stalled socket is reaped within 10% of the deadline. The timeout itself became a `Server` field (defaulting to the existing `tlsHandshakeTimeout` const) so tests can shrink it — no exported API change; `NewServer`'s signature is untouched.

**Kept the existing `OnTraffic` check** (now reading `st.pending.deadline`). It is redundant with the sweep, but it still closes a stalled handshake on the spot when the client does send something, and removing it would be a behaviour change beyond this issue. Happy to drop it if you prefer a single mechanism.

**Out of scope, flagging rather than expanding this PR:**

1. `internal/network/server.go` `OnOpen` installs `tlsConn` **without any deadline at all**, so the binary listener on `:9988` has the same exhaustion surface with nothing to enforce. The same sweeper would apply — separate issue if you want it.
2. A sweeper-closed connection produces a plain `audit.EventDisconnect`, indistinguishable from a normal hang-up. A dedicated event type would mean touching `internal/audit`, so I left it out.
3. Plaintext RESP connections that never send `STARTTLS` are untouched — that is an idle-connection concern (Redis `timeout`-style), not a handshake one.

---

## Performance & Benchmarks

**No measurable change to the request path** — nothing in `Parse` or `dispatch` was modified. The added work is one slice append per TLS connection at accept/upgrade time, and one O(n) scan per tick over connections that are still negotiating.

**Workload:** `go test -bench -benchmem -count=5 ./internal/resp/`, base `76d874a` vs this branch, same machine (Windows 11, i5-12500H, 16 logical cores). Means of 5 runs.

| Benchmark | Before | After | allocs/op (before → after) |
|---|---|---|---|
| `BenchmarkParseGet` | 37.7 ns/op | 37.2 ns/op | 0 → 0 |
| `BenchmarkParseSet` | 52.3 ns/op | 49.2 ns/op | 0 → 0 |
| `BenchmarkParsePipeline` | 628.3 ns/op | 639.4 ns/op | 0 → 0 |
| `BenchmarkDispatchGetHit` | 56.9 ns/op | 58.0 ns/op | 0 → 0 |
| `BenchmarkDispatchSet` | 75.0 ns/op | 70.1 ns/op | 1 → 1 |
| `BenchmarkDispatchSetParallel` | 99.5 ns/op | 90.8 ns/op | 1 → 1 |
| `BenchmarkHandshakeSweep` (new) | — | 3188 ns/op | — → **0** |

I am explicitly **not** claiming the timing deltas above mean anything: individual runs on this laptop spread up to 2× (`BenchmarkDispatchSet` ranged 55.4–104.6 ns/op across the 5 baseline runs), so ±10% is noise. The deterministic result is that allocation counts are unchanged, and the new sweep allocates nothing.

`BenchmarkHandshakeSweep` measures the steady-state scan with 1024 tracked connections whose handshakes have neither completed nor expired — ~3 ns per tracked connection, once per tick.

```text
goos: windows
goarch: amd64
pkg: github.com/Saxy/Tellstone/internal/resp
cpu: 12th Gen Intel(R) Core(TM) i5-12500H
BenchmarkHandshakeSweep-16    535716    3073 ns/op    0 B/op    0 allocs/op
BenchmarkHandshakeSweep-16    362383    3623 ns/op    0 B/op    0 allocs/op
BenchmarkHandshakeSweep-16    360015    3215 ns/op    0 B/op    0 allocs/op
BenchmarkHandshakeSweep-16    333140    3427 ns/op    0 B/op    0 allocs/op
BenchmarkHandshakeSweep-16    424623    2603 ns/op    0 B/op    0 allocs/op
```

I did not run `memtier_benchmark`: it exercises established connections, which this change does not touch, and I have no second host to generate load from.

---

## How Has This Been Tested?

Five new tests in `internal/resp/handshake_test.go`, covering each acceptance criterion in #25. They inject a 400 ms deadline via the `Server.handshakeTimeout` field so the suite does not wait out the 10 s production deadline.

| Test | Asserts |
|---|---|
| `TestRESPServer_StalledSTARTTLSTimesOut` | closes after `+OK` with no ClientHello — and **not before** the deadline |
| `TestRESPServer_StalledClientHelloTimesOut` | closes when parked mid-ClientHello (record header + 2 bytes) |
| `TestRESPServer_SilentImplicitTLSTimesOut` | closes an implicit-TLS connection that sends nothing at all |
| `TestRESPServer_EstablishedConnectionSurvivesDeadline` | established session idles 3× the deadline, still answers `PING` |
| `TestRESPServer_ConcurrentHandshakesUnderSweep` | 24 stalled + 8 established connections concurrently, so `track` runs on several event loops while the ticker sweeps — this is what gives `-race` something to look at on the registry boundary |

The first three **fail without the sweeper** (`still open after 2s`), which reproduces the reported behaviour rather than passing vacuously — verified by disabling the ticker and re-running.

CI on this branch: **Build, Vet, Test, and Test (race) all green on ubuntu-latest.**

Locally (Windows):

* `go build ./...`, `go vet ./...` — clean
* `go test ./internal/resp/` — pass
* `go test -race -count=2` on the handshake tests, and `go test -race ./internal/resp/ ./internal/network/ ./internal/rbac/ ./internal/audit/ ./internal/storage/ ./internal/shard/` — pass, no data race
* `go test ./...` — `internal/persistence` and `internal/tls` fail on this machine only, identically on clean `main` (Windows temp-file locking during `TempDir` cleanup, and `symlink: A required privilege is not held by the client`). Both pass in CI on Linux.

---

## Checklist

- [x] My code follows the existing code style of this project
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally (`go test ./...` and `go test -race ./...`)
- [x] I have updated the documentation (README, comments, or any relevant docs)
- [x] My changes generate no new `go vet` warnings
- [x] Any breaking changes are documented and communicated — there are none; no exported signature changes, and the new `Server` fields are unexported

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TLS connections must complete their handshake within 10 seconds.
  * Stalled implicit TLS and STARTTLS connections are automatically closed when the deadline expires.
  * Connections that complete the handshake remain active and usable.
  * Handshake timeout handling remains reliable during concurrent connection activity.
* **Documentation**
  * Updated RESP TLS documentation to describe the 10-second handshake deadline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->