### PR TITLE
feat(crypto): add file-sourced encryption key via KeyProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,12 +181,12 @@ tellstone --enable-encryption --encryption-key-file /etc/tellstone/key
 The key is read once at startup; rotating it requires a restart. Enabling encryption without either
 source is refused at startup rather than silently falling back to plaintext.
 
-> **Upgrading:** `--encryption-key` was previously used as raw text, so a literal 32-character
-> value such as `0123456789abcdef0123456789abcdef` worked. It is now base64-decoded, and such a
-> value will fail with a key-length error. Re-encode an existing key with `base64 < <keyfile>`,
-> or move it to `--encryption-key-file`. Note that generating a key with `openssl rand -hex 16`
-> yielded only 128 bits of entropy despite being 32 characters long; `openssl rand -base64 32`
-> carries the full 256 bits.
+> **Deprecated:** `--encryption-key` previously used the value as raw text, so a literal
+> 32-character key such as `0123456789abcdef0123456789abcdef` was accepted. That form still
+> works and logs a warning at startup, but it is insecure and will be removed in the next
+> major release. Re-encode an existing key with `base64 < <keyfile>`, or move it to
+> `--encryption-key-file`. The two forms are never ambiguous: a base64 key is 44 characters
+> (43 unpadded), while a 32-character value can only decode to 24 bytes.
 
 When TLS is enabled, Tellstone watches the parent directories of the certificate, key, and
 optional client CA. Valid replacements are applied after a 500 ms debounce; existing TLS

--- a/README.md
+++ b/README.md
@@ -172,7 +172,9 @@ Kubernetes Secret or a vault-agent-rendered file. Every byte of the file is sign
 be exactly 32 bytes with no trailing newline:
 
 ```bash
-head -c 32 /dev/urandom > /etc/tellstone/key
+# umask 077 in a subshell so the file is created 0600; a later chmod would leave
+# the key world-readable in between.
+(umask 077; head -c 32 /dev/urandom > /etc/tellstone/key)
 tellstone --enable-encryption --encryption-key-file /etc/tellstone/key
 ```
 
@@ -181,7 +183,7 @@ source is refused at startup rather than silently falling back to plaintext.
 
 > **Upgrading:** `--encryption-key` was previously used as raw text, so a literal 32-character
 > value such as `0123456789abcdef0123456789abcdef` worked. It is now base64-decoded, and such a
-> value will fail with a key-length error. Re-encode an existing key with `base64 -w0 <keyfile>`,
+> value will fail with a key-length error. Re-encode an existing key with `base64 < <keyfile>`,
 > or move it to `--encryption-key-file`. Note that generating a key with `openssl rand -hex 16`
 > yielded only 128 bits of entropy despite being 32 characters long; `openssl rand -base64 32`
 > carries the full 256 bits.

--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ Every option is available as a flag and an environment variable.
 | `--evict-interval`    | `TSD_EVICT_INTERVAL`    | `1s`             | Chronometer tick interval (`0` disables active eviction) |
 | `--evict-slots`       | `TSD_EVICT_SLOTS`       | `256`            | Timing‑wheel slot count                                  |
 | `--enable-encryption` | `TSD_ENABLE_ENCRYPTION` | `false`          | Enable ChaCha20‑Poly1305 at‑rest encryption              |
-| `--encryption-key`    | `TSD_ENCRYPTION_KEY`    | _(none)_         | 32‑byte key (required when encryption is on)             |
+| `--encryption-key`    | `TSD_ENCRYPTION_KEY`    | _(none)_         | Base‑64 encoded 32‑byte key (one key source is required when encryption is on) |
+| `--encryption-key-file`| `TSD_ENCRYPTION_KEY_FILE`| _(none)_        | Path to a file holding the raw 32‑byte key; mutually exclusive with `--encryption-key` |
 | `--enable-metrics`    | `TSD_ENABLE_METRICS`    | `false`          | Enable the Prometheus exporter                           |
 | `--metrics-addr`      | `TSD_METRICS_ADDR`      | `:9100`          | Prometheus exporter address (`/metrics`)                 |
 | `--trace-ratio`       | `TSD_TRACE_RATIO`       | `0.0`            | OpenTelemetry sample ratio (`0` disables)                |
@@ -157,6 +158,33 @@ Every option is available as a flag and an environment variable.
 Runtime tuning (environment only): `TSD_GC_PERCENT` (default `-1`, GC off for a zero‑GC hot
 path), `TSD_MEM_LIMIT_BYTES` (soft heap ceiling), `TSD_ENABLE_PROFILING` (serves `pprof` on
 `127.0.0.1:6060`).
+
+At-rest encryption takes its 32-byte key from exactly one source. `--encryption-key` carries it
+**base64-encoded**, because process arguments and environment variables are NUL-terminated and
+roughly 1 in 8 random 32-byte keys contains a `0x00` byte that cannot survive them:
+
+```bash
+tellstone --enable-encryption --encryption-key "$(openssl rand -base64 32)"
+```
+
+`--encryption-key-file` carries the same key as **raw, unencoded bytes**, which suits a mounted
+Kubernetes Secret or a vault-agent-rendered file. Every byte of the file is significant, so it must
+be exactly 32 bytes with no trailing newline:
+
+```bash
+head -c 32 /dev/urandom > /etc/tellstone/key
+tellstone --enable-encryption --encryption-key-file /etc/tellstone/key
+```
+
+The key is read once at startup; rotating it requires a restart. Enabling encryption without either
+source is refused at startup rather than silently falling back to plaintext.
+
+> **Upgrading:** `--encryption-key` was previously used as raw text, so a literal 32-character
+> value such as `0123456789abcdef0123456789abcdef` worked. It is now base64-decoded, and such a
+> value will fail with a key-length error. Re-encode an existing key with `base64 -w0 <keyfile>`,
+> or move it to `--encryption-key-file`. Note that generating a key with `openssl rand -hex 16`
+> yielded only 128 bits of entropy despite being 32 characters long; `openssl rand -base64 32`
+> carries the full 256 bits.
 
 When TLS is enabled, Tellstone watches the parent directories of the certificate, key, and
 optional client CA. Valid replacements are applied after a 500 ms debounce; existing TLS

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	evictSlots        uint32
 	enableEncryption  bool
 	encryptionKey     string
+	encryptionKeyFile string
 	traceRatio        float64
 	maxMsgSize        uint64
 	maxMemBytes       uint64
@@ -107,7 +108,8 @@ func getEnv[T any](key string, fallback T) T {
 //		TSD_LOG_LEVEL       – log verbosity (debug, info, warn, error, fatal)
 //		TSD_EVICT_INTERVAL  – eviction ticker interval (e.g. "500ms", "2s")
 //		TSD_EVICT_SLOTS     – number of slots in the timing‑wheel chronometer
-//		TSD_ENCRYPTION_KEY  – optional base‑64 symmetric key for data encryption
+//		TSD_ENCRYPTION_KEY  – optional base‑64 encoded 32-byte symmetric key for data encryption
+//		TSD_ENCRYPTION_KEY_FILE – path to a file holding the raw 32-byte key; mutually exclusive with TSD_ENCRYPTION_KEY
 //		TSD_TRACE_RATIO     – OpenTelemetry sampling ratio in the range [0.0‑1.0]
 //		TSD_MAX_MSG_SIZE	- optional parameter to define the maximum msg size
 //		TSD_METRICS_ADDR    – Prometheus HTTP exporter address (e.g. ":9100")
@@ -127,7 +129,7 @@ func getEnv[T any](key string, fallback T) T {
 //		TSD_REQUIRE_PASS     – server password required by AUTH (empty = no authentication)
 //		TSD_RBAC_CONFIG      – path to a YAML/JSON RBAC policy file (roles, users, default_role)
 //		TSD_ENABLE_AUDIT	 - boolean to enable audit logging (default: false)
-// 		TSD_AUDIT_LOG_PATH	 - path where the audit log file(s) will be created (default: stdout)
+//		TSD_AUDIT_LOG_PATH	 - path where the audit log file(s) will be created (default: stdout)
 //		TSD_AUDIT_EVENTS	 - comma-seperated event types on which audit events should be logged (default: auth,acl)
 //
 // args are the command-line arguments to parse (typically os.Args[1:]); pass nil for an
@@ -190,7 +192,17 @@ func LoadConfig(args []string) *Config {
 		&cfg.encryptionKey,
 		"encryption-key",
 		getEnv("TSD_ENCRYPTION_KEY", ""),
-		"Base‑64 encoded encryption key; empty disables encryption (default: none)",
+		"Base‑64 encoded 32-byte encryption key; empty disables encryption (default: none)",
+	)
+	// Optional file-sourced encryption key, e.g. a mounted Kubernetes Secret or a
+	// vault-agent-sidecar-rendered path. Mutually exclusive with --encryption-key.
+	// The file carries raw bytes rather than base64: a NUL cannot survive a process
+	// argument or environment variable, but a file has no such restriction.
+	fs.StringVar(
+		&cfg.encryptionKeyFile,
+		"encryption-key-file",
+		getEnv("TSD_ENCRYPTION_KEY_FILE", ""),
+		"Path to a file holding the raw (unencoded) 32-byte encryption key; empty disables (default: none)",
 	)
 	// OpenTelemetry trace sampling ratio.
 	fs.Float64Var(
@@ -351,6 +363,17 @@ func LoadConfig(args []string) *Config {
 	if cfg.respStartTLS && cfg.tlsCert == "" {
 		panic("tellstone: --resp-starttls requires --tls-cert and --tls-key")
 	}
+	// The raw key and file-sourced key are alternative KeyProvider backends;
+	// supplying both leaves the intended source ambiguous.
+	if cfg.encryptionKey != "" && cfg.encryptionKeyFile != "" {
+		panic("tellstone: --encryption-key and --encryption-key-file are mutually exclusive")
+	}
+	// Refuse to start rather than silently downgrade: NewEngine treats an empty key as
+	// pass-through, so without this the server would serve plaintext after the operator
+	// explicitly asked for encryption.
+	if cfg.enableEncryption && cfg.encryptionKey == "" && cfg.encryptionKeyFile == "" {
+		panic("tellstone: --enable-encryption requires --encryption-key or --encryption-key-file")
+	}
 	return cfg
 }
 
@@ -362,6 +385,7 @@ func (cfg *Config) GetEvictTicker() time.Duration     { return cfg.evictTicker }
 func (cfg *Config) GetEvictSlots() uint32             { return cfg.evictSlots }
 func (cfg *Config) EncryptionEnabled() bool           { return cfg.enableEncryption }
 func (cfg *Config) GetEncryptionKey() string          { return cfg.encryptionKey }
+func (cfg *Config) GetEncryptionKeyFile() string      { return cfg.encryptionKeyFile }
 func (cfg *Config) GetTraceRatio() float64            { return cfg.traceRatio }
 func (cfg *Config) GetMaxMsgSize() uint64             { return cfg.maxMsgSize }
 func (cfg *Config) GetMaxMemBytes() uint64            { return cfg.maxMemBytes }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -277,6 +277,60 @@ func TestTLSPanicCAOnly(t *testing.T) {
 	LoadConfig([]string{"--tls-ca", "/path/to/ca.pem"})
 }
 
+func TestEncryptionKeyFileFlagAndEnv(t *testing.T) {
+	t.Setenv("TSD_ENCRYPTION_KEY", "")
+	cfg := LoadConfig([]string{"--encryption-key-file", "/path/to/key"})
+	if cfg.GetEncryptionKeyFile() != "/path/to/key" {
+		t.Fatalf("EncryptionKeyFile mismatch: %s", cfg.GetEncryptionKeyFile())
+	}
+	if cfg.GetEncryptionKey() != "" {
+		t.Fatalf("EncryptionKey should be empty when only the file flag is set")
+	}
+
+	t.Setenv("TSD_ENCRYPTION_KEY_FILE", "/env/key")
+	cfg = LoadConfig(nil)
+	if cfg.GetEncryptionKeyFile() != "/env/key" {
+		t.Fatalf("EncryptionKeyFile env mismatch: %s", cfg.GetEncryptionKeyFile())
+	}
+}
+
+func TestEncryptionKeyPanicWhenBothSourcesSet(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic when both --encryption-key and --encryption-key-file are set")
+		}
+	}()
+	LoadConfig([]string{"--encryption-key", "raw-key-value", "--encryption-key-file", "/path/to/key"})
+}
+
+// An empty key puts the crypto engine in pass-through mode, so accepting this
+// configuration would serve plaintext while the operator believes encryption is on.
+func TestEnableEncryptionPanicWithoutKeySource(t *testing.T) {
+	t.Setenv("TSD_ENCRYPTION_KEY", "")
+	t.Setenv("TSD_ENCRYPTION_KEY_FILE", "")
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic when --enable-encryption is set with no key source")
+		}
+	}()
+	LoadConfig([]string{"--enable-encryption"})
+}
+
+func TestEnableEncryptionAcceptsEitherKeySource(t *testing.T) {
+	t.Setenv("TSD_ENCRYPTION_KEY", "")
+	t.Setenv("TSD_ENCRYPTION_KEY_FILE", "")
+
+	cfg := LoadConfig([]string{"--enable-encryption", "--encryption-key", "raw-key-value"})
+	if !cfg.EncryptionEnabled() || cfg.GetEncryptionKey() != "raw-key-value" {
+		t.Fatal("raw key source should be accepted with --enable-encryption")
+	}
+
+	cfg = LoadConfig([]string{"--enable-encryption", "--encryption-key-file", "/path/to/key"})
+	if !cfg.EncryptionEnabled() || cfg.GetEncryptionKeyFile() != "/path/to/key" {
+		t.Fatal("file key source should be accepted with --enable-encryption")
+	}
+}
+
 func TestTLSEnvVars(t *testing.T) {
 	t.Setenv("TSD_TLS_CERT", "/env/cert.pem")
 	t.Setenv("TSD_TLS_KEY", "/env/key.pem")

--- a/internal/app/tellstone/startup.go
+++ b/internal/app/tellstone/startup.go
@@ -60,13 +60,17 @@ func (a *App) Start(cfg *config.Config, logger log.Logger) {
 		)
 	}
 	if cfg.EncryptionEnabled() {
-		if cfg.GetEncryptionKey() == "" {
-			if logger.Enabled(log.LevelFatal) {
-				logger.Log(log.LevelFatal, "Encryption key must be provided", log.String("error", "encryption key is missing but encryption is enabled"))
-			}
+		// A missing key source is rejected in config.LoadConfig, which runs before
+		// this banner; reaching this branch means a key is present.
+		keySource := "flag/env"
+		if cfg.GetEncryptionKeyFile() != "" {
+			keySource = "file"
 		}
 		if logger.Enabled(log.LevelInfo) {
-			logger.Log(log.LevelInfo, "Engine crypto status", log.String("encryption", "ENABLED (ChaCha20-Poly1305)"))
+			logger.Log(log.LevelInfo, "Engine crypto status",
+				log.String("encryption", "ENABLED (ChaCha20-Poly1305)"),
+				log.String("key_source", keySource),
+			)
 		}
 	} else {
 		if logger.Enabled(log.LevelWarn) {

--- a/internal/crypto/README.md
+++ b/internal/crypto/README.md
@@ -66,6 +66,12 @@ variables are NUL-terminated: a key containing `0x00` — about 1 in 8 random 32
 cannot pass through them intact. A file has no such restriction, so it carries raw bytes
 and every byte is significant (no trailing-newline trimming).
 
+`Base64KeyProvider` accepts the padded and unpadded standard encodings, and falls back to
+a **deprecated** raw 32-character value so deployments predating the decoding keep
+starting; that path logs a warning and is scheduled for removal in the next major release.
+Requiring an exact 32-byte result rules out the raw form before the
+fallback is reached.
+
 Both are resolved exactly once, when `server.initCrypto` builds the `Engine` — the key
 is not re-read while the server is running, so rotating a mounted key file requires a
 restart. External Vault/KMS-backed providers can be added by implementing `KeyProvider`

--- a/internal/crypto/README.md
+++ b/internal/crypto/README.md
@@ -41,6 +41,39 @@ func (e *Engine) DecryptInPlaceWithDst(dst, ciphertext []byte) ([]byte, error)
 
 ---
 
+## 🔑 Key Sourcing
+
+`NewEngine` always takes raw key bytes — where those bytes come from is decided once,
+at startup, via a `KeyProvider`:
+
+```go
+// KeyProvider resolves the raw encryption key. Resolution happens once at server
+// startup; implementations are not called from the encrypt/decrypt hot path.
+type KeyProvider interface {
+    Key() ([]byte, error)
+}
+```
+
+Two backends ship in this package:
+
+| Provider | Source | Config |
+|---|---|---|
+| `Base64KeyProvider` | Base64 string decoded to 32 bytes | `--encryption-key` / `TSD_ENCRYPTION_KEY` |
+| `FileKeyProvider` | Raw 32 bytes read from a file (e.g. a mounted Kubernetes Secret or vault-agent-sidecar path) | `--encryption-key-file` / `TSD_ENCRYPTION_KEY_FILE` |
+
+The flag/env source is base64 rather than raw because process arguments and environment
+variables are NUL-terminated: a key containing `0x00` — about 1 in 8 random 32-byte keys —
+cannot pass through them intact. A file has no such restriction, so it carries raw bytes
+and every byte is significant (no trailing-newline trimming).
+
+Both are resolved exactly once, when `server.initCrypto` builds the `Engine` — the key
+is not re-read while the server is running, so rotating a mounted key file requires a
+restart. External Vault/KMS-backed providers can be added by implementing `KeyProvider`
+in a separate, opt-in module without touching `Engine`, `EncryptInPlace`, or
+`DecryptInPlaceWithDst`.
+
+---
+
 ## 📈 Benchmarks
 
 The benchmark suite lives in `internal/crypto/benchmark_test.go` and `internal/storage/benchmark_crypto_test.go`. Below are the most recent results (run on an AMD Ryzen 9 9950X, 16 Cores, Go 1.22).

--- a/internal/crypto/keyprovider.go
+++ b/internal/crypto/keyprovider.go
@@ -1,0 +1,23 @@
+/*
+Package crypto
+Tellstone Encryption Key Sourcing
+File: keyprovider.go
+Description: KeyProvider abstracts how the 32-byte ChaCha20-Poly1305 key is sourced, so
+NewEngine and the hot-path Encrypt/Decrypt calls stay agnostic of whether the key came
+from a CLI flag, a mounted file, or (via a separate opt-in module) an external secret
+manager.
+
+Authors:
+
+	Mohamad Radi
+*/
+package crypto
+
+// KeyProvider resolves the raw encryption key. Resolution happens once at server
+// startup; implementations are not called from the encrypt/decrypt hot path and may
+// perform I/O.
+type KeyProvider interface {
+	// Key returns the raw key bytes. A nil or empty key with a nil error means
+	// encryption is disabled; NewEngine enforces the required 32-byte length.
+	Key() ([]byte, error)
+}

--- a/internal/crypto/keyprovider.go
+++ b/internal/crypto/keyprovider.go
@@ -13,6 +13,9 @@ Authors:
 */
 package crypto
 
+// keySize is the ChaCha20-Poly1305 key length that NewEngine enforces.
+const keySize = 32
+
 // KeyProvider resolves the raw encryption key. Resolution happens once at server
 // startup; implementations are not called from the encrypt/decrypt hot path and may
 // perform I/O.

--- a/internal/crypto/keyprovider_base64.go
+++ b/internal/crypto/keyprovider_base64.go
@@ -1,0 +1,45 @@
+/*
+Package crypto
+Tellstone Encryption Key Sourcing
+File: keyprovider_base64.go
+Description: KeyProvider implementation for a key supplied as a base64 string through a
+CLI flag or environment variable.
+
+Authors:
+
+	Mohamad Radi
+*/
+package crypto
+
+import (
+	"encoding/base64"
+	"fmt"
+)
+
+// Base64KeyProvider decodes a standard-encoding base64 string into raw key bytes.
+//
+// The transport has to be text: process arguments and environment variables are
+// NUL-terminated, so a key containing 0x00 — about 1 in 8 random 32-byte keys — cannot
+// pass through them intact. Binary keys therefore belong in a file; see FileKeyProvider.
+type Base64KeyProvider struct {
+	encoded string
+}
+
+// NewBase64KeyProvider wraps the value of --encryption-key / TSD_ENCRYPTION_KEY.
+func NewBase64KeyProvider(encoded string) *Base64KeyProvider {
+	return &Base64KeyProvider{encoded: encoded}
+}
+
+// Key decodes the wrapped string. An empty string yields a nil key, which leaves the
+// engine in pass-through mode.
+func (p *Base64KeyProvider) Key() ([]byte, error) {
+	if p.encoded == "" {
+		return nil, nil
+	}
+	key, err := base64.StdEncoding.DecodeString(p.encoded)
+	if err != nil {
+		// The key itself must never reach the logs, so report only the failure.
+		return nil, fmt.Errorf("crypto: decode base64 encryption key: %w", err)
+	}
+	return key, nil
+}

--- a/internal/crypto/keyprovider_base64.go
+++ b/internal/crypto/keyprovider_base64.go
@@ -13,21 +13,29 @@ package crypto
 
 import (
 	"encoding/base64"
-	"fmt"
+	"errors"
+
+	"github.com/Saxy/Tellstone/internal/log"
 )
 
-// Base64KeyProvider decodes a standard-encoding base64 string into raw key bytes.
+// Base64KeyProvider decodes a base64 string into raw key bytes, accepting the padded
+// and unpadded standard encodings.
 //
 // The transport has to be text: process arguments and environment variables are
 // NUL-terminated, so a key containing 0x00 — about 1 in 8 random 32-byte keys — cannot
 // pass through them intact. Binary keys therefore belong in a file; see FileKeyProvider.
 type Base64KeyProvider struct {
 	encoded string
+	logger  log.Logger
 }
 
-// NewBase64KeyProvider wraps the value of --encryption-key / TSD_ENCRYPTION_KEY.
-func NewBase64KeyProvider(encoded string) *Base64KeyProvider {
-	return &Base64KeyProvider{encoded: encoded}
+// NewBase64KeyProvider wraps the value of --encryption-key / TSD_ENCRYPTION_KEY. The
+// logger reports use of the deprecated raw form; a nil logger silences it.
+func NewBase64KeyProvider(encoded string, logger log.Logger) *Base64KeyProvider {
+	if logger == nil {
+		logger = log.NewNoOpLogger()
+	}
+	return &Base64KeyProvider{encoded: encoded, logger: logger}
 }
 
 // Key decodes the wrapped string. An empty string yields a nil key, which leaves the
@@ -36,10 +44,26 @@ func (p *Base64KeyProvider) Key() ([]byte, error) {
 	if p.encoded == "" {
 		return nil, nil
 	}
-	key, err := base64.StdEncoding.DecodeString(p.encoded)
-	if err != nil {
-		// The key itself must never reach the logs, so report only the failure.
-		return nil, fmt.Errorf("crypto: decode base64 encryption key: %w", err)
+	for _, encoding := range []*base64.Encoding{base64.StdEncoding, base64.RawStdEncoding} {
+		if key, err := encoding.DecodeString(p.encoded); err == nil && len(key) == keySize {
+			return key, nil
+		}
 	}
-	return key, nil
+	// DEPRECATED: the raw 32-byte value. This flag has always documented itself as
+	// base64 but never decoded, so deployments predating that fix pass the key as plain
+	// text. Accepting it keeps them starting within v1. Remove this branch, its test,
+	// and the deprecation notes in README.md and internal/crypto/README.md in v2, which
+	// leaves base64 as the only accepted form.
+	if len(p.encoded) == keySize {
+		if p.logger.Enabled(log.LevelWarn) {
+			// Re-encoding preserves the existing key; generating a new one would leave
+			// already-encrypted data unreadable.
+			p.logger.Log(log.LevelWarn, "raw --encryption-key value is deprecated and insecure",
+				log.String("use", `--encryption-key "$(printf %s "$KEY" | base64)", or --encryption-key-file`),
+			)
+		}
+		return []byte(p.encoded), nil
+	}
+	// Deliberately describes the accepted shapes without echoing the key itself.
+	return nil, errors.New("crypto: --encryption-key must be a base64-encoded 32-byte key (44 characters padded, 43 unpadded), or the deprecated raw 32-character value")
 }

--- a/internal/crypto/keyprovider_file.go
+++ b/internal/crypto/keyprovider_file.go
@@ -1,0 +1,52 @@
+/*
+Package crypto
+Tellstone Encryption Key Sourcing
+File: keyprovider_file.go
+Description: KeyProvider implementation that reads the encryption key from a file,
+typically a mounted Kubernetes Secret or a vault-agent-sidecar-rendered path.
+
+Authors:
+
+	Mohamad Radi
+*/
+package crypto
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// keyReadLimit is one byte more than a valid key. The extra byte is what lets an
+// oversized file be rejected: capping the read at 32 would silently accept the first
+// 32 bytes of an arbitrarily long file as a valid key.
+const keyReadLimit = 33
+
+// FileKeyProvider reads the encryption key from a file. The key is resolved once, at
+// startup; picking up a rotated file requires a process restart.
+type FileKeyProvider struct {
+	path string
+}
+
+// NewFileKeyProvider returns a provider that reads the key from path when Key is called.
+func NewFileKeyProvider(path string) *FileKeyProvider {
+	return &FileKeyProvider{path: path}
+}
+
+// Key reads and returns the file's contents verbatim. The key is raw binary, so no
+// byte is treated as formatting: trimming a trailing CR/LF would corrupt the ~1-in-128
+// random keys that legitimately end in 0x0D or 0x0A. NewEngine enforces the exact
+// 32-byte length, which also rejects a file carrying a stray trailing newline.
+func (p *FileKeyProvider) Key() ([]byte, error) {
+	file, err := os.Open(p.path)
+	if err != nil {
+		return nil, fmt.Errorf("crypto: open key file %q: %w", p.path, err)
+	}
+	defer file.Close()
+
+	raw, err := io.ReadAll(io.LimitReader(file, keyReadLimit))
+	if err != nil {
+		return nil, fmt.Errorf("crypto: read key file %q: %w", p.path, err)
+	}
+	return raw, nil
+}

--- a/internal/crypto/keyprovider_file.go
+++ b/internal/crypto/keyprovider_file.go
@@ -18,9 +18,9 @@ import (
 )
 
 // keyReadLimit is one byte more than a valid key. The extra byte is what lets an
-// oversized file be rejected: capping the read at 32 would silently accept the first
-// 32 bytes of an arbitrarily long file as a valid key.
-const keyReadLimit = 33
+// oversized file be rejected: capping the read at the key size would silently accept
+// the first 32 bytes of an arbitrarily long file as a valid key.
+const keyReadLimit = keySize + 1
 
 // FileKeyProvider reads the encryption key from a file. The key is resolved once, at
 // startup; picking up a rotated file requires a process restart.

--- a/internal/crypto/keyprovider_test.go
+++ b/internal/crypto/keyprovider_test.go
@@ -1,0 +1,229 @@
+package crypto
+
+import (
+	"bytes"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBase64KeyProvider(t *testing.T) {
+	key := []byte("0123456789abcdef0123456789abcdef")
+	p := NewBase64KeyProvider(base64.StdEncoding.EncodeToString(key))
+
+	got, err := p.Key()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(got, key) {
+		t.Fatalf("key mismatch: got %q want %q", got, key)
+	}
+}
+
+// Base64 is what makes the flag/env path usable at all: roughly 1 in 8 random 32-byte
+// keys contains a NUL, which cannot survive a process argument or environment variable.
+func TestBase64KeyProviderCarriesNULBytes(t *testing.T) {
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i) // key[0] is 0x00
+	}
+	encoded := base64.StdEncoding.EncodeToString(key)
+	if strings.ContainsRune(encoded, 0) {
+		t.Fatal("encoded form must be NUL-free to survive argv")
+	}
+
+	got, err := NewBase64KeyProvider(encoded).Key()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(got, key) {
+		t.Fatalf("key with NUL not round-tripped: got %d bytes want %d", len(got), len(key))
+	}
+	eng, err := NewEngine(got, nil)
+	if err != nil {
+		t.Fatalf("NewEngine rejected a valid key containing NUL: %v", err)
+	}
+	if !eng.Enabled() {
+		t.Fatal("engine should be enabled")
+	}
+}
+
+func TestBase64KeyProviderEmpty(t *testing.T) {
+	got, err := NewBase64KeyProvider("").Key()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty key, got %d bytes", len(got))
+	}
+}
+
+func TestBase64KeyProviderRejectsInvalidEncoding(t *testing.T) {
+	_, err := NewBase64KeyProvider("not!valid!base64!").Key()
+	if err == nil {
+		t.Fatal("expected an error for a malformed base64 key")
+	}
+	// The key material must never leak into logs or error strings.
+	if strings.Contains(err.Error(), "not!valid!base64!") {
+		t.Fatalf("error must not echo the key value: %v", err)
+	}
+}
+
+func TestFileKeyProvider(t *testing.T) {
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i)
+	}
+	path := filepath.Join(t.TempDir(), "key")
+	if err := os.WriteFile(path, key, 0o600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+
+	got, err := NewFileKeyProvider(path).Key()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(got, key) {
+		t.Fatalf("key mismatch: got %v want %v", got, key)
+	}
+}
+
+// A raw key is binary, so a terminal 0x0D/0x0A is key material rather than formatting.
+// Roughly 1 in 128 randomly generated keys ends in one of those bytes; trimming them
+// would silently corrupt the key and reject a valid file.
+func TestFileKeyProviderPreservesTerminalLineEndingBytes(t *testing.T) {
+	tests := map[string]byte{
+		"lf": '\n',
+		"cr": '\r',
+	}
+	for name, last := range tests {
+		t.Run(name, func(t *testing.T) {
+			key := make([]byte, 32)
+			for i := range key {
+				key[i] = byte(i)
+			}
+			key[31] = last
+
+			path := filepath.Join(t.TempDir(), "key")
+			if err := os.WriteFile(path, key, 0o600); err != nil {
+				t.Fatalf("write key file: %v", err)
+			}
+			got, err := NewFileKeyProvider(path).Key()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !bytes.Equal(got, key) {
+				t.Fatalf("key not preserved verbatim: got %d bytes want %d", len(got), len(key))
+			}
+			// The whole point: a 32-byte key ending in this byte must still drive the engine.
+			eng, err := NewEngine(got, nil)
+			if err != nil {
+				t.Fatalf("NewEngine rejected a valid 32-byte key: %v", err)
+			}
+			if !eng.Enabled() {
+				t.Fatal("engine should be enabled")
+			}
+		})
+	}
+}
+
+// A file carrying a stray trailing newline is 33 bytes and must be rejected rather
+// than silently trimmed back to a "valid" 32.
+func TestFileKeyProviderRejectsOversizedFile(t *testing.T) {
+	content := append(make([]byte, 32), '\n')
+	path := filepath.Join(t.TempDir(), "key")
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+
+	got, err := NewFileKeyProvider(path).Key()
+	if err != nil {
+		t.Fatalf("unexpected read error: %v", err)
+	}
+	if len(got) != 33 {
+		t.Fatalf("expected the file verbatim (33 bytes), got %d", len(got))
+	}
+	if _, err = NewEngine(got, nil); err == nil {
+		t.Fatal("expected NewEngine to reject a 33-byte key")
+	}
+}
+
+// An unbounded read of a large or endless file would stall startup or exhaust memory
+// before NewEngine ever got to check the length.
+func TestFileKeyProviderBoundsTheRead(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "key")
+	if err := os.WriteFile(path, make([]byte, 8<<20), 0o600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+
+	got, err := NewFileKeyProvider(path).Key()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != keyReadLimit {
+		t.Fatalf("read was not bounded: got %d bytes want %d", len(got), keyReadLimit)
+	}
+	// Bounded, and still rejected rather than passing off the first 32 bytes as a key.
+	if _, err = NewEngine(got, nil); err == nil {
+		t.Fatal("expected NewEngine to reject an oversized key")
+	}
+}
+
+// /dev/zero never reaches EOF, so an unbounded read of it never returns at all.
+func TestFileKeyProviderTerminatesOnEndlessFile(t *testing.T) {
+	if _, err := os.Stat("/dev/zero"); err != nil {
+		t.Skip("/dev/zero not available on this platform")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		got, err := NewFileKeyProvider("/dev/zero").Key()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+			return
+		}
+		if len(got) != keyReadLimit {
+			t.Errorf("read was not bounded: got %d bytes", len(got))
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("reading /dev/zero did not terminate: the read is unbounded")
+	}
+}
+
+func TestFileKeyProviderMissingFile(t *testing.T) {
+	_, err := NewFileKeyProvider(filepath.Join(t.TempDir(), "does-not-exist")).Key()
+	if err == nil {
+		t.Fatal("expected error for missing key file")
+	}
+}
+
+func TestFileKeyProviderFeedsEngine(t *testing.T) {
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i)
+	}
+	path := filepath.Join(t.TempDir(), "key")
+	if err := os.WriteFile(path, key, 0o600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+
+	resolved, err := NewFileKeyProvider(path).Key()
+	if err != nil {
+		t.Fatalf("resolve key: %v", err)
+	}
+	eng, err := NewEngine(resolved, nil)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	if !eng.Enabled() {
+		t.Fatal("engine should be enabled with a file-sourced 32-byte key")
+	}
+}

--- a/internal/crypto/keyprovider_test.go
+++ b/internal/crypto/keyprovider_test.go
@@ -10,16 +10,55 @@ import (
 	"time"
 )
 
-func TestBase64KeyProvider(t *testing.T) {
-	key := []byte("0123456789abcdef0123456789abcdef")
-	p := NewBase64KeyProvider(base64.StdEncoding.EncodeToString(key))
-
-	got, err := p.Key()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+// A 32-byte key is 44 base64 characters padded and 43 unpadded; both are accepted.
+func TestBase64KeyProviderAcceptsPaddedAndUnpadded(t *testing.T) {
+	key := make([]byte, keySize)
+	for i := range key {
+		key[i] = byte(i + 1)
 	}
-	if !bytes.Equal(got, key) {
-		t.Fatalf("key mismatch: got %q want %q", got, key)
+	padded := base64.StdEncoding.EncodeToString(key)
+	unpadded := base64.RawStdEncoding.EncodeToString(key)
+
+	if len(padded) != 44 || len(unpadded) != 43 {
+		t.Fatalf("unexpected encoded lengths: padded %d, unpadded %d", len(padded), len(unpadded))
+	}
+
+	for name, encoded := range map[string]string{"padded": padded, "unpadded": unpadded} {
+		t.Run(name, func(t *testing.T) {
+			got, err := NewBase64KeyProvider(encoded, nil).Key()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !bytes.Equal(got, key) {
+				t.Fatalf("key mismatch: got %d bytes want %d", len(got), len(key))
+			}
+		})
+	}
+}
+
+// DEPRECATED PATH: remove alongside the raw fallback in v2.
+//
+// The raw form predates the base64 decoding the flag always documented, so v1 keeps
+// accepting it. It cannot collide with base64: 32 characters decode to 24 bytes, never
+// the 32 the base64 branch requires.
+func TestBase64KeyProviderAcceptsDeprecatedRawValue(t *testing.T) {
+	raw := "0123456789abcdef0123456789abcdef"
+	if len(raw) != keySize {
+		t.Fatalf("fixture must be %d characters, got %d", keySize, len(raw))
+	}
+	if decoded, err := base64.StdEncoding.DecodeString(raw); err != nil || len(decoded) == keySize {
+		t.Fatalf("fixture should decode as valid base64 to a length other than %d", keySize)
+	}
+
+	got, err := NewBase64KeyProvider(raw, nil).Key()
+	if err != nil {
+		t.Fatalf("deprecated raw key must still be accepted: %v", err)
+	}
+	if !bytes.Equal(got, []byte(raw)) {
+		t.Fatalf("raw key not passed through verbatim: got %q", got)
+	}
+	if _, err = NewEngine(got, nil); err != nil {
+		t.Fatalf("NewEngine rejected the deprecated raw key: %v", err)
 	}
 }
 
@@ -35,7 +74,7 @@ func TestBase64KeyProviderCarriesNULBytes(t *testing.T) {
 		t.Fatal("encoded form must be NUL-free to survive argv")
 	}
 
-	got, err := NewBase64KeyProvider(encoded).Key()
+	got, err := NewBase64KeyProvider(encoded, nil).Key()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -52,7 +91,7 @@ func TestBase64KeyProviderCarriesNULBytes(t *testing.T) {
 }
 
 func TestBase64KeyProviderEmpty(t *testing.T) {
-	got, err := NewBase64KeyProvider("").Key()
+	got, err := NewBase64KeyProvider("", nil).Key()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -62,7 +101,7 @@ func TestBase64KeyProviderEmpty(t *testing.T) {
 }
 
 func TestBase64KeyProviderRejectsInvalidEncoding(t *testing.T) {
-	_, err := NewBase64KeyProvider("not!valid!base64!").Key()
+	_, err := NewBase64KeyProvider("not!valid!base64!", nil).Key()
 	if err == nil {
 		t.Fatal("expected an error for a malformed base64 key")
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -286,7 +286,7 @@ func (s *Server) initCrypto() (*crypto.Engine, error) {
 	case cfg.GetEncryptionKeyFile() != "":
 		provider = crypto.NewFileKeyProvider(cfg.GetEncryptionKeyFile())
 	default:
-		provider = crypto.NewBase64KeyProvider(cfg.GetEncryptionKey())
+		provider = crypto.NewBase64KeyProvider(cfg.GetEncryptionKey(), logger)
 	}
 	key, err := provider.Key()
 	if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -270,13 +270,32 @@ func (s *Server) shutdown(ctx context.Context) {
 	}
 }
 
+// initCrypto resolves the encryption key and builds the at-rest cipher engine. The key
+// comes from whichever KeyProvider matches the configured source — a file when
+// --encryption-key-file is set, otherwise the base64 flag value — and is read exactly
+// once here, never from the encrypt/decrypt hot path. It returns a nil engine when
+// encryption is disabled, which leaves callers in pass-through mode.
 func (s *Server) initCrypto() (*crypto.Engine, error) {
 	cfg := s.app.GetConfig()
 	logger := s.app.GetLogger()
 	if !cfg.EncryptionEnabled() {
 		return nil, nil
 	}
-	cryptoEngine, err := crypto.NewEngine([]byte(cfg.GetEncryptionKey()), logger)
+	var provider crypto.KeyProvider
+	switch {
+	case cfg.GetEncryptionKeyFile() != "":
+		provider = crypto.NewFileKeyProvider(cfg.GetEncryptionKeyFile())
+	default:
+		provider = crypto.NewBase64KeyProvider(cfg.GetEncryptionKey())
+	}
+	key, err := provider.Key()
+	if err != nil {
+		if logger.Enabled(log.LevelError) {
+			logger.Log(log.LevelError, "encryption key resolution failed", log.String("error", err.Error()))
+		}
+		return nil, fmt.Errorf("encryption key resolution: %w", err)
+	}
+	cryptoEngine, err := crypto.NewEngine(key, logger)
 	if err != nil {
 		if logger.Enabled(log.LevelError) {
 			logger.Log(log.LevelError, "crypto engine setup failed", log.String("error", err.Error()))


### PR DESCRIPTION
## Description

Adds a `KeyProvider` abstraction in `internal/crypto` so the encryption key can be
sourced from a file (`--encryption-key-file` / `TSD_ENCRYPTION_KEY_FILE`) instead of
only a flag value. The two sources are mutually exclusive, validated in
`config.LoadConfig`.

**Component:** CLI, Crypto

**Type of Change:**
- [ ] Bug fix
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Build / CI / Documentation

---

## Related Issue

Addresses #33 (file-sourced key backend). Not closing it — automatic rotation, also
in #33's acceptance criteria, is out of scope here and tracked separately by #12.

---

## Technical Deep Dive & Context

Implementation:

- `KeyProvider` is a one-method interface (`Key() ([]byte, error)`) in
  `internal/crypto/keyprovider.go`. `server.initCrypto` selects an implementation
  from config, calls `Key()` once, and passes the bytes to the existing
  `crypto.NewEngine`. `EncryptInPlace` / `DecryptInPlace*` in `cipher.go` are
  untouched, so nothing is added to the hot path.
- `Base64KeyProvider` decodes the flag/env string; its error deliberately does not
  echo the key value. It also still accepts the raw 32-byte value that worked before
  this PR — deprecated, logged with a startup warning, and planned for removal in the
  next major release. `FileKeyProvider` returns the file verbatim — a raw key is
  binary, so trimming a trailing CR/LF would corrupt the ~1-in-128 keys ending in
  `0x0D`/`0x0A`.
- The file read is bounded to 33 bytes via `io.LimitReader`. The limit is 33 rather
  than 32 so an oversized file is still rejected by `NewEngine`'s length check
  instead of having its first 32 bytes silently accepted.
- `--enable-encryption` with no key source is now rejected in `LoadConfig`. It
  previously logged at `LevelFatal` without terminating — `LevelFatal` maps to slog
  `ERROR` and there is no `os.Exit` — so the server continued and served plaintext
  in pass-through mode after the operator had asked for encryption.
- The key is read once at startup. Live rotation is deliberately excluded: WAL and
  snapshot records carry no key-version tag, so swapping the key under a running
  server would make existing ciphertext undecryptable. That needs #12 first.

---

## Performance & Benchmarks (If Applicable)

No measurable change — no hot-path code was modified.

```text
$ go test -bench=. -benchmem -run=^$ ./internal/storage/...
BenchmarkEngineGetWithEncryptionNoAlloc-16    6325273    181.3 ns/op    0 B/op    0 allocs/op
```

`task bench:resp` (RESP smoke test, encryption disabled): ~634k ops/sec, p99 0.295 ms,
no errors.

---

## How Has This Been Tested?

```text
$ go test ./...          all packages ok
$ go test -race ./...    all packages ok
$ go vet ./...           clean
$ gofmt -l <changed>     clean
```

15 new tests across `internal/crypto/keyprovider_test.go` and `config/config_test.go`:

- base64 round-trip; a key containing `0x00` end-to-end into `NewEngine`; empty value;
  malformed encoding (asserting the key is not echoed in the error)
- file key verbatim; terminal `0x0D`/`0x0A` preserved; 33-byte file rejected; 8 MB file
  read bounded to 33 bytes; `/dev/zero` terminates rather than hanging; missing file
- config: flag/env wiring, mutual-exclusion panic, `--enable-encryption` with no key
  source panics, and both sources individually accepted

Manual: started the binary with `--encryption-key-file` and confirmed
`"key_source":"file"`; confirmed `--encryption-key-file /dev/zero` now exits with a
length error instead of hanging.

---

## Documentation

- `README.md` — flag table gains `--encryption-key-file`, corrects `--encryption-key`
  to base64, and adds a configuration section covering both sources plus an upgrade note.
- `internal/crypto/README.md` — new "Key Sourcing" section with the provider table and
  the reason the flag is base64 while the file is raw.
- Flag help text and the `LoadConfig` env-var doc block in `config/config.go`.

---

## Checklist

- [x] My code follows the existing code style of this project
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally (`go test ./...` and `go test -race ./...`)
- [x] I have updated the documentation (README, comments, or any relevant docs)
- [x] My changes generate no new `go vet` warnings
- [x] Any breaking changes are documented and communicated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added support for loading encryption keys from a file.
- Encryption now accepts either a base64-encoded 32-byte key or a raw 32-byte key file.
- Added validation for missing or conflicting key sources.
- Startup logs identify the selected key source.
- Improved handling and reporting of key-file read and validation errors.

## Documentation
- Updated configuration guidance, examples, key rotation details, and upgrade instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->