### PR TITLE
feat(crypto): add envelope encryption

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	evictTicker       time.Duration
 	evictSlots        uint32
 	enableEncryption  bool
+	enableEnvelope    bool
 	encryptionKey     string
 	encryptionKeyFile string
 	traceRatio        float64
@@ -122,6 +123,7 @@ func getEnv[T any](key string, fallback T) T {
 //		TSD_RESP_STARTTLS   – allow RESP clients to upgrade plaintext connections to TLS
 //		TSD_ENABLE_METRICS  – boolean to activate the Prometheus exporter (default: false)
 //	 	TSD_ENABLE_ENCRYPTION  – boolean to enforce data-at-rest encryption (default: false)
+//	 	TSD_ENABLE_ENVELOPE    – boolean to enable envelope encryption (KEK wraps a per-shard DEK; default: false)
 //		TSD_SHUTDOWN_TIMEOUT – max wait for graceful shutdown on SIGINT/SIGTERM (default: 10s)
 //		TSD_NUM_SHARDS      – number of shared-nothing shards (default: GOMAXPROCS)
 //		TSD_ENABLE_PERSISTENCE – boolean to enable WAL persistence (default: false)
@@ -209,6 +211,14 @@ func LoadConfig(args []string) *Config {
 		"encryption-key-file",
 		getEnv("TSD_ENCRYPTION_KEY_FILE", ""),
 		"Path to a file holding the raw (unencoded) 32-byte encryption key; empty disables (default: none)",
+	)
+	// Envelope encryption: the configured key becomes a KEK that wraps a per-shard
+	// random DEK. Opt-in; the legacy single-key mode remains the default.
+	fs.BoolVar(
+		&cfg.enableEnvelope,
+		"enable-envelope",
+		getEnv("TSD_ENABLE_ENVELOPE", false),
+		"Envelope encryption: wrap a per-shard random DEK with the configured key (default: false)",
 	)
 	// OpenTelemetry trace sampling ratio.
 	fs.Float64Var(
@@ -402,6 +412,10 @@ func LoadConfig(args []string) *Config {
 	if cfg.enableEncryption && cfg.encryptionKey == "" && cfg.encryptionKeyFile == "" {
 		panic("tellstone: --enable-encryption requires --encryption-key or --encryption-key-file")
 	}
+	// Envelope encryption is a mode of --enable-encryption, not a substitute for it.
+	if cfg.enableEnvelope && !cfg.enableEncryption {
+		panic("tellstone: --enable-envelope requires --enable-encryption")
+	}
 	return cfg
 }
 
@@ -412,6 +426,7 @@ func (cfg *Config) GetLogLevel() log.Level            { return cfg.logLevel }
 func (cfg *Config) GetEvictTicker() time.Duration     { return cfg.evictTicker }
 func (cfg *Config) GetEvictSlots() uint32             { return cfg.evictSlots }
 func (cfg *Config) EncryptionEnabled() bool           { return cfg.enableEncryption }
+func (cfg *Config) EnvelopeEnabled() bool             { return cfg.enableEnvelope }
 func (cfg *Config) GetEncryptionKey() string          { return cfg.encryptionKey }
 func (cfg *Config) GetEncryptionKeyFile() string      { return cfg.encryptionKeyFile }
 func (cfg *Config) GetTraceRatio() float64            { return cfg.traceRatio }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -331,6 +331,35 @@ func TestEnableEncryptionAcceptsEitherKeySource(t *testing.T) {
 	}
 }
 
+func TestEnableEnvelopePanicWithoutEncryption(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic when --enable-envelope is set without --enable-encryption")
+		}
+	}()
+	LoadConfig([]string{"--enable-envelope"})
+}
+
+func TestEnableEnvelopeRequiresKeySource(t *testing.T) {
+	t.Setenv("TSD_ENCRYPTION_KEY", "")
+	t.Setenv("TSD_ENCRYPTION_KEY_FILE", "")
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic when --enable-envelope has no key source")
+		}
+	}()
+	LoadConfig([]string{"--enable-encryption", "--enable-envelope"})
+}
+
+func TestEnableEnvelopeAcceptedWithKey(t *testing.T) {
+	t.Setenv("TSD_ENCRYPTION_KEY", "")
+	t.Setenv("TSD_ENCRYPTION_KEY_FILE", "")
+	cfg := LoadConfig([]string{"--enable-encryption", "--enable-envelope", "--encryption-key", "raw-key-value"})
+	if !cfg.EnvelopeEnabled() {
+		t.Fatal("envelope mode should be enabled")
+	}
+}
+
 func TestTLSEnvVars(t *testing.T) {
 	t.Setenv("TSD_TLS_CERT", "/env/cert.pem")
 	t.Setenv("TSD_TLS_KEY", "/env/key.pem")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -332,6 +332,9 @@ func TestEnableEncryptionAcceptsEitherKeySource(t *testing.T) {
 }
 
 func TestEnableEnvelopePanicWithoutEncryption(t *testing.T) {
+	t.Setenv("TSD_ENABLE_ENCRYPTION", "false")
+	t.Setenv("TSD_ENCRYPTION_KEY", "")
+	t.Setenv("TSD_ENCRYPTION_KEY_FILE", "")
 	defer func() {
 		if r := recover(); r == nil {
 			t.Fatal("expected panic when --enable-envelope is set without --enable-encryption")

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Saxy/Tellstone/internal/crypto"
 	"github.com/Saxy/Tellstone/internal/log"
 )
 
@@ -141,7 +140,11 @@ func TestDefaultEventTypesExist(t *testing.T) {
 // how the server constructs an audit engine without encryption enabled.
 func newTestEngine(t *testing.T, enabled bool, filter *eventSet, dir string) *LogEngine {
 	t.Helper()
-	return NewLogEngine(enabled, filter, dir, log.NewNoOpLogger(), crypto.Engine{})
+	e, err := NewLogEngine(enabled, filter, dir, log.NewNoOpLogger(), false, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return e
 }
 
 // readAuditFiles returns the contents of every *_tsd.log file in dir.

--- a/internal/audit/engine.go
+++ b/internal/audit/engine.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"os"
 	"sync"
 	"time"
@@ -32,14 +31,6 @@ import (
 
 // auditLevel is the fixed severity label emitted in every JSON audit line.
 const auditLevel = "AUDIT"
-
-// auditEnvelopeID is the envelope identity of the shared audit log. Shard
-// envelopes occupy IDs 0..numShards-1 in the persistence directory, while the
-// audit log owns exactly one envelope of its own, stored beside its records.
-// The sentinel can never collide with a real shard regardless of the configured
-// shard count and stays fixed across restarts — even if numShards changes — so
-// the audit DEK survives and the fingerprint check never fails spuriously.
-const auditEnvelopeID uint32 = math.MaxUint32
 
 // LogEngine is the concrete audit logger. When enabled is false (--enable-audit
 // not set), Record() returns immediately with a single bool comparison — no
@@ -58,6 +49,8 @@ type LogEngine struct {
 	// cause, which would hide the root failure from the operator.
 	firstErr error
 }
+
+var envelopeFileName = "audit.env"
 
 // NewLogEngine creates an audit engine. When enabled is false, the engine is
 // a lightweight no-op: no writer opened, no encoder created, Record() is a
@@ -97,7 +90,7 @@ func NewLogEngine(
 		if err != nil {
 			return nil, fmt.Errorf("audit: envelope init: %w", err)
 		}
-		dek, err := env.Load(auditLogPath, auditEnvelopeID)
+		dek, err := env.Load(auditLogPath, envelopeFileName)
 		if err != nil {
 			if !errors.Is(err, os.ErrNotExist) {
 				return nil, fmt.Errorf("audit: load envelope: %w", err)
@@ -105,7 +98,7 @@ func NewLogEngine(
 			if err = env.GenerateDEK(); err != nil {
 				return nil, fmt.Errorf("audit: generate DEK: %w", err)
 			}
-			if err = env.Store(auditLogPath, auditEnvelopeID); err != nil {
+			if err = env.Store(auditLogPath, envelopeFileName); err != nil {
 				return nil, fmt.Errorf("audit: store envelope: %w", err)
 			}
 			dek = env.DEK()

--- a/internal/audit/engine.go
+++ b/internal/audit/engine.go
@@ -117,16 +117,7 @@ func NewLogEngine(
 	}
 	f, err := newFile(auditLogPath, engine, logger)
 	if err != nil {
-		// fallback to stdout in case of error with a file
-		if logger.Enabled(log.LevelError) {
-			logger.Log(log.LevelError, "audit: initial file creation failed -- activate fallback to stdout", log.String("error", err.Error()))
-		}
-		return &LogEngine{
-			enabled: true,
-			filter:  filter,
-			writer:  os.Stdout,
-			enc:     json.NewEncoder(os.Stdout),
-		}, nil
+		return nil, err
 	}
 	return &LogEngine{
 		enabled: true,

--- a/internal/audit/engine.go
+++ b/internal/audit/engine.go
@@ -18,7 +18,10 @@ package audit
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
+	"math"
 	"os"
 	"sync"
 	"time"
@@ -29,6 +32,14 @@ import (
 
 // auditLevel is the fixed severity label emitted in every JSON audit line.
 const auditLevel = "AUDIT"
+
+// auditEnvelopeID is the envelope identity of the shared audit log. Shard
+// envelopes occupy IDs 0..numShards-1 in the persistence directory, while the
+// audit log owns exactly one envelope of its own, stored beside its records.
+// The sentinel can never collide with a real shard regardless of the configured
+// shard count and stays fixed across restarts — even if numShards changes — so
+// the audit DEK survives and the fingerprint check never fails spuriously.
+const auditEnvelopeID uint32 = math.MaxUint32
 
 // LogEngine is the concrete audit logger. When enabled is false (--enable-audit
 // not set), Record() returns immediately with a single bool comparison — no
@@ -54,31 +65,76 @@ type LogEngine struct {
 // log path: "stdout" writes JSON to os.Stdout, any other value is treated as
 // a directory whose audit files are created and rotated automatically. The
 // path is only inspected when enabled, so a disabled engine pays nothing.
-func NewLogEngine(enabled bool, filter *eventSet, auditLogPath string, logger log.Logger, engine crypto.Engine) *LogEngine {
+//
+// In envelope mode (envelopeEnabled) the audit log uses a DEK of its own —
+// never the operator's KEK, never a shard's DEK — wrapped by the KEK and
+// stored as an envelope file beside the audit records, mirroring how each
+// shard seals its data. A changed KEK is rejected (fail-closed) instead of
+// silently generating a fresh DEK and bricking the audit history. A stdout
+// destination is never persisted, so no envelope is created and records stay
+// plaintext.
+func NewLogEngine(
+	enabled bool,
+	filter *eventSet,
+	auditLogPath string,
+	logger log.Logger,
+	envelopeEnabled bool,
+	key []byte,
+	engine *crypto.Engine) (*LogEngine, error) {
 	if !enabled {
-		return &LogEngine{enabled: false}
+		return &LogEngine{enabled: false}, nil
 	}
-	writer := io.Writer(os.Stdout)
-	var closeFn func() error
-	if auditLogPath != "" && auditLogPath != "stdout" {
-		f, err := newFile(auditLogPath, engine, logger)
+	if auditLogPath == "" || auditLogPath == "stdout" {
+		return &LogEngine{
+			enabled: true,
+			filter:  filter,
+			writer:  os.Stdout,
+			enc:     json.NewEncoder(os.Stdout),
+		}, nil
+	}
+	if envelopeEnabled {
+		env, err := crypto.NewEnvelope(key, logger)
 		if err != nil {
-			// fallback to stdout in case of error with a file
-			if logger.Enabled(log.LevelError) {
-				logger.Log(log.LevelError, "audit: initial file creation failed -- activate fallback to stdout", log.String("error", err.Error()))
-			}
-		} else {
-			writer = f
-			closeFn = f.Close
+			return nil, fmt.Errorf("audit: envelope init: %w", err)
 		}
+		dek, err := env.Load(auditLogPath, auditEnvelopeID)
+		if err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				return nil, fmt.Errorf("audit: load envelope: %w", err)
+			}
+			if err = env.GenerateDEK(); err != nil {
+				return nil, fmt.Errorf("audit: generate DEK: %w", err)
+			}
+			if err = env.Store(auditLogPath, auditEnvelopeID); err != nil {
+				return nil, fmt.Errorf("audit: store envelope: %w", err)
+			}
+			dek = env.DEK()
+		}
+		engine, err = crypto.NewEngine(dek, logger)
+		if err != nil {
+			return nil, fmt.Errorf("audit: data engine init: %w", err)
+		}
+	}
+	f, err := newFile(auditLogPath, engine, logger)
+	if err != nil {
+		// fallback to stdout in case of error with a file
+		if logger.Enabled(log.LevelError) {
+			logger.Log(log.LevelError, "audit: initial file creation failed -- activate fallback to stdout", log.String("error", err.Error()))
+		}
+		return &LogEngine{
+			enabled: true,
+			filter:  filter,
+			writer:  os.Stdout,
+			enc:     json.NewEncoder(os.Stdout),
+		}, nil
 	}
 	return &LogEngine{
 		enabled: true,
 		filter:  filter,
-		writer:  writer,
-		enc:     json.NewEncoder(writer),
-		closeFn: closeFn,
-	}
+		writer:  f,
+		enc:     json.NewEncoder(f),
+		closeFn: f.Close,
+	}, nil
 }
 
 // Record writes one audit event. When the engine is not enabled, this is a

--- a/internal/audit/file.go
+++ b/internal/audit/file.go
@@ -39,7 +39,7 @@ type file struct {
 	dir          string
 	path         string
 	isEncrypted  bool
-	ce           crypto.Engine
+	ce           *crypto.Engine
 	file         *os.File
 	bytesWritten uint64
 	maxSize      uint64
@@ -49,9 +49,9 @@ type file struct {
 
 // newFile opens the first audit file inside dir. When engine.Enabled() is
 // false, records are written as plaintext; otherwise every record is sealed.
-func newFile(dir string, engine crypto.Engine, logger log.Logger) (*file, error) {
+func newFile(dir string, engine *crypto.Engine, logger log.Logger) (*file, error) {
 	f := &file{dir: dir, maxSize: rotateAfterBytes}
-	if engine.Enabled() {
+	if engine != nil && engine.Enabled() {
 		f.isEncrypted = true
 		f.ce = engine
 	}

--- a/internal/audit/file_test.go
+++ b/internal/audit/file_test.go
@@ -286,7 +286,7 @@ func TestFileAuditLoggingEnvelope(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	dek, err := env.Load(dir, auditEnvelopeID)
+	dek, err := env.Load(dir, envelopeFileName)
 	if err != nil {
 		t.Fatalf("failed to load audit DEK for decoding: %v", err)
 	}

--- a/internal/audit/file_test.go
+++ b/internal/audit/file_test.go
@@ -87,7 +87,7 @@ func TestFileNameContainsTimestampHashAndMarker(t *testing.T) {
 	if len(parts) != 3 {
 		t.Fatalf("expected <timestamp>_<hash>_<pid>_tsd.log, got %q", base)
 	}
-	if _, err := fmt.Sscanf(parts[0], "%d", new(int64)); err != nil {
+	if _, err = fmt.Sscanf(parts[0], "%d", new(int64)); err != nil {
 		t.Fatalf("timestamp segment %q is not numeric: %v", parts[0], err)
 	}
 	if len(parts[1]) != 8 {
@@ -131,10 +131,10 @@ func TestFileRotation(t *testing.T) {
 		t.Fatalf("previous file holds %q, want both writes", data)
 	}
 
-	if _, err := f.Write([]byte("xyz")); err != nil {
+	if _, err = f.Write([]byte("xyz")); err != nil {
 		t.Fatal(err)
 	}
-	if err := f.Close(); err != nil {
+	if err = f.Close(); err != nil {
 		t.Fatal(err)
 	}
 	data, err = os.ReadFile(f.path)
@@ -243,7 +243,7 @@ func TestFileAuditLoggingEnvelope(t *testing.T) {
 		t.Fatal(err)
 	}
 	e.Record(EventAuthSuccess, "user logged in", log.String("user", "alice"))
-	if err := e.Close(); err != nil {
+	if err = e.Close(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -271,7 +271,7 @@ func TestFileAuditLoggingEnvelope(t *testing.T) {
 		t.Fatal(err)
 	}
 	e2.Record(EventACLDeny, "command denied")
-	if err := e2.Close(); err != nil {
+	if err = e2.Close(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -298,7 +298,7 @@ func TestFileAuditLoggingEnvelope(t *testing.T) {
 	// Every record across both boots decodes with the restored DEK.
 	var msgs []string
 	for _, p := range auditFilePaths(t, dir) {
-		data, err := os.ReadFile(p)
+		data, err = os.ReadFile(p)
 		if err != nil {
 			t.Fatal("ReadFile:", err)
 		}
@@ -311,12 +311,13 @@ func TestFileAuditLoggingEnvelope(t *testing.T) {
 			if blobLen == 0 || blobLen > len(data) {
 				t.Fatalf("%s: invalid blob length %d (remaining %d)", p, blobLen, len(data))
 			}
-			plain, err := ce.DecryptInPlace(data[:blobLen])
+			var plain []byte
+			plain, err = ce.DecryptInPlace(data[:blobLen])
 			if err != nil {
 				t.Fatalf("%s: failed to decrypt: %v", p, err)
 			}
 			var m map[string]any
-			if err := json.Unmarshal(plain, &m); err != nil {
+			if err = json.Unmarshal(plain, &m); err != nil {
 				t.Fatalf("%s: not valid JSON after decryption: %v\n%s", p, err, plain)
 			}
 			msgs = append(msgs, fmt.Sprintf("%v", m["msg"]))

--- a/internal/audit/file_test.go
+++ b/internal/audit/file_test.go
@@ -73,7 +73,7 @@ func auditLines(t *testing.T, dir string) []string {
 
 func TestFileNameContainsTimestampHashAndMarker(t *testing.T) {
 	dir := t.TempDir()
-	f, err := newFile(dir, crypto.Engine{}, log.NewNoOpLogger())
+	f, err := newFile(dir, &crypto.Engine{}, log.NewNoOpLogger())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,7 +104,7 @@ func TestFileNameContainsTimestampHashAndMarker(t *testing.T) {
 
 func TestFileRotation(t *testing.T) {
 	dir := t.TempDir()
-	f, err := newFile(dir, crypto.Engine{}, log.NewNoOpLogger())
+	f, err := newFile(dir, &crypto.Engine{}, log.NewNoOpLogger())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -175,7 +175,10 @@ func TestFileAuditLoggingEncrypted(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	e := NewLogEngine(true, ParseEventTypes("all"), dir, log.NewNoOpLogger(), *ce)
+	e, err := NewLogEngine(true, ParseEventTypes("all"), dir, log.NewNoOpLogger(), false, nil, ce)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	records := []struct {
 		event EventType
@@ -228,6 +231,100 @@ func TestFileAuditLoggingEncrypted(t *testing.T) {
 	}
 	if len(data) != 0 {
 		t.Fatalf("file holds %d trailing bytes beyond the last record", len(data))
+	}
+}
+
+func TestFileAuditLoggingEnvelope(t *testing.T) {
+	dir := t.TempDir()
+	kek := bytes.Repeat([]byte{0x2a}, 32)
+
+	e, err := NewLogEngine(true, ParseEventTypes("all"), dir, log.NewNoOpLogger(), true, kek, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e.Record(EventAuthSuccess, "user logged in", log.String("user", "alice"))
+	if err := e.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// The DEK envelope is stored beside the records it protects and the records
+	// themselves carry no plaintext marker.
+	matches, err := filepath.Glob(filepath.Join(dir, "*.env"))
+	if err != nil {
+		t.Fatal("Glob:", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected exactly one envelope file, got %d: %v", len(matches), matches)
+	}
+	data, err := os.ReadFile(singleAuditFile(t, dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "AUDIT") {
+		t.Fatal("envelope-encrypted audit file contains plaintext AUDIT marker")
+	}
+
+	// A restart with the same KEK must load the stored DEK (the Load path)
+	// rather than generating a fresh one, and still write decryptable records.
+	e2, err := NewLogEngine(true, ParseEventTypes("all"), dir, log.NewNoOpLogger(), true, kek, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e2.Record(EventACLDeny, "command denied")
+	if err := e2.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// A changed KEK must fail the engine closed instead of minting a fresh DEK
+	// that would brick the existing audit history.
+	if e3, err := NewLogEngine(true, ParseEventTypes("all"), dir, log.NewNoOpLogger(), true, bytes.Repeat([]byte{0x11}, 32), nil); err == nil {
+		_ = e3.Close()
+		t.Fatal("changed KEK unexpectedly accepted")
+	}
+
+	env, err := crypto.NewEnvelope(kek, log.NewNoOpLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	dek, err := env.Load(dir, auditEnvelopeID)
+	if err != nil {
+		t.Fatalf("failed to load audit DEK for decoding: %v", err)
+	}
+	ce, err := crypto.NewEngine(dek, log.NewNoOpLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Every record across both boots decodes with the restored DEK.
+	var msgs []string
+	for _, p := range auditFilePaths(t, dir) {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatal("ReadFile:", err)
+		}
+		for len(data) > 0 {
+			if len(data) < 4 {
+				t.Fatalf("%s: truncated length prefix (%d bytes left)", p, len(data))
+			}
+			blobLen := int(binary.BigEndian.Uint32(data[:4]))
+			data = data[4:]
+			if blobLen == 0 || blobLen > len(data) {
+				t.Fatalf("%s: invalid blob length %d (remaining %d)", p, blobLen, len(data))
+			}
+			plain, err := ce.DecryptInPlace(data[:blobLen])
+			if err != nil {
+				t.Fatalf("%s: failed to decrypt: %v", p, err)
+			}
+			var m map[string]any
+			if err := json.Unmarshal(plain, &m); err != nil {
+				t.Fatalf("%s: not valid JSON after decryption: %v\n%s", p, err, plain)
+			}
+			msgs = append(msgs, fmt.Sprintf("%v", m["msg"]))
+			data = data[blobLen:]
+		}
+	}
+	if got := strings.Join(msgs, "|"); got != "user logged in|command denied" {
+		t.Fatalf("decrypted messages = %v", msgs)
 	}
 }
 

--- a/internal/crypto/cipher_bench_test.go
+++ b/internal/crypto/cipher_bench_test.go
@@ -1,0 +1,97 @@
+package crypto
+
+import (
+	"crypto/rand"
+	"fmt"
+	"testing"
+)
+
+func benchSize(size int) string {
+	return fmt.Sprintf("size=%d", size)
+}
+
+func benchKey(b *testing.B) []byte {
+	b.Helper()
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		b.Fatalf("generate key: %v", err)
+	}
+	return key
+}
+
+// EncryptInPlace with a pre-sized, reused buffer measures the AEAD seal + nonce
+// generation. The storage Set path additionally allocates the buffer once per
+// call, so the full-write allocation cost is one make() on top of this.
+func BenchmarkEncryptInPlace(b *testing.B) {
+	for _, size := range []int{64, 1024, 4096} {
+		b.Run(benchSize(size), func(b *testing.B) {
+			eng, err := NewEngine(benchKey(b), nil)
+			if err != nil {
+				b.Fatalf("engine init: %v", err)
+			}
+			plain := make([]byte, size)
+			buf := make([]byte, 0, eng.aead.NonceSize()+size+eng.aead.Overhead())
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if _, err := eng.EncryptInPlace(buf, plain); err != nil {
+					b.Fatalf("encrypt: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// DecryptInPlaceWithDst into a reused buffer mirrors the storage GET path and
+// must stay allocation-free.
+func BenchmarkDecryptInPlaceWithDst(b *testing.B) {
+	for _, size := range []int{64, 1024, 4096} {
+		b.Run(benchSize(size), func(b *testing.B) {
+			eng, err := NewEngine(benchKey(b), nil)
+			if err != nil {
+				b.Fatalf("engine init: %v", err)
+			}
+			plain := make([]byte, size)
+			sealed, err := eng.EncryptInPlace(nil, plain)
+			if err != nil {
+				b.Fatalf("encrypt: %v", err)
+			}
+			dst := make([]byte, 0, size)
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				open, err := eng.DecryptInPlaceWithDst(dst, sealed)
+				if err != nil {
+					b.Fatalf("decrypt: %v", err)
+				}
+				dst = open[:0]
+			}
+		})
+	}
+}
+
+// DecryptInPlace allocates a fresh plaintext buffer per call. It is the
+// allocating variant, used by the envelope unwrap path and the large-value GET
+// fallback, so it is benchmarked separately from the zero-alloc GET path.
+func BenchmarkDecryptInPlace(b *testing.B) {
+	for _, size := range []int{64, 1024, 4096} {
+		b.Run(benchSize(size), func(b *testing.B) {
+			eng, err := NewEngine(benchKey(b), nil)
+			if err != nil {
+				b.Fatalf("engine init: %v", err)
+			}
+			plain := make([]byte, size)
+			sealed, err := eng.EncryptInPlace(nil, plain)
+			if err != nil {
+				b.Fatalf("encrypt: %v", err)
+			}
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if _, err := eng.DecryptInPlace(sealed); err != nil {
+					b.Fatalf("decrypt: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/internal/crypto/cipher_bench_test.go
+++ b/internal/crypto/cipher_bench_test.go
@@ -34,7 +34,7 @@ func BenchmarkEncryptInPlace(b *testing.B) {
 			b.ResetTimer()
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				if _, err := eng.EncryptInPlace(buf, plain); err != nil {
+				if _, err = eng.EncryptInPlace(buf, plain); err != nil {
 					b.Fatalf("encrypt: %v", err)
 				}
 			}
@@ -60,7 +60,8 @@ func BenchmarkDecryptInPlaceWithDst(b *testing.B) {
 			b.ResetTimer()
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				open, err := eng.DecryptInPlaceWithDst(dst, sealed)
+				var open []byte
+				open, err = eng.DecryptInPlaceWithDst(dst, sealed)
 				if err != nil {
 					b.Fatalf("decrypt: %v", err)
 				}
@@ -88,7 +89,7 @@ func BenchmarkDecryptInPlace(b *testing.B) {
 			b.ResetTimer()
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				if _, err := eng.DecryptInPlace(sealed); err != nil {
+				if _, err = eng.DecryptInPlace(sealed); err != nil {
 					b.Fatalf("decrypt: %v", err)
 				}
 			}

--- a/internal/crypto/envelope.go
+++ b/internal/crypto/envelope.go
@@ -263,9 +263,3 @@ func fingerprintBytes(key []byte) [16]byte {
 	copy(fp[:], sum[:16])
 	return fp
 }
-
-// Fingerprint returns the truncated SHA-256 hex of a key — the identifier stored
-// in each envelope header to detect a changed KEK on Load.
-func Fingerprint(key []byte) string {
-	return fmt.Sprintf("%x", fingerprintBytes(key))
-}

--- a/internal/crypto/envelope.go
+++ b/internal/crypto/envelope.go
@@ -249,12 +249,6 @@ func (e *Envelope) Load(dir, fileName string) ([]byte, error) {
 	return dek, nil
 }
 
-// envelopeFileName maps a shard to its envelope file. The shard ID is not part of
-// the on-disk layout; the file name is the identifier.
-func EnvelopeFileName(shardID uint32) string {
-	return fmt.Sprintf("shard-%d.env", shardID)
-}
-
 func rnd() ([]byte, error) {
 	b := make([]byte, keySize)
 	_, err := rand.Read(b)

--- a/internal/crypto/envelope.go
+++ b/internal/crypto/envelope.go
@@ -203,6 +203,19 @@ func (e *Envelope) Store(dir string, shardID uint32) error {
 		}
 		return fmt.Errorf("envelope: finalize envelope file: %w", err)
 	}
+	parent, err := os.Open(dir)
+	if err != nil {
+		return fmt.Errorf("envelope: open envelope directory: %w", err)
+	}
+	if err = parent.Sync(); err != nil {
+		if err = parent.Close(); err != nil {
+			return fmt.Errorf("envelope: close envelope directory: %w", err)
+		}
+		return fmt.Errorf("envelope: sync envelope directory: %w", err)
+	}
+	if err = parent.Close(); err != nil {
+		return fmt.Errorf("envelope: close envelope directory: %w", err)
+	}
 	if e.logger.Enabled(log.LevelDebug) {
 		e.logger.Log(log.LevelDebug, "envelope: stored for shard", log.Uint("shard", shardID))
 	}

--- a/internal/crypto/envelope.go
+++ b/internal/crypto/envelope.go
@@ -1,0 +1,271 @@
+/*
+Package crypto
+Tellstone Envelope Encryption
+File: envelope.go
+Description: Envelope encryption for per-shard data keys. Each shard owns a random
+32-byte Data Encryption Key (DEK) that is wrapped (encrypted) with a Key Encryption
+Key (KEK) supplied by the operator. On disk every shard has exactly one envelope:
+
+	[version:1][KEK fingerprint:16][wrapped DEK: nonce(12)+ct(32)+tag(16)]
+
+The KEK never touches data: values are sealed by the shard's DEK engine, and the KEK
+exists only to protect the DEK at rest. A wrapped DEK is worthless without its KEK, so
+envelope files can live alongside the data they protect. A changed KEK is detected on
+Load via the stored fingerprint and fails to close instead of silently generating fresh
+DEKs and losing the dataset.
+
+Lifecycle per shard:
+  - first boot: NewEnvelope(kek) -> GenerateDEK -> Store
+  - restart:    NewEnvelope(kek) -> Load (fingerprint check, unwrap, restore DEK)
+
+Authors:
+
+	Maximilian Hagen
+*/
+package crypto
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Saxy/Tellstone/internal/log"
+)
+
+const (
+	// envVersion identifies the on-disk envelope layout. Bump it, not the fields
+	// inside, when the format changes.
+	envVersion byte = 1
+	// envFingerprintLen is the truncated SHA-256 of the KEK carried by each
+	// envelope, so Load can reject a changed KEK before attempting to unwrap.
+	envFingerprintLen = 16
+)
+
+// Envelope holds a Key Encryption Key (KEK) and the shard's current Data Encryption
+// Key (DEK). It wraps the DEK with the KEK for durable storage (Store) and unwraps
+// it again on restart (Load). The DEK is what the shard builds its data Engine
+// from; the KEK is never used for data.
+type Envelope struct {
+	logger       log.Logger
+	kek          []byte
+	dek          []byte
+	cryptoEngine *Engine
+	enabled      bool
+}
+
+// NewEnvelope validates the KEK and prepares the wrapping engine. A nil or empty
+// key yields a pass-through envelope (enabled == false) whose lifecycle methods
+// are no-ops, mirroring Engine's disabled mode.
+func NewEnvelope(key []byte, logger log.Logger) (*Envelope, error) {
+	if logger == nil {
+		logger = log.NewNoOpLogger()
+	}
+	engine, err := NewEngine(key, logger)
+	if err != nil {
+		return nil, err
+	}
+	if len(key) == 0 {
+		if logger.Enabled(log.LevelInfo) {
+			logger.Log(log.LevelInfo, "envelope: initialized in pass-through mode (disabled)")
+		}
+		return &Envelope{
+			enabled: false,
+			logger:  logger,
+			kek:     key,
+		}, nil
+	}
+	if len(key) != 32 {
+		if logger.Enabled(log.LevelError) {
+			logger.Log(log.LevelError, "envelope: failed to initialize key length mismatch",
+				log.Int("provided_bytes", len(key)),
+				log.Int("required_bytes", 32),
+			)
+		}
+		return nil, errors.New("envelope: KEK must be exactly 32 bytes")
+	}
+	if logger.Enabled(log.LevelInfo) {
+		logger.Log(log.LevelInfo, "envelope: successfully initialized with KEK")
+	}
+	return &Envelope{
+		logger:       logger,
+		kek:          key,
+		cryptoEngine: engine,
+		enabled:      true,
+	}, nil
+}
+
+// Enabled reports whether the envelope actively wraps DEKs (false in pass-through
+// mode).
+func (e *Envelope) Enabled() bool {
+	return e.enabled
+}
+
+// GenerateDEK draws a fresh random DEK for this shard. It must not be called on a
+// restart where an envelope already exists — that path is Load, so old data stays
+// decryptable.
+func (e *Envelope) GenerateDEK() error {
+	if !e.enabled {
+		return nil
+	}
+	data, err := rnd()
+	if err != nil {
+		if e.logger.Enabled(log.LevelError) {
+			e.logger.Log(log.LevelError, "envelope: failed to create random 32 bytes", log.String("error", err.Error()))
+		}
+		return err
+	}
+	e.dek = data
+	return nil
+}
+
+// DEK returns the shard's data key. In pass-through mode it returns the configured
+// key so callers can build a pass-through engine without special-casing.
+func (e *Envelope) DEK() []byte {
+	if !e.enabled {
+		return e.kek
+	}
+	return e.dek
+}
+
+func (e *Envelope) encrypt() ([]byte, error) {
+	if !e.enabled {
+		return e.kek, nil
+	}
+	var buf []byte
+	return e.cryptoEngine.EncryptInPlace(buf, e.dek)
+}
+func (e *Envelope) decrypt(encryptedDEK []byte) ([]byte, error) {
+	if !e.enabled {
+		return e.kek, nil
+	}
+	return e.cryptoEngine.DecryptInPlace(encryptedDEK)
+}
+
+// Store wraps the DEK with the KEK and persists it to <dir>/shard-<n>.env.
+// On-disk layout: [version:1][KEK fingerprint:16][wrapped DEK: nonce+ct+tag].
+func (e *Envelope) Store(dir string, shardID uint32) error {
+	if !e.enabled {
+		return nil
+	}
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		if e.logger.Enabled(log.LevelError) {
+			e.logger.Log(log.LevelError, "envelope: failed to create envelope directory",
+				log.String("dir", dir), log.String("error", err.Error()))
+		}
+		return fmt.Errorf("envelope: create envelope directory %s: %w", dir, err)
+	}
+	wrapped, err := e.encrypt()
+	if err != nil {
+		return fmt.Errorf("envelope: wrap DEK with KEK: %w", err)
+	}
+	buf := make([]byte, 1+envFingerprintLen+len(wrapped))
+	buf[0] = envVersion
+	fp := fingerprintBytes(e.kek)
+	copy(buf[1:1+envFingerprintLen], fp[:])
+	copy(buf[1+envFingerprintLen:], wrapped)
+	name := filepath.Join(dir, envelopeFileName(shardID))
+	tmp := name + ".tmp"
+	file, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		return fmt.Errorf("envelope: open envelope file: %w", err)
+	}
+	if _, err = file.Write(buf); err != nil {
+		if err = file.Close(); err != nil {
+			return fmt.Errorf("envelope: write envelope file: %w", err)
+		}
+		if err = os.Remove(tmp); err != nil {
+			return fmt.Errorf("envelope: write envelope file: %w", err)
+		}
+		return fmt.Errorf("envelope: write envelope file: %w", err)
+	}
+	if err = file.Sync(); err != nil {
+		if err = file.Close(); err != nil {
+			return fmt.Errorf("envelope: sync envelope file: %w", err)
+		}
+		if err = os.Remove(tmp); err != nil {
+			return fmt.Errorf("envelope: sync envelope file: %w", err)
+		}
+		return fmt.Errorf("envelope: sync envelope file: %w", err)
+	}
+	if err = file.Close(); err != nil {
+		if err = os.Remove(tmp); err != nil {
+			return fmt.Errorf("envelope: close envelope file: %w", err)
+		}
+		return fmt.Errorf("envelope: close envelope file: %w", err)
+	}
+	if err = os.Rename(tmp, name); err != nil {
+		if err = os.Remove(tmp); err != nil {
+			return fmt.Errorf("envelope: finalize envelope file: %w", err)
+		}
+		return fmt.Errorf("envelope: finalize envelope file: %w", err)
+	}
+	if e.logger.Enabled(log.LevelDebug) {
+		e.logger.Log(log.LevelDebug, "envelope: stored for shard", log.Uint("shard", shardID))
+	}
+	return nil
+}
+
+// Load reads the envelope for shard, rejects a changed KEK via the stored
+// fingerprint, and returns the unwrapped DEK for the caller to build an Engine.
+func (e *Envelope) Load(dir string, shardID uint32) ([]byte, error) {
+	if !e.enabled {
+		return nil, nil
+	}
+	name := filepath.Join(dir, envelopeFileName(shardID))
+	raw, err := os.ReadFile(name)
+	if err != nil {
+		return nil, fmt.Errorf("envelope: read envelope for shard %d: %w", shardID, err)
+	}
+	headerLen := 1 + envFingerprintLen
+	if len(raw) < headerLen || raw[0] != envVersion {
+		return nil, fmt.Errorf("envelope: unsupported envelope format for shard %d", shardID)
+	}
+	fp := fingerprintBytes(e.kek)
+	if !bytes.Equal(raw[1:headerLen], fp[:]) {
+		return nil,
+			fmt.Errorf(
+				"envelope: KEK fingerprint mismatch for shard %d; data was written with a different key",
+				shardID,
+			)
+	}
+	dek, err := e.decrypt(raw[headerLen:])
+	if err != nil {
+		return nil, fmt.Errorf("envelope: unwrap DEK for shard %d: %w", shardID, err)
+	}
+	e.dek = dek
+	return dek, nil
+}
+
+// envelopeFileName maps a shard to its envelope file. The shard ID is not part of
+// the on-disk layout; the file name is the identifier.
+func envelopeFileName(shardID uint32) string {
+	return fmt.Sprintf("shard-%d.env", shardID)
+}
+
+func rnd() ([]byte, error) {
+	b := make([]byte, keySize)
+	_, err := rand.Read(b)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// fingerprintBytes is the truncated SHA-256 used as the KEK's identifier in the
+// envelope header.
+func fingerprintBytes(key []byte) [16]byte {
+	var fp [16]byte
+	sum := sha256.Sum256(key)
+	copy(fp[:], sum[:16])
+	return fp
+}
+
+// Fingerprint returns the truncated SHA-256 hex of a key — the identifier stored
+// in each envelope header to detect a changed KEK on Load.
+func Fingerprint(key []byte) string {
+	return fmt.Sprintf("%x", fingerprintBytes(key))
+}

--- a/internal/crypto/envelope.go
+++ b/internal/crypto/envelope.go
@@ -147,7 +147,7 @@ func (e *Envelope) decrypt(encryptedDEK []byte) ([]byte, error) {
 
 // Store wraps the DEK with the KEK and persists it to <dir>/shard-<n>.env.
 // On-disk layout: [version:1][KEK fingerprint:16][wrapped DEK: nonce+ct+tag].
-func (e *Envelope) Store(dir string, shardID uint32) error {
+func (e *Envelope) Store(dir string, fileName string) error {
 	if !e.enabled {
 		return nil
 	}
@@ -167,7 +167,7 @@ func (e *Envelope) Store(dir string, shardID uint32) error {
 	fp := fingerprintBytes(e.kek)
 	copy(buf[1:1+envFingerprintLen], fp[:])
 	copy(buf[1+envFingerprintLen:], wrapped)
-	name := filepath.Join(dir, envelopeFileName(shardID))
+	name := filepath.Join(dir, fileName)
 	tmp := name + ".tmp"
 	file, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
 	if err != nil {
@@ -217,37 +217,33 @@ func (e *Envelope) Store(dir string, shardID uint32) error {
 		return fmt.Errorf("envelope: close envelope directory: %w", err)
 	}
 	if e.logger.Enabled(log.LevelDebug) {
-		e.logger.Log(log.LevelDebug, "envelope: stored for shard", log.Uint("shard", shardID))
+		e.logger.Log(log.LevelDebug, "envelope: stored", log.String("file", fileName))
 	}
 	return nil
 }
 
 // Load reads the envelope for shard, rejects a changed KEK via the stored
 // fingerprint, and returns the unwrapped DEK for the caller to build an Engine.
-func (e *Envelope) Load(dir string, shardID uint32) ([]byte, error) {
+func (e *Envelope) Load(dir, fileName string) ([]byte, error) {
 	if !e.enabled {
 		return nil, nil
 	}
-	name := filepath.Join(dir, envelopeFileName(shardID))
+	name := filepath.Join(dir, fileName)
 	raw, err := os.ReadFile(name)
 	if err != nil {
-		return nil, fmt.Errorf("envelope: read envelope for shard %d: %w", shardID, err)
+		return nil, fmt.Errorf("envelope: read envelope %s: %w", fileName, err)
 	}
 	headerLen := 1 + envFingerprintLen
 	if len(raw) < headerLen || raw[0] != envVersion {
-		return nil, fmt.Errorf("envelope: unsupported envelope format for shard %d", shardID)
+		return nil, fmt.Errorf("envelope: unsupported envelope format %s", fileName)
 	}
 	fp := fingerprintBytes(e.kek)
 	if !bytes.Equal(raw[1:headerLen], fp[:]) {
-		return nil,
-			fmt.Errorf(
-				"envelope: KEK fingerprint mismatch for shard %d; data was written with a different key",
-				shardID,
-			)
+		return nil, fmt.Errorf("envelope: KEK fingerprint mismatch for %s; data was written with a different key", fileName)
 	}
 	dek, err := e.decrypt(raw[headerLen:])
 	if err != nil {
-		return nil, fmt.Errorf("envelope: unwrap DEK for shard %d: %w", shardID, err)
+		return nil, fmt.Errorf("envelope: unwrap DEK %s: %w", fileName, err)
 	}
 	e.dek = dek
 	return dek, nil
@@ -255,7 +251,7 @@ func (e *Envelope) Load(dir string, shardID uint32) ([]byte, error) {
 
 // envelopeFileName maps a shard to its envelope file. The shard ID is not part of
 // the on-disk layout; the file name is the identifier.
-func envelopeFileName(shardID uint32) string {
+func EnvelopeFileName(shardID uint32) string {
 	return fmt.Sprintf("shard-%d.env", shardID)
 }
 

--- a/internal/crypto/envelope_test.go
+++ b/internal/crypto/envelope_test.go
@@ -63,10 +63,10 @@ func TestEnvelopePassThroughWhenDisabled(t *testing.T) {
 	if err := env.GenerateDEK(); err != nil {
 		t.Fatalf("GenerateDEK should be a no-op: %v", err)
 	}
-	if err := env.Store(t.TempDir(), 0); err != nil {
+	if err := env.Store(t.TempDir(), EnvelopeFileName(0)); err != nil {
 		t.Fatalf("Store should be a no-op: %v", err)
 	}
-	dek, err := env.Load(t.TempDir(), 0)
+	dek, err := env.Load(t.TempDir(), EnvelopeFileName(0))
 	if err != nil {
 		t.Fatalf("Load should be a no-op: %v", err)
 	}
@@ -111,7 +111,7 @@ func TestEnvelopeStoreLoadRoundTrip(t *testing.T) {
 	if err := env.GenerateDEK(); err != nil {
 		t.Fatalf("generate DEK: %v", err)
 	}
-	if err := env.Store(dir, 7); err != nil {
+	if err := env.Store(dir, EnvelopeFileName(7)); err != nil {
 		t.Fatalf("store: %v", err)
 	}
 
@@ -119,7 +119,7 @@ func TestEnvelopeStoreLoadRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reload init: %v", err)
 	}
-	got, err := reloaded.Load(dir, 7)
+	got, err := reloaded.Load(dir, EnvelopeFileName(7))
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
@@ -140,11 +140,11 @@ func TestEnvelopeFileLayout(t *testing.T) {
 	if err := env.GenerateDEK(); err != nil {
 		t.Fatalf("generate DEK: %v", err)
 	}
-	if err := env.Store(dir, 1); err != nil {
+	if err := env.Store(dir, EnvelopeFileName(1)); err != nil {
 		t.Fatalf("store: %v", err)
 	}
 
-	raw, err := os.ReadFile(filepath.Join(dir, envelopeFileName(1)))
+	raw, err := os.ReadFile(filepath.Join(dir, EnvelopeFileName(1)))
 	if err != nil {
 		t.Fatalf("read envelope file: %v", err)
 	}
@@ -174,7 +174,7 @@ func TestEnvelopeLoadRejectsChangedKEK(t *testing.T) {
 	if err := env.GenerateDEK(); err != nil {
 		t.Fatalf("generate DEK: %v", err)
 	}
-	if err := env.Store(dir, 0); err != nil {
+	if err := env.Store(dir, EnvelopeFileName(0)); err != nil {
 		t.Fatalf("store: %v", err)
 	}
 
@@ -182,7 +182,7 @@ func TestEnvelopeLoadRejectsChangedKEK(t *testing.T) {
 	if err != nil {
 		t.Fatalf("envelope init: %v", err)
 	}
-	if _, err := other.Load(dir, 0); err == nil {
+	if _, err := other.Load(dir, EnvelopeFileName(0)); err == nil {
 		t.Fatal("expected fingerprint mismatch error for a different KEK")
 	}
 }
@@ -191,7 +191,7 @@ func TestEnvelopeLoadRejectsChangedKEK(t *testing.T) {
 // time, not silently accepted.
 func TestEnvelopeLoadRejectsBadFormat(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, envelopeFileName(0))
+	path := filepath.Join(dir, EnvelopeFileName(0))
 	if err := os.WriteFile(path, []byte{0x99, 0x01}, 0600); err != nil {
 		t.Fatalf("write envelope: %v", err)
 	}
@@ -199,7 +199,7 @@ func TestEnvelopeLoadRejectsBadFormat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("envelope init: %v", err)
 	}
-	if _, err := env.Load(dir, 0); err == nil {
+	if _, err := env.Load(dir, EnvelopeFileName(0)); err == nil {
 		t.Fatal("expected format error for garbage envelope")
 	}
 }
@@ -214,12 +214,12 @@ func TestEnvelopeLoadRejectsCorruptEnvelope(t *testing.T) {
 	if err := env.GenerateDEK(); err != nil {
 		t.Fatalf("generate DEK: %v", err)
 	}
-	if err := env.Store(dir, 0); err != nil {
+	if err := env.Store(dir, EnvelopeFileName(0)); err != nil {
 		t.Fatalf("store: %v", err)
 	}
 
 	// Flip the last tag byte: the Poly1305 check must fail during unwrap.
-	path := filepath.Join(dir, envelopeFileName(0))
+	path := filepath.Join(dir, EnvelopeFileName(0))
 	raw, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("read envelope: %v", err)
@@ -233,7 +233,7 @@ func TestEnvelopeLoadRejectsCorruptEnvelope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("envelope init: %v", err)
 	}
-	if _, err := reloaded.Load(dir, 0); err == nil {
+	if _, err := reloaded.Load(dir, EnvelopeFileName(0)); err == nil {
 		t.Fatal("expected unwrap failure on corrupted envelope")
 	}
 }
@@ -245,7 +245,7 @@ func TestEnvelopeLoadMissingFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("envelope init: %v", err)
 	}
-	if _, err := env.Load(t.TempDir(), 42); !errors.Is(err, os.ErrNotExist) {
+	if _, err := env.Load(t.TempDir(), EnvelopeFileName(42)); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("expected os.ErrNotExist, got %v", err)
 	}
 }
@@ -267,7 +267,7 @@ func TestEnvelopePerShardIsolation(t *testing.T) {
 			t.Fatalf("generate DEK %d: %v", i, err)
 		}
 		deks[i] = append([]byte(nil), env.DEK()...)
-		if err := env.Store(dir, uint32(i)); err != nil {
+		if err := env.Store(dir, EnvelopeFileName(uint32(i))); err != nil {
 			t.Fatalf("store %d: %v", i, err)
 		}
 	}
@@ -281,7 +281,7 @@ func TestEnvelopePerShardIsolation(t *testing.T) {
 		if err != nil {
 			t.Fatalf("reload %d init: %v", i, err)
 		}
-		got, err := reloaded.Load(dir, uint32(i))
+		got, err := reloaded.Load(dir, EnvelopeFileName(uint32(i)))
 		if err != nil {
 			t.Fatalf("load %d: %v", i, err)
 		}
@@ -303,13 +303,13 @@ func TestEnvelopeFilePermissions(t *testing.T) {
 	if err := env.GenerateDEK(); err != nil {
 		t.Fatalf("generate DEK: %v", err)
 	}
-	if err := env.Store(dir, 0); err != nil {
+	if err := env.Store(dir, EnvelopeFileName(0)); err != nil {
 		t.Fatalf("store: %v", err)
 	}
 	if info, err := os.Stat(dir); err != nil || info.Mode().Perm() != 0700 {
 		t.Fatalf("envelope dir mode = %o, want 700 (err=%v)", info.Mode().Perm(), err)
 	}
-	if info, err := os.Stat(filepath.Join(dir, envelopeFileName(0))); err != nil || info.Mode().Perm() != 0600 {
+	if info, err := os.Stat(filepath.Join(dir, EnvelopeFileName(0))); err != nil || info.Mode().Perm() != 0600 {
 		t.Fatalf("envelope file mode = %o, want 600 (err=%v)", info.Mode().Perm(), err)
 	}
 }

--- a/internal/crypto/envelope_test.go
+++ b/internal/crypto/envelope_test.go
@@ -1,0 +1,355 @@
+/*
+Package crypto
+Tellstone Envelope Encryption
+File: envelope_test.go
+Description: Tests for the per-shard key envelope: key-length validation,
+pass-through mode, Store/Load round-trips, KEK-change detection, corrupt-envelope
+rejection, file permissions, and per-shard DEK isolation.
+
+Authors:
+
+	Maximilian Hagen
+*/
+package crypto
+
+import (
+	"bytes"
+	"crypto/rand"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// wrappedDEKLen is the EncryptInPlace output for a 32-byte key: nonce(12) +
+// ciphertext(32) + Poly1305 tag(16).
+const wrappedDEKLen = 12 + keySize + 16
+
+func testKEK(t *testing.T) []byte {
+	t.Helper()
+	key := make([]byte, keySize)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("generate KEK: %v", err)
+	}
+	return key
+}
+
+// NewEnvelope requires exactly a 32-byte key; a nil key selects pass-through mode
+// instead, mirroring NewEngine.
+func TestNewEnvelopeRejectsWrongKeyLength(t *testing.T) {
+	for _, n := range []int{1, 16, 31, 33, 64} {
+		if _, err := NewEnvelope(make([]byte, n), nil); err == nil {
+			t.Fatalf("expected error for %d-byte key", n)
+		}
+	}
+	env, err := NewEnvelope(make([]byte, keySize), nil)
+	if err != nil {
+		t.Fatalf("32-byte key should initialize: %v", err)
+	}
+	if !env.Enabled() {
+		t.Fatal("expected an enabled envelope")
+	}
+}
+
+// Without a key the envelope must be inert: no files, no state, no errors.
+func TestEnvelopePassThroughWhenDisabled(t *testing.T) {
+	env, err := NewEnvelope(nil, nil)
+	if err != nil {
+		t.Fatalf("nil key should not error: %v", err)
+	}
+	if env.Enabled() {
+		t.Fatal("expected pass-through mode")
+	}
+	if err := env.GenerateDEK(); err != nil {
+		t.Fatalf("GenerateDEK should be a no-op: %v", err)
+	}
+	if err := env.Store(t.TempDir(), 0); err != nil {
+		t.Fatalf("Store should be a no-op: %v", err)
+	}
+	dek, err := env.Load(t.TempDir(), 0)
+	if err != nil {
+		t.Fatalf("Load should be a no-op: %v", err)
+	}
+	if dek != nil {
+		t.Fatalf("Load should return nil DEK in pass-through mode, got %d bytes", len(dek))
+	}
+	if env.DEK() != nil {
+		t.Fatal("DEK should be nil in pass-through mode")
+	}
+}
+
+func TestEnvelopeGenerateDEK(t *testing.T) {
+	env, err := NewEnvelope(testKEK(t), nil)
+	if err != nil {
+		t.Fatalf("envelope init: %v", err)
+	}
+	if err := env.GenerateDEK(); err != nil {
+		t.Fatalf("generate DEK: %v", err)
+	}
+	if len(env.DEK()) != keySize {
+		t.Fatalf("DEK length = %d, want %d", len(env.DEK()), keySize)
+	}
+	first := append([]byte(nil), env.DEK()...)
+	if err := env.GenerateDEK(); err != nil {
+		t.Fatalf("generate DEK: %v", err)
+	}
+	if bytes.Equal(env.DEK(), first) {
+		t.Fatal("GenerateDEK produced the same key twice")
+	}
+}
+
+// A DEK stored under one envelope must survive a Store -> fresh Envelope -> Load
+// round-trip unchanged, which is exactly what a restart needs.
+func TestEnvelopeStoreLoadRoundTrip(t *testing.T) {
+	kek := testKEK(t)
+	dir := t.TempDir()
+
+	env, err := NewEnvelope(kek, nil)
+	if err != nil {
+		t.Fatalf("envelope init: %v", err)
+	}
+	if err := env.GenerateDEK(); err != nil {
+		t.Fatalf("generate DEK: %v", err)
+	}
+	if err := env.Store(dir, 7); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+
+	reloaded, err := NewEnvelope(kek, nil)
+	if err != nil {
+		t.Fatalf("reload init: %v", err)
+	}
+	got, err := reloaded.Load(dir, 7)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !bytes.Equal(got, env.DEK()) {
+		t.Fatal("recovered DEK differs from the stored one")
+	}
+}
+
+// The on-disk envelope must carry the version byte, the KEK fingerprint, and the
+// wrapped DEK — and must never leak the plaintext DEK.
+func TestEnvelopeFileLayout(t *testing.T) {
+	kek := testKEK(t)
+	dir := t.TempDir()
+	env, err := NewEnvelope(kek, nil)
+	if err != nil {
+		t.Fatalf("envelope init: %v", err)
+	}
+	if err := env.GenerateDEK(); err != nil {
+		t.Fatalf("generate DEK: %v", err)
+	}
+	if err := env.Store(dir, 1); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, envelopeFileName(1)))
+	if err != nil {
+		t.Fatalf("read envelope file: %v", err)
+	}
+	if len(raw) != 1+envFingerprintLen+wrappedDEKLen {
+		t.Fatalf("envelope size = %d, want %d", len(raw), 1+envFingerprintLen+wrappedDEKLen)
+	}
+	if raw[0] != envVersion {
+		t.Fatalf("version byte = %d, want %d", raw[0], envVersion)
+	}
+	fp := fingerprintBytes(kek)
+	if !bytes.Equal(raw[1:1+envFingerprintLen], fp[:]) {
+		t.Fatal("stored fingerprint does not match the KEK")
+	}
+	if bytes.Contains(raw, env.DEK()) {
+		t.Fatal("plaintext DEK leaked into the envelope file")
+	}
+}
+
+// Loading with a different KEK must fail on the fingerprint check so a restart
+// never silently regenerates DEKs and orphans the existing dataset.
+func TestEnvelopeLoadRejectsChangedKEK(t *testing.T) {
+	dir := t.TempDir()
+	env, err := NewEnvelope(testKEK(t), nil)
+	if err != nil {
+		t.Fatalf("envelope init: %v", err)
+	}
+	if err := env.GenerateDEK(); err != nil {
+		t.Fatalf("generate DEK: %v", err)
+	}
+	if err := env.Store(dir, 0); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+
+	other, err := NewEnvelope(testKEK(t), nil)
+	if err != nil {
+		t.Fatalf("envelope init: %v", err)
+	}
+	if _, err := other.Load(dir, 0); err == nil {
+		t.Fatal("expected fingerprint mismatch error for a different KEK")
+	}
+}
+
+// A truncated or garbage envelope must be rejected at format or authentication
+// time, not silently accepted.
+func TestEnvelopeLoadRejectsBadFormat(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, envelopeFileName(0))
+	if err := os.WriteFile(path, []byte{0x99, 0x01}, 0600); err != nil {
+		t.Fatalf("write envelope: %v", err)
+	}
+	env, err := NewEnvelope(testKEK(t), nil)
+	if err != nil {
+		t.Fatalf("envelope init: %v", err)
+	}
+	if _, err := env.Load(dir, 0); err == nil {
+		t.Fatal("expected format error for garbage envelope")
+	}
+}
+
+func TestEnvelopeLoadRejectsCorruptEnvelope(t *testing.T) {
+	kek := testKEK(t)
+	dir := t.TempDir()
+	env, err := NewEnvelope(kek, nil)
+	if err != nil {
+		t.Fatalf("envelope init: %v", err)
+	}
+	if err := env.GenerateDEK(); err != nil {
+		t.Fatalf("generate DEK: %v", err)
+	}
+	if err := env.Store(dir, 0); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+
+	// Flip the last tag byte: the Poly1305 check must fail during unwrap.
+	path := filepath.Join(dir, envelopeFileName(0))
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read envelope: %v", err)
+	}
+	raw[len(raw)-1] ^= 0xff
+	if err := os.WriteFile(path, raw, 0600); err != nil {
+		t.Fatalf("rewrite envelope: %v", err)
+	}
+
+	reloaded, err := NewEnvelope(kek, nil)
+	if err != nil {
+		t.Fatalf("envelope init: %v", err)
+	}
+	if _, err := reloaded.Load(dir, 0); err == nil {
+		t.Fatal("expected unwrap failure on corrupted envelope")
+	}
+}
+
+// Load must surface a missing file as os.ErrNotExist — the shard wiring uses
+// errors.Is against it to tell first boot (generate) from restart (load).
+func TestEnvelopeLoadMissingFile(t *testing.T) {
+	env, err := NewEnvelope(testKEK(t), nil)
+	if err != nil {
+		t.Fatalf("envelope init: %v", err)
+	}
+	if _, err := env.Load(t.TempDir(), 42); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected os.ErrNotExist, got %v", err)
+	}
+}
+
+// The per-shard guarantee: N shards under one KEK must each get a unique random
+// DEK, and each must load back its own without cross-talk.
+func TestEnvelopePerShardIsolation(t *testing.T) {
+	const numShards = 4
+	kek := testKEK(t)
+	dir := t.TempDir()
+
+	deks := make([][]byte, numShards)
+	for i := 0; i < numShards; i++ {
+		env, err := NewEnvelope(kek, nil)
+		if err != nil {
+			t.Fatalf("envelope %d init: %v", i, err)
+		}
+		if err := env.GenerateDEK(); err != nil {
+			t.Fatalf("generate DEK %d: %v", i, err)
+		}
+		deks[i] = append([]byte(nil), env.DEK()...)
+		if err := env.Store(dir, uint32(i)); err != nil {
+			t.Fatalf("store %d: %v", i, err)
+		}
+	}
+	for i := 1; i < numShards; i++ {
+		if bytes.Equal(deks[i], deks[0]) {
+			t.Fatalf("shard %d reused shard 0's DEK", i)
+		}
+	}
+	for i := 0; i < numShards; i++ {
+		reloaded, err := NewEnvelope(kek, nil)
+		if err != nil {
+			t.Fatalf("reload %d init: %v", i, err)
+		}
+		got, err := reloaded.Load(dir, uint32(i))
+		if err != nil {
+			t.Fatalf("load %d: %v", i, err)
+		}
+		if !bytes.Equal(got, deks[i]) {
+			t.Fatalf("shard %d DEK mismatch on reload", i)
+		}
+	}
+}
+
+// Envelope files are key material: the directory and file must be created with
+// restrictive permissions.
+func TestEnvelopeFilePermissions(t *testing.T) {
+	// Use a path Store must create itself so MkdirAll's mode is exercised.
+	dir := filepath.Join(t.TempDir(), "enc")
+	env, err := NewEnvelope(testKEK(t), nil)
+	if err != nil {
+		t.Fatalf("envelope init: %v", err)
+	}
+	if err := env.GenerateDEK(); err != nil {
+		t.Fatalf("generate DEK: %v", err)
+	}
+	if err := env.Store(dir, 0); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	if info, err := os.Stat(dir); err != nil || info.Mode().Perm() != 0700 {
+		t.Fatalf("envelope dir mode = %o, want 700 (err=%v)", info.Mode().Perm(), err)
+	}
+	if info, err := os.Stat(filepath.Join(dir, envelopeFileName(0))); err != nil || info.Mode().Perm() != 0600 {
+		t.Fatalf("envelope file mode = %o, want 600 (err=%v)", info.Mode().Perm(), err)
+	}
+}
+
+// The recovered DEK must power a working data engine, and the KEK engine must not
+// be able to open DEK-sealed values — the core separation envelope encryption
+// provides.
+func TestEnvelopeDEKFeedsEngine(t *testing.T) {
+	kek := testKEK(t)
+	env, err := NewEnvelope(kek, nil)
+	if err != nil {
+		t.Fatalf("envelope init: %v", err)
+	}
+	if err := env.GenerateDEK(); err != nil {
+		t.Fatalf("generate DEK: %v", err)
+	}
+
+	dekEngine, err := NewEngine(env.DEK(), nil)
+	if err != nil {
+		t.Fatalf("DEK engine init: %v", err)
+	}
+	plaintext := []byte("sensitive value")
+	sealed, err := dekEngine.EncryptInPlace(nil, plaintext)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	kekEngine, err := NewEngine(kek, nil)
+	if err != nil {
+		t.Fatalf("KEK engine init: %v", err)
+	}
+	if _, err := kekEngine.DecryptInPlace(sealed); err == nil {
+		t.Fatal("KEK engine should not open DEK-sealed data")
+	}
+
+	open, err := dekEngine.DecryptInPlace(sealed)
+	if err != nil {
+		t.Fatalf("DEK engine decrypt: %v", err)
+	}
+	if !bytes.Equal(open, plaintext) {
+		t.Fatalf("DEK round-trip mismatch: got %q want %q", open, plaintext)
+	}
+}

--- a/internal/crypto/envelope_test.go
+++ b/internal/crypto/envelope_test.go
@@ -65,10 +65,10 @@ func TestEnvelopePassThroughWhenDisabled(t *testing.T) {
 	if env.Enabled() {
 		t.Fatal("expected pass-through mode")
 	}
-	if err := env.GenerateDEK(); err != nil {
+	if err = env.GenerateDEK(); err != nil {
 		t.Fatalf("GenerateDEK should be a no-op: %v", err)
 	}
-	if err := env.Store(t.TempDir(), envelopeFileName(0)); err != nil {
+	if err = env.Store(t.TempDir(), envelopeFileName(0)); err != nil {
 		t.Fatalf("Store should be a no-op: %v", err)
 	}
 	dek, err := env.Load(t.TempDir(), envelopeFileName(0))
@@ -95,7 +95,7 @@ func TestEnvelopeGenerateDEK(t *testing.T) {
 		t.Fatalf("DEK length = %d, want %d", len(env.DEK()), keySize)
 	}
 	first := append([]byte(nil), env.DEK()...)
-	if err := env.GenerateDEK(); err != nil {
+	if err = env.GenerateDEK(); err != nil {
 		t.Fatalf("generate DEK: %v", err)
 	}
 	if bytes.Equal(env.DEK(), first) {
@@ -113,10 +113,10 @@ func TestEnvelopeStoreLoadRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("envelope init: %v", err)
 	}
-	if err := env.GenerateDEK(); err != nil {
+	if err = env.GenerateDEK(); err != nil {
 		t.Fatalf("generate DEK: %v", err)
 	}
-	if err := env.Store(dir, envelopeFileName(7)); err != nil {
+	if err = env.Store(dir, envelopeFileName(7)); err != nil {
 		t.Fatalf("store: %v", err)
 	}
 
@@ -142,10 +142,10 @@ func TestEnvelopeFileLayout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("envelope init: %v", err)
 	}
-	if err := env.GenerateDEK(); err != nil {
+	if err = env.GenerateDEK(); err != nil {
 		t.Fatalf("generate DEK: %v", err)
 	}
-	if err := env.Store(dir, envelopeFileName(1)); err != nil {
+	if err = env.Store(dir, envelopeFileName(1)); err != nil {
 		t.Fatalf("store: %v", err)
 	}
 
@@ -176,10 +176,10 @@ func TestEnvelopeLoadRejectsChangedKEK(t *testing.T) {
 	if err != nil {
 		t.Fatalf("envelope init: %v", err)
 	}
-	if err := env.GenerateDEK(); err != nil {
+	if err = env.GenerateDEK(); err != nil {
 		t.Fatalf("generate DEK: %v", err)
 	}
-	if err := env.Store(dir, envelopeFileName(0)); err != nil {
+	if err = env.Store(dir, envelopeFileName(0)); err != nil {
 		t.Fatalf("store: %v", err)
 	}
 
@@ -187,7 +187,7 @@ func TestEnvelopeLoadRejectsChangedKEK(t *testing.T) {
 	if err != nil {
 		t.Fatalf("envelope init: %v", err)
 	}
-	if _, err := other.Load(dir, envelopeFileName(0)); err == nil {
+	if _, err = other.Load(dir, envelopeFileName(0)); err == nil {
 		t.Fatal("expected fingerprint mismatch error for a different KEK")
 	}
 }
@@ -204,7 +204,7 @@ func TestEnvelopeLoadRejectsBadFormat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("envelope init: %v", err)
 	}
-	if _, err := env.Load(dir, envelopeFileName(0)); err == nil {
+	if _, err = env.Load(dir, envelopeFileName(0)); err == nil {
 		t.Fatal("expected format error for garbage envelope")
 	}
 }
@@ -216,10 +216,10 @@ func TestEnvelopeLoadRejectsCorruptEnvelope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("envelope init: %v", err)
 	}
-	if err := env.GenerateDEK(); err != nil {
+	if err = env.GenerateDEK(); err != nil {
 		t.Fatalf("generate DEK: %v", err)
 	}
-	if err := env.Store(dir, envelopeFileName(0)); err != nil {
+	if err = env.Store(dir, envelopeFileName(0)); err != nil {
 		t.Fatalf("store: %v", err)
 	}
 
@@ -230,7 +230,7 @@ func TestEnvelopeLoadRejectsCorruptEnvelope(t *testing.T) {
 		t.Fatalf("read envelope: %v", err)
 	}
 	raw[len(raw)-1] ^= 0xff
-	if err := os.WriteFile(path, raw, 0600); err != nil {
+	if err = os.WriteFile(path, raw, 0600); err != nil {
 		t.Fatalf("rewrite envelope: %v", err)
 	}
 
@@ -238,7 +238,7 @@ func TestEnvelopeLoadRejectsCorruptEnvelope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("envelope init: %v", err)
 	}
-	if _, err := reloaded.Load(dir, envelopeFileName(0)); err == nil {
+	if _, err = reloaded.Load(dir, envelopeFileName(0)); err == nil {
 		t.Fatal("expected unwrap failure on corrupted envelope")
 	}
 }
@@ -250,7 +250,7 @@ func TestEnvelopeLoadMissingFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("envelope init: %v", err)
 	}
-	if _, err := env.Load(t.TempDir(), envelopeFileName(42)); !errors.Is(err, os.ErrNotExist) {
+	if _, err = env.Load(t.TempDir(), envelopeFileName(42)); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("expected os.ErrNotExist, got %v", err)
 	}
 }
@@ -268,11 +268,11 @@ func TestEnvelopePerShardIsolation(t *testing.T) {
 		if err != nil {
 			t.Fatalf("envelope %d init: %v", i, err)
 		}
-		if err := env.GenerateDEK(); err != nil {
+		if err = env.GenerateDEK(); err != nil {
 			t.Fatalf("generate DEK %d: %v", i, err)
 		}
 		deks[i] = append([]byte(nil), env.DEK()...)
-		if err := env.Store(dir, envelopeFileName(uint32(i))); err != nil {
+		if err = env.Store(dir, envelopeFileName(uint32(i))); err != nil {
 			t.Fatalf("store %d: %v", i, err)
 		}
 	}
@@ -305,16 +305,17 @@ func TestEnvelopeFilePermissions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("envelope init: %v", err)
 	}
-	if err := env.GenerateDEK(); err != nil {
+	if err = env.GenerateDEK(); err != nil {
 		t.Fatalf("generate DEK: %v", err)
 	}
-	if err := env.Store(dir, envelopeFileName(0)); err != nil {
+	if err = env.Store(dir, envelopeFileName(0)); err != nil {
 		t.Fatalf("store: %v", err)
 	}
-	if info, err := os.Stat(dir); err != nil || info.Mode().Perm() != 0700 {
+	var info os.FileInfo
+	if info, err = os.Stat(dir); err != nil || info.Mode().Perm() != 0700 {
 		t.Fatalf("envelope dir mode = %o, want 700 (err=%v)", info.Mode().Perm(), err)
 	}
-	if info, err := os.Stat(filepath.Join(dir, envelopeFileName(0))); err != nil || info.Mode().Perm() != 0600 {
+	if info, err = os.Stat(filepath.Join(dir, envelopeFileName(0))); err != nil || info.Mode().Perm() != 0600 {
 		t.Fatalf("envelope file mode = %o, want 600 (err=%v)", info.Mode().Perm(), err)
 	}
 }
@@ -328,7 +329,7 @@ func TestEnvelopeDEKFeedsEngine(t *testing.T) {
 	if err != nil {
 		t.Fatalf("envelope init: %v", err)
 	}
-	if err := env.GenerateDEK(); err != nil {
+	if err = env.GenerateDEK(); err != nil {
 		t.Fatalf("generate DEK: %v", err)
 	}
 
@@ -346,7 +347,7 @@ func TestEnvelopeDEKFeedsEngine(t *testing.T) {
 	if err != nil {
 		t.Fatalf("KEK engine init: %v", err)
 	}
-	if _, err := kekEngine.DecryptInPlace(sealed); err == nil {
+	if _, err = kekEngine.DecryptInPlace(sealed); err == nil {
 		t.Fatal("KEK engine should not open DEK-sealed data")
 	}
 

--- a/internal/crypto/envelope_test.go
+++ b/internal/crypto/envelope_test.go
@@ -16,10 +16,15 @@ import (
 	"bytes"
 	"crypto/rand"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 )
+
+func envelopeFileName(shardID uint32) string {
+	return fmt.Sprintf("shard-%d.env", shardID)
+}
 
 // wrappedDEKLen is the EncryptInPlace output for a 32-byte key: nonce(12) +
 // ciphertext(32) + Poly1305 tag(16).
@@ -63,10 +68,10 @@ func TestEnvelopePassThroughWhenDisabled(t *testing.T) {
 	if err := env.GenerateDEK(); err != nil {
 		t.Fatalf("GenerateDEK should be a no-op: %v", err)
 	}
-	if err := env.Store(t.TempDir(), EnvelopeFileName(0)); err != nil {
+	if err := env.Store(t.TempDir(), envelopeFileName(0)); err != nil {
 		t.Fatalf("Store should be a no-op: %v", err)
 	}
-	dek, err := env.Load(t.TempDir(), EnvelopeFileName(0))
+	dek, err := env.Load(t.TempDir(), envelopeFileName(0))
 	if err != nil {
 		t.Fatalf("Load should be a no-op: %v", err)
 	}
@@ -111,7 +116,7 @@ func TestEnvelopeStoreLoadRoundTrip(t *testing.T) {
 	if err := env.GenerateDEK(); err != nil {
 		t.Fatalf("generate DEK: %v", err)
 	}
-	if err := env.Store(dir, EnvelopeFileName(7)); err != nil {
+	if err := env.Store(dir, envelopeFileName(7)); err != nil {
 		t.Fatalf("store: %v", err)
 	}
 
@@ -119,7 +124,7 @@ func TestEnvelopeStoreLoadRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reload init: %v", err)
 	}
-	got, err := reloaded.Load(dir, EnvelopeFileName(7))
+	got, err := reloaded.Load(dir, envelopeFileName(7))
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
@@ -140,11 +145,11 @@ func TestEnvelopeFileLayout(t *testing.T) {
 	if err := env.GenerateDEK(); err != nil {
 		t.Fatalf("generate DEK: %v", err)
 	}
-	if err := env.Store(dir, EnvelopeFileName(1)); err != nil {
+	if err := env.Store(dir, envelopeFileName(1)); err != nil {
 		t.Fatalf("store: %v", err)
 	}
 
-	raw, err := os.ReadFile(filepath.Join(dir, EnvelopeFileName(1)))
+	raw, err := os.ReadFile(filepath.Join(dir, envelopeFileName(1)))
 	if err != nil {
 		t.Fatalf("read envelope file: %v", err)
 	}
@@ -174,7 +179,7 @@ func TestEnvelopeLoadRejectsChangedKEK(t *testing.T) {
 	if err := env.GenerateDEK(); err != nil {
 		t.Fatalf("generate DEK: %v", err)
 	}
-	if err := env.Store(dir, EnvelopeFileName(0)); err != nil {
+	if err := env.Store(dir, envelopeFileName(0)); err != nil {
 		t.Fatalf("store: %v", err)
 	}
 
@@ -182,7 +187,7 @@ func TestEnvelopeLoadRejectsChangedKEK(t *testing.T) {
 	if err != nil {
 		t.Fatalf("envelope init: %v", err)
 	}
-	if _, err := other.Load(dir, EnvelopeFileName(0)); err == nil {
+	if _, err := other.Load(dir, envelopeFileName(0)); err == nil {
 		t.Fatal("expected fingerprint mismatch error for a different KEK")
 	}
 }
@@ -191,7 +196,7 @@ func TestEnvelopeLoadRejectsChangedKEK(t *testing.T) {
 // time, not silently accepted.
 func TestEnvelopeLoadRejectsBadFormat(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, EnvelopeFileName(0))
+	path := filepath.Join(dir, envelopeFileName(0))
 	if err := os.WriteFile(path, []byte{0x99, 0x01}, 0600); err != nil {
 		t.Fatalf("write envelope: %v", err)
 	}
@@ -199,7 +204,7 @@ func TestEnvelopeLoadRejectsBadFormat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("envelope init: %v", err)
 	}
-	if _, err := env.Load(dir, EnvelopeFileName(0)); err == nil {
+	if _, err := env.Load(dir, envelopeFileName(0)); err == nil {
 		t.Fatal("expected format error for garbage envelope")
 	}
 }
@@ -214,12 +219,12 @@ func TestEnvelopeLoadRejectsCorruptEnvelope(t *testing.T) {
 	if err := env.GenerateDEK(); err != nil {
 		t.Fatalf("generate DEK: %v", err)
 	}
-	if err := env.Store(dir, EnvelopeFileName(0)); err != nil {
+	if err := env.Store(dir, envelopeFileName(0)); err != nil {
 		t.Fatalf("store: %v", err)
 	}
 
 	// Flip the last tag byte: the Poly1305 check must fail during unwrap.
-	path := filepath.Join(dir, EnvelopeFileName(0))
+	path := filepath.Join(dir, envelopeFileName(0))
 	raw, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("read envelope: %v", err)
@@ -233,7 +238,7 @@ func TestEnvelopeLoadRejectsCorruptEnvelope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("envelope init: %v", err)
 	}
-	if _, err := reloaded.Load(dir, EnvelopeFileName(0)); err == nil {
+	if _, err := reloaded.Load(dir, envelopeFileName(0)); err == nil {
 		t.Fatal("expected unwrap failure on corrupted envelope")
 	}
 }
@@ -245,7 +250,7 @@ func TestEnvelopeLoadMissingFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("envelope init: %v", err)
 	}
-	if _, err := env.Load(t.TempDir(), EnvelopeFileName(42)); !errors.Is(err, os.ErrNotExist) {
+	if _, err := env.Load(t.TempDir(), envelopeFileName(42)); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("expected os.ErrNotExist, got %v", err)
 	}
 }
@@ -267,7 +272,7 @@ func TestEnvelopePerShardIsolation(t *testing.T) {
 			t.Fatalf("generate DEK %d: %v", i, err)
 		}
 		deks[i] = append([]byte(nil), env.DEK()...)
-		if err := env.Store(dir, EnvelopeFileName(uint32(i))); err != nil {
+		if err := env.Store(dir, envelopeFileName(uint32(i))); err != nil {
 			t.Fatalf("store %d: %v", i, err)
 		}
 	}
@@ -281,7 +286,7 @@ func TestEnvelopePerShardIsolation(t *testing.T) {
 		if err != nil {
 			t.Fatalf("reload %d init: %v", i, err)
 		}
-		got, err := reloaded.Load(dir, EnvelopeFileName(uint32(i)))
+		got, err := reloaded.Load(dir, envelopeFileName(uint32(i)))
 		if err != nil {
 			t.Fatalf("load %d: %v", i, err)
 		}
@@ -303,13 +308,13 @@ func TestEnvelopeFilePermissions(t *testing.T) {
 	if err := env.GenerateDEK(); err != nil {
 		t.Fatalf("generate DEK: %v", err)
 	}
-	if err := env.Store(dir, EnvelopeFileName(0)); err != nil {
+	if err := env.Store(dir, envelopeFileName(0)); err != nil {
 		t.Fatalf("store: %v", err)
 	}
 	if info, err := os.Stat(dir); err != nil || info.Mode().Perm() != 0700 {
 		t.Fatalf("envelope dir mode = %o, want 700 (err=%v)", info.Mode().Perm(), err)
 	}
-	if info, err := os.Stat(filepath.Join(dir, EnvelopeFileName(0))); err != nil || info.Mode().Perm() != 0600 {
+	if info, err := os.Stat(filepath.Join(dir, envelopeFileName(0))); err != nil || info.Mode().Perm() != 0600 {
 		t.Fatalf("envelope file mode = %o, want 600 (err=%v)", info.Mode().Perm(), err)
 	}
 }

--- a/internal/crypto/keyprovider.go
+++ b/internal/crypto/keyprovider.go
@@ -13,8 +13,10 @@ Authors:
 */
 package crypto
 
+import "golang.org/x/crypto/chacha20poly1305"
+
 // keySize is the ChaCha20-Poly1305 key length that NewEngine enforces.
-const keySize = 32
+const keySize = chacha20poly1305.KeySize
 
 // KeyProvider resolves the raw encryption key. Resolution happens once at server
 // startup; implementations are not called from the encrypt/decrypt hot path and may

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/Saxy/Tellstone/internal/audit"
-	"github.com/Saxy/Tellstone/internal/crypto"
 	"github.com/Saxy/Tellstone/internal/log"
 	"github.com/Saxy/Tellstone/internal/network"
 	"github.com/Saxy/Tellstone/internal/storage"
@@ -16,7 +15,8 @@ import (
 // newNoOpAudit returns a disabled audit engine so the listener harness
 // exercises the unguarded Record() hooks with zero audit output.
 func newNoOpAudit() *audit.LogEngine {
-	return audit.NewLogEngine(false, nil, "stdout", log.NewNoOpLogger(), crypto.Engine{})
+	e, _ := audit.NewLogEngine(false, nil, "stdout", log.NewNoOpLogger(), false, nil, nil)
+	return e
 }
 
 // TestCollectorEngineSnapshot verifies that the engine snapshot reflects

--- a/internal/network/server_test.go
+++ b/internal/network/server_test.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/Saxy/Tellstone/internal/audit"
-	"github.com/Saxy/Tellstone/internal/crypto"
 	"github.com/Saxy/Tellstone/internal/log"
 	tlslib "github.com/Saxy/Tellstone/internal/tls"
 )
@@ -22,7 +21,8 @@ import (
 // newNoOpAudit returns a disabled audit engine so listener tests exercise the
 // unguarded Record() hooks with zero audit output.
 func newNoOpAudit() *audit.LogEngine {
-	return audit.NewLogEngine(false, nil, "stdout", log.NewNoOpLogger(), crypto.Engine{})
+	e, _ := audit.NewLogEngine(false, nil, "stdout", log.NewNoOpLogger(), false, nil, nil)
+	return e
 }
 
 // fakeStore is a minimal in-memory key-value store for testing binary protocol handlers.

--- a/internal/resp/server_test.go
+++ b/internal/resp/server_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/Saxy/Tellstone/internal/audit"
-	"github.com/Saxy/Tellstone/internal/crypto"
 	"github.com/Saxy/Tellstone/internal/log"
 	"github.com/panjf2000/gnet/v2"
 )
@@ -17,7 +16,8 @@ import (
 // newNoOpAudit returns a disabled audit engine so listener tests exercise the
 // unguarded Record() hooks with zero audit output.
 func newNoOpAudit() *audit.LogEngine {
-	return audit.NewLogEngine(false, nil, "stdout", log.NewNoOpLogger(), crypto.Engine{})
+	e, _ := audit.NewLogEngine(false, nil, "stdout", log.NewNoOpLogger(), false, nil, nil)
+	return e
 }
 
 // fakeStore is a minimal in-memory Store. Like the real engine, it must COPY the key and

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -15,7 +15,7 @@ func testDistribution(t *testing.T, numShards int) {
 	cfg := config.LoadConfig([]string{"-shards", fmt.Sprint(numShards)})
 	shards := make([]*shard.Shard, numShards)
 	for i := 0; i < numShards; i++ {
-		s, err := shard.Run(shard.ID(i), cfg, nil, log.NewNoOpLogger(), nil)
+		s, err := shard.Run(shard.ID(i), cfg, nil, nil, log.NewNoOpLogger(), nil)
 		if err != nil {
 			t.Fatalf("shard %d: %v", i, err)
 		}
@@ -54,7 +54,7 @@ func TestRouterSetGet(t *testing.T) {
 	cfg := config.LoadConfig([]string{"-shards=4"})
 	shards := make([]*shard.Shard, 4)
 	for i := 0; i < 4; i++ {
-		s, err := shard.Run(shard.ID(i), cfg, nil, log.NewNoOpLogger(), nil)
+		s, err := shard.Run(shard.ID(i), cfg, nil, nil, log.NewNoOpLogger(), nil)
 		if err != nil {
 			t.Fatalf("shard %d: %v", i, err)
 		}

--- a/internal/shard/runner.go
+++ b/internal/shard/runner.go
@@ -12,7 +12,11 @@ package shard
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
 	"sync/atomic"
 	"time"
 
@@ -56,7 +60,7 @@ func (s *Shard) TotalConnections() uint64 { return atomic.LoadUint64(&s.totalCon
 func (s *Shard) BytesRead() uint64        { return atomic.LoadUint64(&s.bytesRead) }
 func (s *Shard) BytesWritten() uint64     { return atomic.LoadUint64(&s.bytesWritten) }
 
-func Run(id ID, cfg *config.Config, cryptoEngine *crypto.Engine, logger log.Logger, store *persistence.Storage) (*Shard, error) {
+func Run(id ID, cfg *config.Config, key []byte, cryptoEngine *crypto.Engine, logger log.Logger, store *persistence.Storage) (*Shard, error) {
 	if logger == nil {
 		logger = log.NewNoOpLogger()
 	}
@@ -65,6 +69,38 @@ func Run(id ID, cfg *config.Config, cryptoEngine *crypto.Engine, logger log.Logg
 		maxBytes = maxBytes / uint64(cfg.GetNumShards())
 	}
 	shardLogger := log.NewShardLogger(logger, uint32(id))
+	if store == nil {
+		store, _ = persistence.NewStorage(false, logger, cfg.GetPersistenceDir())
+	}
+	// In envelope mode the configured key is a KEK: each shard owns a random DEK
+	// wrapped by the KEK, so the KEK never touches data and shards share no key
+	// material. The DEK is loaded from the shard's envelope file, or generated and
+	// stored on the first boot. A changed KEK is rejected here (fail-closed) rather
+	// than silently generating fresh DEKs and bricking the dataset.
+	if cfg.EncryptionEnabled() && cfg.EnvelopeEnabled() {
+		env, err := crypto.NewEnvelope(key, shardLogger)
+		if err != nil {
+			return nil, fmt.Errorf("shard %d: envelope init: %w", id, err)
+		}
+		envDir := envelopeDir(cfg)
+		dek, err := env.Load(envDir, uint32(id))
+		if err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				return nil, fmt.Errorf("shard %d: load envelope: %w", id, err)
+			}
+			if err = env.GenerateDEK(); err != nil {
+				return nil, fmt.Errorf("shard %d: generate DEK: %w", id, err)
+			}
+			if err = env.Store(envDir, uint32(id)); err != nil {
+				return nil, fmt.Errorf("shard %d: store envelope: %w", id, err)
+			}
+			dek = env.DEK()
+		}
+		cryptoEngine, err = crypto.NewEngine(dek, shardLogger)
+		if err != nil {
+			return nil, fmt.Errorf("shard %d: data engine init: %w", id, err)
+		}
+	}
 	engine := storage.NewEngine(
 		cfg.GetEvictTicker(),
 		cfg.GetEvictSlots(),
@@ -72,9 +108,6 @@ func Run(id ID, cfg *config.Config, cryptoEngine *crypto.Engine, logger log.Logg
 		shardLogger,
 		cryptoEngine,
 	)
-	if store == nil {
-		store, _ = persistence.NewStorage(false, logger, "")
-	}
 	shard := &Shard{
 		ID:          id,
 		Engine:      engine,
@@ -150,4 +183,31 @@ func (s *Shard) Execute(op string, key string, value []byte, ttl time.Duration) 
 func (s *Shard) Stop(_ context.Context) error {
 	s.Engine.Close()
 	return nil
+}
+
+// envelopeDir returns where per-shard envelope files live: the configured
+// persistence dir, or the platform default data dir when none is set. The envelope
+// must stay durable independently of the WAL, so it is written even when
+// --enable-persistence is disabled.
+func envelopeDir(cfg *config.Config) string {
+	if dir := cfg.GetPersistenceDir(); dir != "" {
+		return dir
+	}
+	return defaultDataDir()
+}
+
+// defaultDataDir mirrors persistence's platform default so envelope files have a
+// durable home when the WAL is disabled. Keep in lockstep with
+// persistence.getDefaultDir.
+func defaultDataDir() string {
+	var baseDir string
+	switch runtime.GOOS {
+	case "windows":
+		baseDir = os.Getenv("APPDATA")
+	case "darwin":
+		baseDir = filepath.Join(os.Getenv("HOME"), "Library", "Application Support")
+	default:
+		baseDir = filepath.Join(os.Getenv("HOME"), ".local", "share")
+	}
+	return filepath.Join(baseDir, "tellstone", "data")
 }

--- a/internal/shard/runner.go
+++ b/internal/shard/runner.go
@@ -60,6 +60,10 @@ func (s *Shard) TotalConnections() uint64 { return atomic.LoadUint64(&s.totalCon
 func (s *Shard) BytesRead() uint64        { return atomic.LoadUint64(&s.bytesRead) }
 func (s *Shard) BytesWritten() uint64     { return atomic.LoadUint64(&s.bytesWritten) }
 
+func envelopeFileName(shardID uint32) string {
+	return fmt.Sprintf("shard-%d.env", shardID)
+}
+
 func Run(id ID, cfg *config.Config, key []byte, cryptoEngine *crypto.Engine, logger log.Logger, store *persistence.Storage) (*Shard, error) {
 	if logger == nil {
 		logger = log.NewNoOpLogger()
@@ -83,7 +87,7 @@ func Run(id ID, cfg *config.Config, key []byte, cryptoEngine *crypto.Engine, log
 			return nil, fmt.Errorf("shard %d: envelope init: %w", id, err)
 		}
 		envDir := envelopeDir(cfg)
-		dek, err := env.Load(envDir, uint32(id))
+		dek, err := env.Load(envDir, envelopeFileName(uint32(id)))
 		if err != nil {
 			if !errors.Is(err, os.ErrNotExist) {
 				return nil, fmt.Errorf("shard %d: load envelope: %w", id, err)
@@ -91,7 +95,7 @@ func Run(id ID, cfg *config.Config, key []byte, cryptoEngine *crypto.Engine, log
 			if err = env.GenerateDEK(); err != nil {
 				return nil, fmt.Errorf("shard %d: generate DEK: %w", id, err)
 			}
-			if err = env.Store(envDir, uint32(id)); err != nil {
+			if err = env.Store(envDir, envelopeFileName(uint32(id))); err != nil {
 				return nil, fmt.Errorf("shard %d: store envelope: %w", id, err)
 			}
 			dek = env.DEK()

--- a/internal/shard/shard_test.go
+++ b/internal/shard/shard_test.go
@@ -1,7 +1,9 @@
 package shard
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"testing"
 
 	"github.com/Saxy/Tellstone/config"
@@ -82,5 +84,39 @@ func TestShardStoppedError(t *testing.T) {
 	resp := s.Execute("GET", "x", nil, 0)
 	if resp.Err != nil {
 		t.Fatal("expected no error from stopped shard (engine still accessible)")
+	}
+}
+
+func TestShardEnvelopeStartup(t *testing.T) {
+	kek := bytes.Repeat([]byte{0x2a}, 32)
+	cfg := config.LoadConfig([]string{
+		"-shards=1",
+		"-enable-encryption",
+		"-enable-envelope",
+		"-encryption-key=" + base64.StdEncoding.EncodeToString(kek),
+		"-persistence-dir=" + t.TempDir(),
+	})
+
+	// First boot generates a per-shard DEK and wraps it with the KEK.
+	s1, err := Run(0, cfg, kek, nil, log.NewNoOpLogger(), nil)
+	if err != nil {
+		t.Fatalf("first start: %v", err)
+	}
+	s1.Stop(context.Background())
+
+	// A restart with the same KEK unwraps the stored DEK instead of minting
+	// a fresh one, so existing data stays decryptable.
+	s2, err := Run(0, cfg, kek, nil, log.NewNoOpLogger(), nil)
+	if err != nil {
+		t.Fatalf("restart with same KEK: %v", err)
+	}
+	s2.Stop(context.Background())
+
+	// A changed KEK must fail startup (fingerprint mismatch) rather than
+	// silently generating fresh DEKs and bricking the dataset.
+	other := bytes.Repeat([]byte{0x11}, 32)
+	if s3, err := Run(0, cfg, other, nil, log.NewNoOpLogger(), nil); err == nil {
+		s3.Stop(context.Background())
+		t.Fatal("startup with changed KEK should fail")
 	}
 }

--- a/internal/shard/shard_test.go
+++ b/internal/shard/shard_test.go
@@ -12,7 +12,7 @@ func TestShardIsolation(t *testing.T) {
 	cfg := config.LoadConfig([]string{"-shards=4"})
 	shards := make([]*Shard, 4)
 	for i := 0; i < 4; i++ {
-		s, err := Run(ID(i), cfg, nil, log.NewNoOpLogger(), nil)
+		s, err := Run(ID(i), cfg, nil, nil, log.NewNoOpLogger(), nil)
 		if err != nil {
 			t.Fatalf("shard %d: %v", i, err)
 		}
@@ -40,7 +40,7 @@ func TestShardIsolation(t *testing.T) {
 
 func TestShardSetGetDelete(t *testing.T) {
 	cfg := config.LoadConfig([]string{"-shards=1"})
-	s, err := Run(0, cfg, nil, log.NewNoOpLogger(), nil)
+	s, err := Run(0, cfg, nil, nil, log.NewNoOpLogger(), nil)
 	if err != nil {
 		t.Fatalf("shard init: %v", err)
 	}
@@ -73,7 +73,7 @@ func TestShardSetGetDelete(t *testing.T) {
 
 func TestShardStoppedError(t *testing.T) {
 	cfg := config.LoadConfig([]string{"-shards=1"})
-	s, err := Run(0, cfg, nil, log.NewNoOpLogger(), nil)
+	s, err := Run(0, cfg, nil, nil, log.NewNoOpLogger(), nil)
 	if err != nil {
 		t.Fatalf("shard init: %v", err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -115,11 +115,11 @@ func (s *Server) Run() error {
 	if err = s.initOAuth(); err != nil {
 		return fmt.Errorf("oauth init: %w", err)
 	}
-	if err = s.initShards(key, cryptoEngine); err != nil {
-		return fmt.Errorf("shard init: %w", err)
-	}
 	if err = s.initAudit(key, cryptoEngine); err != nil {
 		return fmt.Errorf("audit init: %w", err)
+	}
+	if err = s.initShards(key, cryptoEngine); err != nil {
+		return fmt.Errorf("shard init: %w", err)
 	}
 	s.netSrv = network.NewServer(
 		cfg.GetAddr(),

--- a/server/server.go
+++ b/server/server.go
@@ -118,7 +118,9 @@ func (s *Server) Run() error {
 	if err = s.initShards(key, cryptoEngine); err != nil {
 		return fmt.Errorf("shard init: %w", err)
 	}
-	s.initAudit(cryptoEngine)
+	if err = s.initAudit(key, cryptoEngine); err != nil {
+		return fmt.Errorf("audit init: %w", err)
+	}
 	s.netSrv = network.NewServer(
 		cfg.GetAddr(),
 		cfg.GetMaxMsgSize(),
@@ -375,20 +377,26 @@ func (s *Server) initCrypto() ([]byte, *crypto.Engine, error) {
 // disabled --enable-audit yields the no-op engine, so every listener hook can
 // call Record() unconditionally. cryptoEngine is nil when encryption is off;
 // the zero-value crypto.Engine keeps the file writer's encryption path inert.
-func (s *Server) initAudit(cryptoEngine *crypto.Engine) {
+// In envelope mode the audit engine derives its own DEK engine, leaving the
+// caller's cryptoEngine untouched for the shards.
+func (s *Server) initAudit(key []byte, cryptoEngine *crypto.Engine) error {
 	cfg := s.app.GetConfig()
 	logger := s.app.GetLogger()
-	var engine crypto.Engine
+	var engine *crypto.Engine
 	if cryptoEngine != nil {
-		engine = *cryptoEngine
+		engine = cryptoEngine
 	}
-	s.audit = audit.NewLogEngine(
+	var err error
+	s.audit, err = audit.NewLogEngine(
 		cfg.AuditEnabled(),
 		audit.ParseEventTypes(strings.Join(cfg.AuditLogEvents(), ",")),
 		cfg.AuditLogPath(),
 		logger,
+		cfg.EncryptionEnabled() && cfg.EnvelopeEnabled(),
+		key,
 		engine,
 	)
+	return err
 }
 
 func (s *Server) initShards(key []byte, cryptoEngine *crypto.Engine) error {

--- a/server/server.go
+++ b/server/server.go
@@ -92,7 +92,7 @@ func NewServer(app *tellstone.App) *Server {
 func (s *Server) Run() error {
 	logger := s.app.GetLogger()
 	cfg := s.app.GetConfig()
-	cryptoEngine, err := s.initCrypto()
+	key, cryptoEngine, err := s.initCrypto()
 	if err != nil {
 		return fmt.Errorf("crypto init: %w", err)
 	}
@@ -115,7 +115,7 @@ func (s *Server) Run() error {
 	if err = s.initOAuth(); err != nil {
 		return fmt.Errorf("oauth init: %w", err)
 	}
-	if err = s.initShards(cryptoEngine); err != nil {
+	if err = s.initShards(key, cryptoEngine); err != nil {
 		return fmt.Errorf("shard init: %w", err)
 	}
 	s.initAudit(cryptoEngine)
@@ -333,16 +333,18 @@ func (s *Server) shutdown(ctx context.Context) {
 	}
 }
 
-// initCrypto resolves the encryption key and builds the at-rest cipher engine. The key
-// comes from whichever KeyProvider matches the configured source — a file when
-// --encryption-key-file is set, otherwise the base64 flag value — and is read exactly
-// once here, never from the encrypt/decrypt hot path. It returns a nil engine when
-// encryption is disabled, which leaves callers in pass-through mode.
-func (s *Server) initCrypto() (*crypto.Engine, error) {
+// initCrypto resolves the encryption key and builds the shared at-rest cipher
+// engine. The key comes from whichever KeyProvider matches the configured source —
+// a file when --encryption-key-file is set, otherwise the base64 flag value — and
+// is read exactly once here, never from the encrypt/decrypt hot path. The raw key
+// is returned alongside the engine so envelope mode can hand it to each shard as a
+// KEK. Both are nil when encryption is disabled, leaving callers in pass-through
+// mode.
+func (s *Server) initCrypto() ([]byte, *crypto.Engine, error) {
 	cfg := s.app.GetConfig()
 	logger := s.app.GetLogger()
 	if !cfg.EncryptionEnabled() {
-		return nil, nil
+		return nil, nil, nil
 	}
 	var provider crypto.KeyProvider
 	switch {
@@ -356,16 +358,16 @@ func (s *Server) initCrypto() (*crypto.Engine, error) {
 		if logger.Enabled(log.LevelError) {
 			logger.Log(log.LevelError, "encryption key resolution failed", log.String("error", err.Error()))
 		}
-		return nil, fmt.Errorf("encryption key resolution: %w", err)
+		return nil, nil, fmt.Errorf("encryption key resolution: %w", err)
 	}
 	cryptoEngine, err := crypto.NewEngine(key, logger)
 	if err != nil {
 		if logger.Enabled(log.LevelError) {
 			logger.Log(log.LevelError, "server: crypto engine setup failed", log.String("error", err.Error()))
 		}
-		return nil, fmt.Errorf("crypto engine initialization: %w", err)
+		return nil, nil, fmt.Errorf("crypto engine initialization: %w", err)
 	}
-	return cryptoEngine, nil
+	return key, cryptoEngine, nil
 }
 
 // initAudit constructs the shared audit engine from the --enable-audit,
@@ -389,7 +391,7 @@ func (s *Server) initAudit(cryptoEngine *crypto.Engine) {
 	)
 }
 
-func (s *Server) initShards(cryptoEngine *crypto.Engine) error {
+func (s *Server) initShards(key []byte, cryptoEngine *crypto.Engine) error {
 	cfg := s.app.GetConfig()
 	numShards := cfg.GetNumShards()
 	logger := s.app.GetLogger()
@@ -408,7 +410,7 @@ func (s *Server) initShards(cryptoEngine *crypto.Engine) error {
 
 	s.shards = make([]*shard.Shard, numShards)
 	for i := 0; i < numShards; i++ {
-		sh, err := shard.Run(shard.ID(i), cfg, cryptoEngine, logger, store)
+		sh, err := shard.Run(shard.ID(i), cfg, key, cryptoEngine, logger, store)
 		if err != nil {
 			if logger.Enabled(log.LevelError) {
 				logger.Log(log.LevelError, "server: shard initialization failed",


### PR DESCRIPTION
## Description

**Component:** Crypto / Storage engine (data-at-rest), CLI

**Type of Change:**
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance optimization (no change in behavior, improved speed/memory)
- [ ] Refactoring (no functional changes, code cleanup)
- [ ] Build / CI / Documentation

Adds **envelope encryption**: the key configured via `--encryption-key` / `--encryption-key-file` becomes a Key Encryption Key (KEK). On first boot each shard generates a random 32-byte Data Encryption Key (DEK), wraps it with the KEK, and persists it as `shard-<N>.env`. On restart the KEK fingerprint is verified and the DEK unwrapped, so the KEK never touches data and each shard has an independent DEK (rotation- and compromise-friendly).

## Related Issue

Implements the envelope-encryption item tracked alongside the key-provider work (#35).

## Technical Deep Dive & Context

- **On-disk envelope** (`internal/crypto/envelope.go`), fixed 77 bytes:
  `[version:1][KEK fingerprint:16][nonce:12][ciphertext:32][tag:16]` (ChaCha20-Poly1305). FP is `SHA-256(KEK)[:16]`.
- **Fail-closed startup:** `Load` compares the stored fingerprint against the presented KEK; on mismatch the shard refuses to initialize, so a changed/lost KEK surfaces immediately instead of silently corrupting data.
- **Per-shard isolation:** every shard gets its own random DEK — one envelope file per shard, written atomically (tmp + fsync + rename), mode 0600, dir 0700.
- **Decoupled from the WAL:** envelopes are written even when `--enable-persistence` is off (`internal/shard/runner.go`), so encryption stays durable independently of persistence.
- **Zero hot-path cost:** the envelope is touched only at startup. Per-request work is unchanged from the existing DEK/`EncryptInPlace`/`DecryptInPlaceWithDst` path — no new allocations added.
- **params:** new `--enable-envelope` flag (env `TSD_ENABLE_ENVELOPE`); validation panics at startup if `--enable-envelope` is set without `--enable-encryption` or without a key source.

## Performance & Benchmarks

**Workload:** cipher primitives at 64B / 1024B / 4096B payloads — this is a new feature with no before-state, so the numbers below are baselines establishing the crypto cost (no per-request behavior changed). Measured on AMD Ryzen 9 9950X, `go test -bench=. -benchmem`.

| Metric | 64B | 1024B | 4096B |
|--------|-----|-------|-------|
| `EncryptInPlace` (SET path) | 289 ns/op, 0 allocs | 550 ns/op, 0 allocs | 1470 ns/op, 0 allocs |
| `DecryptInPlaceWithDst` (GET path) | 154 ns/op, 0 allocs | 429 ns/op, 0 allocs | 1289 ns/op, 0 allocs |
| `DecryptInPlace` (envelope/large-value) | 164 ns/op, 1 alloc | 635 ns/op, 1 alloc | 2138 ns/op, 1 alloc |

The 0-allocs results confirm the zero-allocation invariant holds at the cipher level. Storage-level encrypted GET is already covered by `BenchmarkEngineGetWithEncryptionNoAlloc`.

## How Has This Been Tested?

- `go build ./...` — pass
- `go vet ./...` — pass, no new warnings
- `go test ./...` — pass, 19 packages
- `go test -race ./...` — pass (crypto, storage, shard, config)
- **Unit tests:** 12 new tests in `internal/crypto/envelope_test.go` (layout, round-trip, corruption, changed-KEK rejection, `os.ErrNotExist`, per-shard isolation across 4 shards, 0600/0700 permissions).
- **Manual end-to-end proof** (binary protocol):
  1. Started with `--enable-encryption --enable-envelope --encryption-key-file kek.key --enable-persistence --persistence-dir ...`
  2. Verified 32 `shard-<N>.env` files, 77 bytes each, mode 0600; hex dump confirmed `version=0x01` and `fingerprint == SHA-256(KEK)[:16]`.
  3. `SET` => restart => `GET` returned the value (DEK unwrapped from envelope, WAL replayed).
  4. Restarted with a different KEK → rejected at startup: `KEK fingerprint mismatch for shard 0; data was written with a different key`.

## Checklist

- [x] My code follows the existing code style of this project
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally (`go test ./...` and `go test -race ./...`)
- [x] I have updated the documentation (README, comments, or any relevant docs) — envelope.go and benchmark file fully documented
- [x] My changes generate no new `go vet` warnings
- [ ] Any breaking changes are documented and communicated — n/a; additive flag, default-off (matches opt-in policy)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional envelope encryption for data and audit logs, with separate encrypted keys per shard.
  * Added command-line and environment variable configuration.
  * Securely stores and restores encrypted key metadata with integrity and access protections.
  * Supports encrypted audit logs across application restarts.

* **Bug Fixes**
  * Validates incompatible encryption settings and required key sources.
  * Detects incorrect keys, damaged metadata, missing files, and malformed encryption data.

* **Performance**
  * Added encryption and decryption benchmarks across common payload sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->