### PR TITLE
feat(audit): restore ACL LOG across restarts and cover NOPERM denials

### DIFF
--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -147,10 +147,13 @@ func newTestEngine(t *testing.T, enabled bool, filter *eventSet, dir string) *Lo
 	return e
 }
 
-// readAuditFiles returns the contents of every *_tsd.log file in dir.
+// readAuditFiles returns the contents of every audit file in dir. It locates
+// them the way replay does, so a rename of the suffix moves this helper with the
+// code instead of failing it; the name itself is pinned by
+// TestFileNameContainsTimestampHashAndMarker.
 func readAuditFiles(t *testing.T, dir string) []string {
 	t.Helper()
-	matches, err := filepath.Glob(filepath.Join(dir, "*_tsd.log"))
+	matches, err := filepath.Glob(filepath.Join(dir, auditFileGlob))
 	if err != nil {
 		t.Fatal("Glob:", err)
 	}

--- a/internal/audit/file.go
+++ b/internal/audit/file.go
@@ -33,6 +33,12 @@ import (
 // while making rotation rare enough not to matter operationally.
 const rotateAfterBytes = 50 << 20
 
+// auditFileSuffix ends every audit file name. Audit files carry no index or
+// manifest, so this suffix is the whole contract between the writer and anyone
+// discovering the files afterwards — replay globs on it. Defined here, beside
+// the fileName that applies it, so the two cannot drift apart.
+const auditFileSuffix = "_tsd.log"
+
 // file is a rotating, optionally encrypted audit log. bytesWritten counts the
 // bytes flushed to the current file; when it reaches maxSize, Write rotates.
 type file struct {
@@ -88,7 +94,7 @@ func open(dir string) (*os.File, string, error) {
 // processes writing to the same directory.
 func fileName(dir string) string {
 	h := sha256.Sum256([]byte(dir))
-	return fmt.Sprintf("%d_%x_%d_tsd.log", time.Now().UnixNano(), h[:4], os.Getpid())
+	return fmt.Sprintf("%d_%x_%d%s", time.Now().UnixNano(), h[:4], os.Getpid(), auditFileSuffix)
 }
 
 // Write encrypts the record when enabled, flushes it to the current file, and

--- a/internal/audit/file_test.go
+++ b/internal/audit/file_test.go
@@ -30,11 +30,13 @@ import (
 	"github.com/Saxy/Tellstone/internal/log"
 )
 
-// auditFilePaths lists every *_tsd.log file in dir. Sorted order equals
-// creation order because the file name embeds its creation timestamp.
+// auditFilePaths lists every audit file in dir. Sorted order equals creation
+// order because the file name embeds its creation timestamp. Discovery only —
+// it locates files the way replay does rather than restating the name, which
+// TestFileNameContainsTimestampHashAndMarker asserts.
 func auditFilePaths(t *testing.T, dir string) []string {
 	t.Helper()
-	matches, err := filepath.Glob(filepath.Join(dir, "*_tsd.log"))
+	matches, err := filepath.Glob(filepath.Join(dir, auditFileGlob))
 	if err != nil {
 		t.Fatal("Glob:", err)
 	}
@@ -79,6 +81,10 @@ func TestFileNameContainsTimestampHashAndMarker(t *testing.T) {
 	}
 	defer f.Close()
 
+	// The suffix is spelled out rather than taken from auditFileSuffix on
+	// purpose. This is the test that pins the on-disk name, and one that built
+	// its expectation from the constant it is checking would pass whatever that
+	// constant said. Changing the suffix is meant to fail here.
 	base := filepath.Base(f.path)
 	if !strings.HasSuffix(base, "_tsd.log") {
 		t.Fatalf("file name %q missing the tsd marker", base)

--- a/internal/audit/replay.go
+++ b/internal/audit/replay.go
@@ -1,0 +1,211 @@
+/*
+Package audit
+Tellstone Cloud-Native In-Memory Database
+File: replay.go
+Description: Startup reader for the persisted audit log. Walks the audit files a
+previous process left in the configured directory and recovers the recent
+auth-failure and acl-deny records, so the ACL LOG buffer — which lives in memory
+and would otherwise start empty — carries its history across a restart. Reading
+happens once during startup, before any listener accepts connections; nothing
+here runs while the server is serving.
+
+Authors:
+
+	Mohamad Radi
+*/
+package audit
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/Saxy/Tellstone/internal/crypto"
+	"github.com/Saxy/Tellstone/internal/log"
+)
+
+// auditFileGlob matches the names fileName generates. Audit files carry no
+// index or manifest, so discovery is a directory glob.
+const auditFileGlob = "*_tsd.log"
+
+// ReplayEntry is one recovered security event, shaped for the ACL LOG buffer.
+// The audit package does not import rbac: the caller translates these into
+// rbac.AuthLogEntry values, keeping the two packages independent.
+type ReplayEntry struct {
+	Timestamp  time.Time
+	Username   string
+	RemoteAddr string
+	Reason     string
+}
+
+// record is the subset of an audit JSON line replay cares about. Fields absent
+// from a given event type decode as empty strings.
+type record struct {
+	Time       string `json:"time"`
+	Event      string `json:"event"`
+	User       string `json:"user"`
+	RemoteAddr string `json:"remote_addr"`
+	Reason     string `json:"reason"`
+	Command    string `json:"command"`
+	Key        string `json:"key"`
+}
+
+// ReplayAuthLog recovers up to maxEntries of the most recent auth-failure and
+// acl-deny records from the audit files in dir, returned oldest first — the
+// order the ACL LOG buffer expects. engine must be the same crypto.Engine the
+// writer used, since it selects the on-disk format; a mismatch (encryption
+// toggled between runs) recovers nothing rather than failing.
+//
+// Every failure mode here is non-fatal and returns whatever was recovered so
+// far: a missing directory, an unreadable file, a corrupt record. History is a
+// convenience, never a reason to refuse to boot.
+func ReplayAuthLog(dir string, engine crypto.Engine, maxEntries int, logger log.Logger) []ReplayEntry {
+	if maxEntries <= 0 {
+		return nil
+	}
+	if logger == nil {
+		logger = log.NewNoOpLogger()
+	}
+	// Glob reports no error for a directory that does not exist, so a first run
+	// with no prior audit history needs no special case.
+	paths, err := filepath.Glob(filepath.Join(dir, auditFileGlob))
+	if err != nil {
+		if logger.Enabled(log.LevelWarn) {
+			logger.Log(log.LevelWarn, "audit: replay could not list audit files",
+				log.String("dir", dir),
+				log.String("error", err.Error()),
+			)
+		}
+		return nil
+	}
+	// File names lead with a creation timestamp in nanoseconds, so lexical order
+	// is creation order. Walking it backwards visits the newest file first and
+	// stops as soon as maxEntries is met, leaving older files unopened.
+	sort.Strings(paths)
+	// Left nil rather than preallocated so "nothing recovered" is a nil slice,
+	// matching what the ACL LOG buffer returns when it is empty.
+	var out []ReplayEntry
+	for i := len(paths) - 1; i >= 0 && len(out) < maxEntries; i-- {
+		entries := readFile(paths[i], engine, logger)
+		for j := len(entries) - 1; j >= 0 && len(out) < maxEntries; j-- {
+			out = append(out, entries[j])
+		}
+	}
+	// The walk collected newest first; the buffer wants oldest first.
+	for l, r := 0, len(out)-1; l < r; l, r = l+1, r-1 {
+		out[l], out[r] = out[r], out[l]
+	}
+	return out
+}
+
+// readFile decodes one audit file into its replayable entries, oldest first. An
+// unreadable file yields nothing: one damaged file must not cost the history
+// held in its siblings.
+func readFile(path string, engine crypto.Engine, logger log.Logger) []ReplayEntry {
+	// Audit files are bounded by rotateAfterBytes, and this runs once at startup
+	// off any serving path, so reading a file whole is simpler than streaming it
+	// and costs one short-lived allocation per file visited.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if logger.Enabled(log.LevelWarn) {
+			logger.Log(log.LevelWarn, "audit: replay could not read audit file",
+				log.String("filename", path),
+				log.String("error", err.Error()),
+			)
+		}
+		return nil
+	}
+	if engine.Enabled() {
+		return decodeEncrypted(data, engine, path, logger)
+	}
+	return decodePlaintext(data)
+}
+
+// decodePlaintext walks newline-delimited JSON, the format the encoder writes
+// when encryption is off. Records are delimited independently of their content,
+// so a malformed line costs only itself — including the partial trailing line a
+// process killed mid-write leaves behind.
+func decodePlaintext(data []byte) []ReplayEntry {
+	var out []ReplayEntry
+	for _, line := range bytes.Split(data, []byte{'\n'}) {
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		if entry, ok := decodeRecord(line); ok {
+			out = append(out, entry)
+		}
+	}
+	return out
+}
+
+// decodeEncrypted walks the [4-byte big-endian length][sealed blob] framing the
+// file writer emits when encryption is on.
+//
+// A record that fails to decrypt is skipped rather than fatal: its length prefix
+// still located the next record, so the stream stays aligned. Broken framing is
+// different — the position of the next record becomes unknowable, so decoding
+// stops and keeps what came before. That is exactly the shape of a process
+// killed between writing a prefix and writing its blob.
+func decodeEncrypted(data []byte, engine crypto.Engine, path string, logger log.Logger) []ReplayEntry {
+	var out []ReplayEntry
+	for len(data) >= 4 {
+		blobLen := int(binary.BigEndian.Uint32(data[:4]))
+		data = data[4:]
+		if blobLen == 0 || blobLen > len(data) {
+			if logger.Enabled(log.LevelWarn) {
+				logger.Log(log.LevelWarn, "audit: replay stopped at a truncated record",
+					log.String("filename", path),
+					log.Int("record_bytes", blobLen),
+					log.Int("remaining_bytes", len(data)),
+				)
+			}
+			return out
+		}
+		plain, err := engine.DecryptInPlace(data[:blobLen])
+		data = data[blobLen:]
+		if err != nil {
+			if logger.Enabled(log.LevelWarn) {
+				logger.Log(log.LevelWarn, "audit: replay skipped an undecryptable record",
+					log.String("filename", path),
+					log.String("error", err.Error()),
+				)
+			}
+			continue
+		}
+		if entry, ok := decodeRecord(plain); ok {
+			out = append(out, entry)
+		}
+	}
+	return out
+}
+
+// decodeRecord turns one JSON audit line into a ReplayEntry. ok is false for
+// malformed JSON, an unparseable timestamp, and every event type ACL LOG does
+// not display — the audit trail holds far more than the two kinds replayed here.
+func decodeRecord(data []byte) (ReplayEntry, bool) {
+	var r record
+	if err := json.Unmarshal(data, &r); err != nil {
+		return ReplayEntry{}, false
+	}
+	entry := ReplayEntry{Username: r.User, RemoteAddr: r.RemoteAddr}
+	switch EventType(r.Event) {
+	case EventAuthFailure:
+		entry.Reason = r.Reason
+	case EventACLDeny:
+		// Rebuilt with the format rbac.Store.LogDenied writes live, so a
+		// replayed denial and a fresh one are indistinguishable in ACL LOG.
+		entry.Reason = "NOPERM command=" + r.Command + " key=" + r.Key
+	default:
+		return ReplayEntry{}, false
+	}
+	ts, err := time.Parse(time.RFC3339Nano, r.Time)
+	if err != nil {
+		return ReplayEntry{}, false
+	}
+	entry.Timestamp = ts
+	return entry, true
+}

--- a/internal/audit/replay.go
+++ b/internal/audit/replay.go
@@ -29,8 +29,12 @@ import (
 )
 
 // auditFileGlob matches the names fileName generates. Audit files carry no
-// index or manifest, so discovery is a directory glob.
-const auditFileGlob = "*_tsd.log"
+// index or manifest, so discovery is a directory glob. Built from the writer's
+// own suffix: a reader that spelled the name out again would stop finding
+// anything the moment the writer's changed, and would do it silently, since a
+// glob that matches nothing is indistinguishable from a directory with no
+// history in it.
+const auditFileGlob = "*" + auditFileSuffix
 
 // ReplayEntry is one recovered security event, shaped for the ACL LOG buffer.
 // The audit package does not import rbac: the caller translates these into

--- a/internal/audit/replay.go
+++ b/internal/audit/replay.go
@@ -55,15 +55,33 @@ type record struct {
 }
 
 // ReplayAuthLog recovers up to maxEntries of the most recent auth-failure and
-// acl-deny records from the audit files in dir, returned oldest first — the
-// order the ACL LOG buffer expects. engine must be the same crypto.Engine the
-// writer used, since it selects the on-disk format; a mismatch (encryption
-// toggled between runs) recovers nothing rather than failing.
+// acl-deny records this engine's directory already holds, returned oldest first
+// — the order the ACL LOG buffer expects.
+//
+// Everything replay needs is the engine's own state, so a caller cannot pair a
+// directory with the wrong key: the destination and the DEK that seals it are
+// both taken from the file writer. An engine that is disabled or writing to
+// stdout has no file writer and replays nothing, since neither has recoverable
+// history.
+//
+// Records this run has written are included, which is why callers replay before
+// serving traffic; at that point the current file is still empty and costs one
+// read.
+func (e *LogEngine) ReplayAuthLog(maxEntries int) []ReplayEntry {
+	f, ok := e.writer.(*file)
+	if !ok {
+		return nil
+	}
+	return replayAuthLog(f.dir, f.ce, maxEntries, f.logger)
+}
+
+// replayAuthLog walks the audit files in dir. engine is the one that sealed
+// them, or nil when they are plaintext.
 //
 // Every failure mode here is non-fatal and returns whatever was recovered so
 // far: a missing directory, an unreadable file, a corrupt record. History is a
 // convenience, never a reason to refuse to boot.
-func ReplayAuthLog(dir string, engine crypto.Engine, maxEntries int, logger log.Logger) []ReplayEntry {
+func replayAuthLog(dir string, engine *crypto.Engine, maxEntries int, logger log.Logger) []ReplayEntry {
 	if maxEntries <= 0 {
 		return nil
 	}
@@ -105,7 +123,7 @@ func ReplayAuthLog(dir string, engine crypto.Engine, maxEntries int, logger log.
 // readFile decodes one audit file into its replayable entries, oldest first. An
 // unreadable file yields nothing: one damaged file must not cost the history
 // held in its siblings.
-func readFile(path string, engine crypto.Engine, logger log.Logger) []ReplayEntry {
+func readFile(path string, engine *crypto.Engine, logger log.Logger) []ReplayEntry {
 	// Audit files are bounded by rotateAfterBytes, and this runs once at startup
 	// off any serving path, so reading a file whole is simpler than streaming it
 	// and costs one short-lived allocation per file visited.
@@ -119,7 +137,9 @@ func readFile(path string, engine crypto.Engine, logger log.Logger) []ReplayEntr
 		}
 		return nil
 	}
-	if engine.Enabled() {
+	// The same condition newFile applies when deciding to seal records, so the
+	// reader and the writer cannot disagree about the format.
+	if engine != nil && engine.Enabled() {
 		return decodeEncrypted(data, engine, path, logger)
 	}
 	return decodePlaintext(data)
@@ -150,7 +170,7 @@ func decodePlaintext(data []byte) []ReplayEntry {
 // different — the position of the next record becomes unknowable, so decoding
 // stops and keeps what came before. That is exactly the shape of a process
 // killed between writing a prefix and writing its blob.
-func decodeEncrypted(data []byte, engine crypto.Engine, path string, logger log.Logger) []ReplayEntry {
+func decodeEncrypted(data []byte, engine *crypto.Engine, path string, logger log.Logger) []ReplayEntry {
 	var out []ReplayEntry
 	for len(data) >= 4 {
 		blobLen := int(binary.BigEndian.Uint32(data[:4]))

--- a/internal/audit/replay.go
+++ b/internal/audit/replay.go
@@ -173,13 +173,19 @@ func decodePlaintext(data []byte) []ReplayEntry {
 func decodeEncrypted(data []byte, engine *crypto.Engine, path string, logger log.Logger) []ReplayEntry {
 	var out []ReplayEntry
 	for len(data) >= 4 {
-		blobLen := int(binary.BigEndian.Uint32(data[:4]))
+		// Kept unsigned, the width the prefix is written in, and compared as
+		// uint64 so the check means the same thing on every platform. Converting
+		// to int first would turn a prefix of 0x80000000 or more negative where
+		// int is 32 bits, slipping past the bounds check and panicking on the
+		// slice below. The length comes from disk, so a crash or a tampered file
+		// can put any value here.
+		blobLen := binary.BigEndian.Uint32(data[:4])
 		data = data[4:]
-		if blobLen == 0 || blobLen > len(data) {
+		if blobLen == 0 || uint64(blobLen) > uint64(len(data)) {
 			if logger.Enabled(log.LevelWarn) {
 				logger.Log(log.LevelWarn, "audit: replay stopped at a truncated record",
 					log.String("filename", path),
-					log.Int("record_bytes", blobLen),
+					log.Uint("record_bytes", blobLen),
 					log.Int("remaining_bytes", len(data)),
 				)
 			}

--- a/internal/audit/replay_test.go
+++ b/internal/audit/replay_test.go
@@ -195,13 +195,23 @@ func TestReplayAuthLogSkipsCorruptLine(t *testing.T) {
 	if err != nil {
 		t.Fatal("ReadFile:", err)
 	}
-	// Splice a malformed line between the two valid records.
+	// Splice a malformed line between the two valid records. The pieces are
+	// copied into a buffer of the test's own rather than appended onto one of
+	// them: SplitN returns subslices of data, and appending to one in place
+	// would overwrite the record that follows it.
 	lines := bytes.SplitN(data, []byte{'\n'}, 2)
-	corrupted := append(append(lines[0], []byte("\n{not json at all\n")...), lines[1]...)
+	var corrupted []byte
+	corrupted = append(corrupted, lines[0]...)
+	corrupted = append(corrupted, "\n{not json at all\n"...)
+	corrupted = append(corrupted, lines[1]...)
 	if err = os.WriteFile(path, corrupted, 0o600); err != nil {
 		t.Fatal("WriteFile:", err)
 	}
 
+	// Three lines in, two records out: the middle one is the skipped record.
+	if got := bytes.Count(corrupted, []byte{'\n'}); got != 3 {
+		t.Fatalf("corrupted file has %d lines, want 3", got)
+	}
 	entries := replayAuthLog(dir, nil, 100, log.NewNoOpLogger())
 	if len(entries) != 2 {
 		t.Fatalf("ReplayAuthLog len = %d, want 2 (corrupt line skipped)", len(entries))
@@ -452,5 +462,39 @@ func TestLogEngineReplayAuthLogNoFileWriter(t *testing.T) {
 	}
 	if entries := stdout.ReplayAuthLog(100); entries != nil {
 		t.Fatalf("stdout engine replayed %+v, want nil", entries)
+	}
+}
+
+// TestReplayAuthLogHugeFrameLength feeds the length prefixes that a corrupt or
+// tampered file can carry. 0x80000000 is the one that matters: it converts to a
+// negative int where int is 32 bits, which would pass a bounds check written
+// against int and panic on the slice.
+func TestReplayAuthLogHugeFrameLength(t *testing.T) {
+	ce, err := crypto.NewEngine(bytes.Repeat([]byte{0x42}, 32), log.NewNoOpLogger())
+	if err != nil {
+		t.Fatal("NewEngine:", err)
+	}
+
+	for name, prefix := range map[string][]byte{
+		"high bit set": {0x80, 0x00, 0x00, 0x00},
+		"max uint32":   {0xFF, 0xFF, 0xFF, 0xFF},
+	} {
+		dir := t.TempDir()
+		writeAuthEvents(t, dir, ce)
+		path := singleAuditFile(t, dir)
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Fatal("ReadFile:", readErr)
+		}
+		// Append the bogus prefix plus a little payload, so the only thing
+		// stopping the decoder is the length check itself.
+		tail := append(append([]byte(nil), prefix...), 0x01, 0x02, 0x03, 0x04)
+		if writeErr := os.WriteFile(path, append(data, tail...), 0o600); writeErr != nil {
+			t.Fatal("WriteFile:", writeErr)
+		}
+		entries := replayAuthLog(dir, ce, 100, log.NewNoOpLogger())
+		if len(entries) != 2 {
+			t.Fatalf("%s: replayAuthLog len = %d, want 2", name, len(entries))
+		}
 	}
 }

--- a/internal/audit/replay_test.go
+++ b/internal/audit/replay_test.go
@@ -1,0 +1,357 @@
+package audit
+
+import (
+	"bytes"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Saxy/Tellstone/internal/crypto"
+	"github.com/Saxy/Tellstone/internal/log"
+)
+
+// writeAuthEvents records one auth failure and one denial through a real engine
+// and closes it, leaving a finished audit file for replay to read back.
+func writeAuthEvents(t *testing.T, dir string, engine crypto.Engine) {
+	t.Helper()
+	e := NewLogEngine(true, ParseEventTypes("all"), dir, log.NewNoOpLogger(), engine)
+	e.Record(EventAuthFailure, "authentication failed",
+		log.String("user", "alice"),
+		log.String("remote_addr", "10.0.0.1:5000"),
+		log.String("reason", "invalid password"),
+		log.String("protocol", "resp"),
+	)
+	e.Record(EventACLDeny, "command denied by rbac policy",
+		log.String("user", "bob"),
+		log.String("command", "set"),
+		log.String("key", "forbidden"),
+		log.String("remote_addr", "10.0.0.2:5001"),
+		log.String("protocol", "resp"),
+	)
+	if err := e.Close(); err != nil {
+		t.Fatal("Close:", err)
+	}
+}
+
+// TestReplayAuthLogPlaintext verifies both replayable event types round-trip
+// through an unencrypted audit file with their fields intact.
+func TestReplayAuthLogPlaintext(t *testing.T) {
+	dir := t.TempDir()
+	writeAuthEvents(t, dir, crypto.Engine{})
+
+	entries := ReplayAuthLog(dir, crypto.Engine{}, 100, log.NewNoOpLogger())
+	if len(entries) != 2 {
+		t.Fatalf("ReplayAuthLog len = %d, want 2", len(entries))
+	}
+	if entries[0].Username != "alice" || entries[0].Reason != "invalid password" {
+		t.Fatalf("entry 0 = %+v, want alice/invalid password", entries[0])
+	}
+	if entries[0].RemoteAddr != "10.0.0.1:5000" {
+		t.Fatalf("entry 0 remote addr = %q", entries[0].RemoteAddr)
+	}
+	if entries[0].Timestamp.IsZero() {
+		t.Fatal("entry 0 has zero timestamp")
+	}
+	// The denial's reason is rebuilt in the format LogDenied writes live.
+	if want := "NOPERM command=set key=forbidden"; entries[1].Reason != want {
+		t.Fatalf("entry 1 Reason = %q, want %q", entries[1].Reason, want)
+	}
+	if entries[1].Username != "bob" {
+		t.Fatalf("entry 1 username = %q, want bob", entries[1].Username)
+	}
+}
+
+// TestReplayAuthLogEncrypted verifies the length-prefixed sealed format decodes
+// back to the same entries as the plaintext one.
+func TestReplayAuthLogEncrypted(t *testing.T) {
+	dir := t.TempDir()
+	ce, err := crypto.NewEngine(bytes.Repeat([]byte{0x42}, 32), log.NewNoOpLogger())
+	if err != nil {
+		t.Fatal("NewEngine:", err)
+	}
+	writeAuthEvents(t, dir, *ce)
+
+	entries := ReplayAuthLog(dir, *ce, 100, log.NewNoOpLogger())
+	if len(entries) != 2 {
+		t.Fatalf("ReplayAuthLog len = %d, want 2", len(entries))
+	}
+	if entries[0].Reason != "invalid password" {
+		t.Fatalf("entry 0 Reason = %q", entries[0].Reason)
+	}
+	if entries[1].Reason != "NOPERM command=set key=forbidden" {
+		t.Fatalf("entry 1 Reason = %q", entries[1].Reason)
+	}
+}
+
+// TestReplayAuthLogIgnoresOtherEvents verifies the audit trail's other event
+// types never reach ACL LOG.
+func TestReplayAuthLogIgnoresOtherEvents(t *testing.T) {
+	dir := t.TempDir()
+	e := NewLogEngine(true, ParseEventTypes("all"), dir, log.NewNoOpLogger(), crypto.Engine{})
+	e.Record(EventConnect, "client connected", log.String("remote_addr", "10.0.0.1:1"))
+	e.Record(EventAuthSuccess, "client authenticated", log.String("user", "alice"))
+	e.Record(EventCommand, "command dispatched", log.String("command", "get"))
+	e.Record(EventDisconnect, "client disconnected", log.String("remote_addr", "10.0.0.1:1"))
+	if err := e.Close(); err != nil {
+		t.Fatal("Close:", err)
+	}
+
+	if entries := ReplayAuthLog(dir, crypto.Engine{}, 100, log.NewNoOpLogger()); len(entries) != 0 {
+		t.Fatalf("ReplayAuthLog = %+v, want no entries", entries)
+	}
+}
+
+// TestReplayAuthLogCapsAtMaxEntries verifies the cap keeps the newest records
+// and still returns them oldest first.
+func TestReplayAuthLogCapsAtMaxEntries(t *testing.T) {
+	dir := t.TempDir()
+	e := NewLogEngine(true, ParseEventTypes("all"), dir, log.NewNoOpLogger(), crypto.Engine{})
+	for i := 0; i < 10; i++ {
+		e.Record(EventAuthFailure, "authentication failed",
+			log.String("user", "u"+string(rune('0'+i))),
+			log.String("reason", "invalid password"),
+		)
+	}
+	if err := e.Close(); err != nil {
+		t.Fatal("Close:", err)
+	}
+
+	entries := ReplayAuthLog(dir, crypto.Engine{}, 3, log.NewNoOpLogger())
+	if len(entries) != 3 {
+		t.Fatalf("ReplayAuthLog len = %d, want 3", len(entries))
+	}
+	// Writes 7, 8 and 9 are the newest three, oldest first.
+	for i, want := range []string{"u7", "u8", "u9"} {
+		if entries[i].Username != want {
+			t.Fatalf("entry %d username = %q, want %q", i, entries[i].Username, want)
+		}
+	}
+}
+
+// TestReplayAuthLogAcrossRotatedFiles verifies chronological order is preserved
+// across a rotation boundary, since each file is a separate read.
+func TestReplayAuthLogAcrossRotatedFiles(t *testing.T) {
+	dir := t.TempDir()
+	e := NewLogEngine(true, ParseEventTypes("all"), dir, log.NewNoOpLogger(), crypto.Engine{})
+	f, ok := e.writer.(*file)
+	if !ok {
+		t.Fatalf("engine writer is %T, want *file", e.writer)
+	}
+	// Rotate after every record so each lands in its own file.
+	f.maxSize = 1
+	for i := 0; i < 4; i++ {
+		e.Record(EventAuthFailure, "authentication failed",
+			log.String("user", "u"+string(rune('0'+i))),
+			log.String("reason", "invalid password"),
+		)
+	}
+	if err := e.Close(); err != nil {
+		t.Fatal("Close:", err)
+	}
+	if paths := auditFilePaths(t, dir); len(paths) < 2 {
+		t.Fatalf("expected rotation to produce several files, got %d", len(paths))
+	}
+
+	entries := ReplayAuthLog(dir, crypto.Engine{}, 100, log.NewNoOpLogger())
+	if len(entries) != 4 {
+		t.Fatalf("ReplayAuthLog len = %d, want 4", len(entries))
+	}
+	for i, want := range []string{"u0", "u1", "u2", "u3"} {
+		if entries[i].Username != want {
+			t.Fatalf("entry %d username = %q, want %q", i, entries[i].Username, want)
+		}
+	}
+
+	// The cap must also work across the boundary, keeping the newest records.
+	capped := ReplayAuthLog(dir, crypto.Engine{}, 2, log.NewNoOpLogger())
+	if len(capped) != 2 {
+		t.Fatalf("capped len = %d, want 2", len(capped))
+	}
+	if capped[0].Username != "u2" || capped[1].Username != "u3" {
+		t.Fatalf("capped = %+v, want u2 then u3", capped)
+	}
+}
+
+// TestReplayAuthLogSkipsCorruptLine verifies a damaged record costs only itself:
+// valid records on both sides of it are still recovered.
+func TestReplayAuthLogSkipsCorruptLine(t *testing.T) {
+	dir := t.TempDir()
+	writeAuthEvents(t, dir, crypto.Engine{})
+
+	path := singleAuditFile(t, dir)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal("ReadFile:", err)
+	}
+	// Splice a malformed line between the two valid records.
+	lines := bytes.SplitN(data, []byte{'\n'}, 2)
+	corrupted := append(append(lines[0], []byte("\n{not json at all\n")...), lines[1]...)
+	if err = os.WriteFile(path, corrupted, 0o600); err != nil {
+		t.Fatal("WriteFile:", err)
+	}
+
+	entries := ReplayAuthLog(dir, crypto.Engine{}, 100, log.NewNoOpLogger())
+	if len(entries) != 2 {
+		t.Fatalf("ReplayAuthLog len = %d, want 2 (corrupt line skipped)", len(entries))
+	}
+	if entries[0].Username != "alice" || entries[1].Username != "bob" {
+		t.Fatalf("entries = %+v, want alice then bob", entries)
+	}
+}
+
+// TestReplayAuthLogTruncatedPlaintextTail simulates a process killed mid-write:
+// the partial trailing line is dropped, the completed records survive.
+func TestReplayAuthLogTruncatedPlaintextTail(t *testing.T) {
+	dir := t.TempDir()
+	writeAuthEvents(t, dir, crypto.Engine{})
+
+	path := singleAuditFile(t, dir)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal("ReadFile:", err)
+	}
+	partial := append(data, []byte(`{"time":"2026-08-12T10:00:00Z","event":"auth_fail`)...)
+	if err = os.WriteFile(path, partial, 0o600); err != nil {
+		t.Fatal("WriteFile:", err)
+	}
+
+	entries := ReplayAuthLog(dir, crypto.Engine{}, 100, log.NewNoOpLogger())
+	if len(entries) != 2 {
+		t.Fatalf("ReplayAuthLog len = %d, want 2", len(entries))
+	}
+}
+
+// TestReplayAuthLogTruncatedEncryptedTail covers both broken-framing shapes: a
+// length prefix cut short, and a prefix promising more bytes than remain.
+func TestReplayAuthLogTruncatedEncryptedTail(t *testing.T) {
+	ce, err := crypto.NewEngine(bytes.Repeat([]byte{0x42}, 32), log.NewNoOpLogger())
+	if err != nil {
+		t.Fatal("NewEngine:", err)
+	}
+
+	for name, tail := range map[string][]byte{
+		"partial length prefix": {0x00, 0x00},
+		"length beyond file":    {0x00, 0x00, 0xFF, 0xFF, 0x01, 0x02},
+	} {
+		dir := t.TempDir()
+		writeAuthEvents(t, dir, *ce)
+		path := singleAuditFile(t, dir)
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Fatal("ReadFile:", readErr)
+		}
+		if writeErr := os.WriteFile(path, append(data, tail...), 0o600); writeErr != nil {
+			t.Fatal("WriteFile:", writeErr)
+		}
+		entries := ReplayAuthLog(dir, *ce, 100, log.NewNoOpLogger())
+		if len(entries) != 2 {
+			t.Fatalf("%s: ReplayAuthLog len = %d, want 2", name, len(entries))
+		}
+	}
+}
+
+// TestReplayAuthLogUndecryptableRecord verifies a corrupt blob is skipped rather
+// than ending the file: its length prefix still located the next record.
+func TestReplayAuthLogUndecryptableRecord(t *testing.T) {
+	dir := t.TempDir()
+	ce, err := crypto.NewEngine(bytes.Repeat([]byte{0x42}, 32), log.NewNoOpLogger())
+	if err != nil {
+		t.Fatal("NewEngine:", err)
+	}
+	writeAuthEvents(t, dir, *ce)
+
+	path := singleAuditFile(t, dir)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal("ReadFile:", err)
+	}
+	// Flip a byte inside the first sealed blob, past its 4-byte length prefix,
+	// so authentication fails for that record alone.
+	data[8] ^= 0xFF
+	if err = os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal("WriteFile:", err)
+	}
+
+	entries := ReplayAuthLog(dir, *ce, 100, log.NewNoOpLogger())
+	if len(entries) != 1 {
+		t.Fatalf("ReplayAuthLog len = %d, want 1 (first record undecryptable)", len(entries))
+	}
+	if entries[0].Username != "bob" {
+		t.Fatalf("surviving entry = %+v, want bob", entries[0])
+	}
+}
+
+// TestReplayAuthLogMissingDirectory covers a first run with no prior history:
+// the audit directory does not exist yet.
+func TestReplayAuthLogMissingDirectory(t *testing.T) {
+	if entries := ReplayAuthLog(t.TempDir()+"/never-created", crypto.Engine{}, 100, log.NewNoOpLogger()); entries != nil {
+		t.Fatalf("ReplayAuthLog = %+v, want nil", entries)
+	}
+}
+
+// TestReplayAuthLogEmptyDirectory covers audit being enabled for the first time
+// against an existing but empty directory.
+func TestReplayAuthLogEmptyDirectory(t *testing.T) {
+	if entries := ReplayAuthLog(t.TempDir(), crypto.Engine{}, 100, log.NewNoOpLogger()); entries != nil {
+		t.Fatalf("ReplayAuthLog = %+v, want nil", entries)
+	}
+}
+
+// TestReplayAuthLogZeroMaxEntries verifies a non-positive cap reads nothing at
+// all rather than everything.
+func TestReplayAuthLogZeroMaxEntries(t *testing.T) {
+	dir := t.TempDir()
+	writeAuthEvents(t, dir, crypto.Engine{})
+	if entries := ReplayAuthLog(dir, crypto.Engine{}, 0, log.NewNoOpLogger()); entries != nil {
+		t.Fatalf("ReplayAuthLog = %+v, want nil", entries)
+	}
+}
+
+// TestReplayAuthLogNilLogger verifies the logger is optional, matching newFile.
+func TestReplayAuthLogNilLogger(t *testing.T) {
+	dir := t.TempDir()
+	writeAuthEvents(t, dir, crypto.Engine{})
+	if entries := ReplayAuthLog(dir, crypto.Engine{}, 100, nil); len(entries) != 2 {
+		t.Fatalf("ReplayAuthLog len = %d, want 2", len(entries))
+	}
+}
+
+// TestReplayAuthLogFormatMismatch documents the encryption-toggle case: files
+// written in one format and read in the other recover nothing, and must not
+// panic or hang.
+func TestReplayAuthLogFormatMismatch(t *testing.T) {
+	ce, err := crypto.NewEngine(bytes.Repeat([]byte{0x42}, 32), log.NewNoOpLogger())
+	if err != nil {
+		t.Fatal("NewEngine:", err)
+	}
+
+	plainDir := t.TempDir()
+	writeAuthEvents(t, plainDir, crypto.Engine{})
+	if entries := ReplayAuthLog(plainDir, *ce, 100, log.NewNoOpLogger()); len(entries) != 0 {
+		t.Fatalf("plaintext read as encrypted = %+v, want no entries", entries)
+	}
+
+	encDir := t.TempDir()
+	writeAuthEvents(t, encDir, *ce)
+	if entries := ReplayAuthLog(encDir, crypto.Engine{}, 100, log.NewNoOpLogger()); len(entries) != 0 {
+		t.Fatalf("encrypted read as plaintext = %+v, want no entries", entries)
+	}
+}
+
+// TestReplayAuthLogTimestampPreserved verifies the recovered timestamp is the
+// one the record carried, not the time of the replay.
+func TestReplayAuthLogTimestampPreserved(t *testing.T) {
+	dir := t.TempDir()
+	before := time.Now()
+	writeAuthEvents(t, dir, crypto.Engine{})
+	after := time.Now()
+
+	entries := ReplayAuthLog(dir, crypto.Engine{}, 100, log.NewNoOpLogger())
+	if len(entries) == 0 {
+		t.Fatal("no entries replayed")
+	}
+	ts := entries[0].Timestamp
+	if ts.Before(before.Add(-time.Second)) || ts.After(after.Add(time.Second)) {
+		t.Fatalf("timestamp %v outside the write window %v..%v", ts, before, after)
+	}
+}

--- a/internal/audit/replay_test.go
+++ b/internal/audit/replay_test.go
@@ -42,7 +42,7 @@ func TestReplayAuthLogPlaintext(t *testing.T) {
 	dir := t.TempDir()
 	writeAuthEvents(t, dir, nil)
 
-	entries := ReplayAuthLog(dir, crypto.Engine{}, 100, log.NewNoOpLogger())
+	entries := replayAuthLog(dir, nil, 100, log.NewNoOpLogger())
 	if len(entries) != 2 {
 		t.Fatalf("ReplayAuthLog len = %d, want 2", len(entries))
 	}
@@ -74,7 +74,7 @@ func TestReplayAuthLogEncrypted(t *testing.T) {
 	}
 	writeAuthEvents(t, dir, ce)
 
-	entries := ReplayAuthLog(dir, *ce, 100, log.NewNoOpLogger())
+	entries := replayAuthLog(dir, ce, 100, log.NewNoOpLogger())
 	if len(entries) != 2 {
 		t.Fatalf("ReplayAuthLog len = %d, want 2", len(entries))
 	}
@@ -102,7 +102,7 @@ func TestReplayAuthLogIgnoresOtherEvents(t *testing.T) {
 		t.Fatal("Close:", err)
 	}
 
-	if entries := ReplayAuthLog(dir, crypto.Engine{}, 100, log.NewNoOpLogger()); len(entries) != 0 {
+	if entries := replayAuthLog(dir, nil, 100, log.NewNoOpLogger()); len(entries) != 0 {
 		t.Fatalf("ReplayAuthLog = %+v, want no entries", entries)
 	}
 }
@@ -125,7 +125,7 @@ func TestReplayAuthLogCapsAtMaxEntries(t *testing.T) {
 		t.Fatal("Close:", err)
 	}
 
-	entries := ReplayAuthLog(dir, crypto.Engine{}, 3, log.NewNoOpLogger())
+	entries := replayAuthLog(dir, nil, 3, log.NewNoOpLogger())
 	if len(entries) != 3 {
 		t.Fatalf("ReplayAuthLog len = %d, want 3", len(entries))
 	}
@@ -164,7 +164,7 @@ func TestReplayAuthLogAcrossRotatedFiles(t *testing.T) {
 		t.Fatalf("expected rotation to produce several files, got %d", len(paths))
 	}
 
-	entries := ReplayAuthLog(dir, crypto.Engine{}, 100, log.NewNoOpLogger())
+	entries := replayAuthLog(dir, nil, 100, log.NewNoOpLogger())
 	if len(entries) != 4 {
 		t.Fatalf("ReplayAuthLog len = %d, want 4", len(entries))
 	}
@@ -175,7 +175,7 @@ func TestReplayAuthLogAcrossRotatedFiles(t *testing.T) {
 	}
 
 	// The cap must also work across the boundary, keeping the newest records.
-	capped := ReplayAuthLog(dir, crypto.Engine{}, 2, log.NewNoOpLogger())
+	capped := replayAuthLog(dir, nil, 2, log.NewNoOpLogger())
 	if len(capped) != 2 {
 		t.Fatalf("capped len = %d, want 2", len(capped))
 	}
@@ -202,7 +202,7 @@ func TestReplayAuthLogSkipsCorruptLine(t *testing.T) {
 		t.Fatal("WriteFile:", err)
 	}
 
-	entries := ReplayAuthLog(dir, crypto.Engine{}, 100, log.NewNoOpLogger())
+	entries := replayAuthLog(dir, nil, 100, log.NewNoOpLogger())
 	if len(entries) != 2 {
 		t.Fatalf("ReplayAuthLog len = %d, want 2 (corrupt line skipped)", len(entries))
 	}
@@ -227,7 +227,7 @@ func TestReplayAuthLogTruncatedPlaintextTail(t *testing.T) {
 		t.Fatal("WriteFile:", err)
 	}
 
-	entries := ReplayAuthLog(dir, crypto.Engine{}, 100, log.NewNoOpLogger())
+	entries := replayAuthLog(dir, nil, 100, log.NewNoOpLogger())
 	if len(entries) != 2 {
 		t.Fatalf("ReplayAuthLog len = %d, want 2", len(entries))
 	}
@@ -255,7 +255,7 @@ func TestReplayAuthLogTruncatedEncryptedTail(t *testing.T) {
 		if writeErr := os.WriteFile(path, append(data, tail...), 0o600); writeErr != nil {
 			t.Fatal("WriteFile:", writeErr)
 		}
-		entries := ReplayAuthLog(dir, *ce, 100, log.NewNoOpLogger())
+		entries := replayAuthLog(dir, ce, 100, log.NewNoOpLogger())
 		if len(entries) != 2 {
 			t.Fatalf("%s: ReplayAuthLog len = %d, want 2", name, len(entries))
 		}
@@ -284,7 +284,7 @@ func TestReplayAuthLogUndecryptableRecord(t *testing.T) {
 		t.Fatal("WriteFile:", err)
 	}
 
-	entries := ReplayAuthLog(dir, *ce, 100, log.NewNoOpLogger())
+	entries := replayAuthLog(dir, ce, 100, log.NewNoOpLogger())
 	if len(entries) != 1 {
 		t.Fatalf("ReplayAuthLog len = %d, want 1 (first record undecryptable)", len(entries))
 	}
@@ -296,7 +296,7 @@ func TestReplayAuthLogUndecryptableRecord(t *testing.T) {
 // TestReplayAuthLogMissingDirectory covers a first run with no prior history:
 // the audit directory does not exist yet.
 func TestReplayAuthLogMissingDirectory(t *testing.T) {
-	if entries := ReplayAuthLog(t.TempDir()+"/never-created", crypto.Engine{}, 100, log.NewNoOpLogger()); entries != nil {
+	if entries := replayAuthLog(t.TempDir()+"/never-created", nil, 100, log.NewNoOpLogger()); entries != nil {
 		t.Fatalf("ReplayAuthLog = %+v, want nil", entries)
 	}
 }
@@ -304,7 +304,7 @@ func TestReplayAuthLogMissingDirectory(t *testing.T) {
 // TestReplayAuthLogEmptyDirectory covers audit being enabled for the first time
 // against an existing but empty directory.
 func TestReplayAuthLogEmptyDirectory(t *testing.T) {
-	if entries := ReplayAuthLog(t.TempDir(), crypto.Engine{}, 100, log.NewNoOpLogger()); entries != nil {
+	if entries := replayAuthLog(t.TempDir(), nil, 100, log.NewNoOpLogger()); entries != nil {
 		t.Fatalf("ReplayAuthLog = %+v, want nil", entries)
 	}
 }
@@ -314,7 +314,7 @@ func TestReplayAuthLogEmptyDirectory(t *testing.T) {
 func TestReplayAuthLogZeroMaxEntries(t *testing.T) {
 	dir := t.TempDir()
 	writeAuthEvents(t, dir, nil)
-	if entries := ReplayAuthLog(dir, crypto.Engine{}, 0, log.NewNoOpLogger()); entries != nil {
+	if entries := replayAuthLog(dir, nil, 0, log.NewNoOpLogger()); entries != nil {
 		t.Fatalf("ReplayAuthLog = %+v, want nil", entries)
 	}
 }
@@ -323,7 +323,7 @@ func TestReplayAuthLogZeroMaxEntries(t *testing.T) {
 func TestReplayAuthLogNilLogger(t *testing.T) {
 	dir := t.TempDir()
 	writeAuthEvents(t, dir, nil)
-	if entries := ReplayAuthLog(dir, crypto.Engine{}, 100, nil); len(entries) != 2 {
+	if entries := replayAuthLog(dir, nil, 100, nil); len(entries) != 2 {
 		t.Fatalf("ReplayAuthLog len = %d, want 2", len(entries))
 	}
 }
@@ -339,13 +339,13 @@ func TestReplayAuthLogFormatMismatch(t *testing.T) {
 
 	plainDir := t.TempDir()
 	writeAuthEvents(t, plainDir, nil)
-	if entries := ReplayAuthLog(plainDir, *ce, 100, log.NewNoOpLogger()); len(entries) != 0 {
+	if entries := replayAuthLog(plainDir, ce, 100, log.NewNoOpLogger()); len(entries) != 0 {
 		t.Fatalf("plaintext read as encrypted = %+v, want no entries", entries)
 	}
 
 	encDir := t.TempDir()
 	writeAuthEvents(t, encDir, ce)
-	if entries := ReplayAuthLog(encDir, crypto.Engine{}, 100, log.NewNoOpLogger()); len(entries) != 0 {
+	if entries := replayAuthLog(encDir, nil, 100, log.NewNoOpLogger()); len(entries) != 0 {
 		t.Fatalf("encrypted read as plaintext = %+v, want no entries", entries)
 	}
 }
@@ -358,12 +358,99 @@ func TestReplayAuthLogTimestampPreserved(t *testing.T) {
 	writeAuthEvents(t, dir, nil)
 	after := time.Now()
 
-	entries := ReplayAuthLog(dir, crypto.Engine{}, 100, log.NewNoOpLogger())
+	entries := replayAuthLog(dir, nil, 100, log.NewNoOpLogger())
 	if len(entries) == 0 {
 		t.Fatal("no entries replayed")
 	}
 	ts := entries[0].Timestamp
 	if ts.Before(before.Add(-time.Second)) || ts.After(after.Add(time.Second)) {
 		t.Fatalf("timestamp %v outside the write window %v..%v", ts, before, after)
+	}
+}
+
+// TestLogEngineReplayAuthLogFromFile verifies the method sources the directory
+// and the key from the engine's own writer rather than from its caller.
+func TestLogEngineReplayAuthLogFromFile(t *testing.T) {
+	dir := t.TempDir()
+	writeAuthEvents(t, dir, nil)
+
+	e, err := NewLogEngine(true, ParseEventTypes("all"), dir, log.NewNoOpLogger(), false, nil, nil)
+	if err != nil {
+		t.Fatal("NewLogEngine:", err)
+	}
+	t.Cleanup(func() { _ = e.Close() })
+
+	entries := e.ReplayAuthLog(100)
+	if len(entries) != 2 {
+		t.Fatalf("ReplayAuthLog len = %d, want 2", len(entries))
+	}
+	if entries[0].Username != "alice" || entries[1].Username != "bob" {
+		t.Fatalf("entries = %+v, want alice then bob", entries)
+	}
+}
+
+// TestLogEngineReplayAuthLogEnvelope is the case the method exists for: in
+// envelope mode the records are sealed with the audit log's own DEK, not the
+// shared engine, and a restart with the same KEK must recover them.
+func TestLogEngineReplayAuthLogEnvelope(t *testing.T) {
+	dir := t.TempDir()
+	kek := bytes.Repeat([]byte{0x2a}, 32)
+
+	first, err := NewLogEngine(true, ParseEventTypes("all"), dir, log.NewNoOpLogger(), true, kek, nil)
+	if err != nil {
+		t.Fatal("NewLogEngine:", err)
+	}
+	first.Record(EventAuthFailure, "authentication failed",
+		log.String("user", "alice"),
+		log.String("remote_addr", "10.0.0.1:5000"),
+		log.String("reason", "invalid password"),
+	)
+	first.Record(EventACLDeny, "command denied by rbac policy",
+		log.String("user", "bob"),
+		log.String("command", "set"),
+		log.String("key", "forbidden"),
+		log.String("remote_addr", "10.0.0.2:5001"),
+	)
+	if err = first.Close(); err != nil {
+		t.Fatal("Close:", err)
+	}
+
+	// The restart reloads the stored DEK, so replay decrypts what the previous
+	// run sealed.
+	second, err := NewLogEngine(true, ParseEventTypes("all"), dir, log.NewNoOpLogger(), true, kek, nil)
+	if err != nil {
+		t.Fatal("NewLogEngine:", err)
+	}
+	t.Cleanup(func() { _ = second.Close() })
+
+	entries := second.ReplayAuthLog(100)
+	if len(entries) != 2 {
+		t.Fatalf("ReplayAuthLog len = %d, want 2", len(entries))
+	}
+	if entries[0].Reason != "invalid password" {
+		t.Fatalf("entry 0 Reason = %q", entries[0].Reason)
+	}
+	if entries[1].Reason != "NOPERM command=set key=forbidden" {
+		t.Fatalf("entry 1 Reason = %q", entries[1].Reason)
+	}
+}
+
+// TestLogEngineReplayAuthLogNoFileWriter verifies the destinations that hold no
+// recoverable history replay nothing instead of guessing at a directory.
+func TestLogEngineReplayAuthLogNoFileWriter(t *testing.T) {
+	disabled, err := NewLogEngine(false, nil, t.TempDir(), log.NewNoOpLogger(), false, nil, nil)
+	if err != nil {
+		t.Fatal("NewLogEngine:", err)
+	}
+	if entries := disabled.ReplayAuthLog(100); entries != nil {
+		t.Fatalf("disabled engine replayed %+v, want nil", entries)
+	}
+
+	stdout, err := NewLogEngine(true, ParseEventTypes("all"), "stdout", log.NewNoOpLogger(), false, nil, nil)
+	if err != nil {
+		t.Fatal("NewLogEngine:", err)
+	}
+	if entries := stdout.ReplayAuthLog(100); entries != nil {
+		t.Fatalf("stdout engine replayed %+v, want nil", entries)
 	}
 }

--- a/internal/network/acl_test.go
+++ b/internal/network/acl_test.go
@@ -401,6 +401,69 @@ func TestServerACLLog(t *testing.T) {
 	}
 }
 
+// TestServerACLLogDenials verifies NOPERM denials reach the ACL LOG buffer over
+// the binary protocol and survive the wire round-trip with the command and key
+// folded into Reason, leaving the four-field entry encoding unchanged.
+func TestServerACLLogDenials(t *testing.T) {
+	addr, store := startACLNetworkServer(t)
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	if resp := sendAndRecv(t, conn, MsgAuth, buildAuthPayloadWithUser("limited", "anything")); resp.Type != MsgAuthOk {
+		t.Fatalf("expected MsgAuthOk for nopass user, got %v", resp.Type)
+	}
+	payload, err := roleRequestPayload(OpACLList, nil)
+	if err != nil {
+		t.Fatalf("roleRequestPayload: %v", err)
+	}
+	if resp := sendAndRecv(t, conn, MsgRequest, payload); !bytes.Equal(resp.Value, ResponseNotAuthorized) {
+		t.Fatalf("expected ResponseNotAuthorized for ACL LIST, got %q", resp.Value)
+	}
+
+	entries := store.AuthLog()
+	if len(entries) != 1 {
+		t.Fatalf("AuthLog len = %d, want 1", len(entries))
+	}
+	if entries[0].Username != "limited" {
+		t.Fatalf("entry 0 username = %q, want limited", entries[0].Username)
+	}
+	// OpACLList carries no key, so the folded Reason ends with an empty key.
+	if want := "NOPERM command=ACL LIST key="; entries[0].Reason != want {
+		t.Fatalf("entry 0 Reason = %q, want %q", entries[0].Reason, want)
+	}
+
+	admin, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer admin.Close()
+	if resp := sendAndRecv(t, admin, MsgAuth, buildAuthPayloadWithUser("admin", "sekret")); resp.Type != MsgAuthOk {
+		t.Fatalf("expected MsgAuthOk, got %v", resp.Type)
+	}
+	payload, err = roleRequestPayload(OpACLLog, nil)
+	if err != nil {
+		t.Fatalf("roleRequestPayload: %v", err)
+	}
+	resp := sendAndRecv(t, admin, MsgRequest, payload)
+	if resp.Type != MsgResponse {
+		t.Fatalf("expected MsgResponse for ACL LOG, got %v", resp.Type)
+	}
+	wireEntries, ok := DecodeACLLogResponse(resp.Value)
+	if !ok {
+		t.Fatal("malformed ACL LOG response")
+	}
+	if len(wireEntries) != 1 {
+		t.Fatalf("wire ACL LOG entry count = %d, want 1", len(wireEntries))
+	}
+	if wireEntries[0].Username != "limited" || wireEntries[0].Reason != entries[0].Reason {
+		t.Fatalf("wire entry 0 = %+v, want it to match the store entry %+v", wireEntries[0], entries[0])
+	}
+}
+
 // TestClientACLMethods exercises the ACL client API against a live server.
 func TestClientACLMethods(t *testing.T) {
 	addr, _ := startACLNetworkServer(t)

--- a/internal/network/acl_test.go
+++ b/internal/network/acl_test.go
@@ -536,3 +536,48 @@ func TestClientACLMethods(t *testing.T) {
 		t.Fatalf("log entry missing timestamp or remote address: %+v", last)
 	}
 }
+
+// TestServerACLLogPolicyNotLoaded covers the AUTH rejection that fires when the
+// store holds no policy snapshot. It is still a failed AUTH, so it has to reach
+// ACL LOG and count against the per-connection limit rather than returning bare.
+func TestServerACLLogPolicyNotLoaded(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	addr := l.Addr().String()
+	_ = l.Close()
+
+	// A store with no snapshot: Load() returns nil, the condition under test.
+	store := rbac.NewStore(nil, log.NewNoOpLogger())
+	srv := NewServer(addr, 0, nil, aclTestHandler(store), log.NewNoOpLogger(), nil, "", store, nil, newNoOpAudit())
+	go func() { _ = srv.ListenAndServe() }()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	})
+	if err = waitForServer(addr, 2*time.Second); err != nil {
+		t.Fatalf("server not ready: %v", err)
+	}
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	if resp := sendAndRecv(t, conn, MsgAuth, buildAuthPayloadWithUser("alice", "whatever")); resp.Type != MsgAuthErr {
+		t.Fatalf("expected MsgAuthErr, got %v", resp.Type)
+	}
+
+	entries := store.AuthLog()
+	if len(entries) != 1 {
+		t.Fatalf("AuthLog len = %d, want 1", len(entries))
+	}
+	if entries[0].Username != "alice" || entries[0].Reason != "policy not loaded" {
+		t.Fatalf("entry 0 = %+v, want alice/policy not loaded", entries[0])
+	}
+	if got := store.AuthFailures(); got != 1 {
+		t.Fatalf("AuthFailures = %d, want 1", got)
+	}
+}

--- a/internal/network/server.go
+++ b/internal/network/server.go
@@ -558,12 +558,16 @@ func (s *Server) discardFrame(c gnet.Conn, totalPacketLen int) {
 	}
 }
 
-// authFailed logs a rejected AUTH attempt to the audit trail, increments the
-// per-connection fail counter, and marks the connection for closure when the
-// rate limit is exceeded. The store-wide ACL counter and log entry are recorded
-// by the caller via LogAuthFailure, which carries the username and reason.
+// authFailed records a rejected AUTH attempt in the ACL LOG buffer and the
+// audit trail, increments the per-connection fail counter, and marks the
+// connection for closure when the rate limit is exceeded. Both recordings live
+// here rather than at the call sites so a new failure path cannot reach one
+// sink without the other, which would let ACL LOG and the audit trail drift.
 func (s *Server) authFailed(st *connState, username, reason string) []byte {
 	st.authFails++
+	if s.policy != nil {
+		s.policy.LogAuthFailure(username, st.remoteAddr, reason)
+	}
 	s.audit.Record(audit.EventAuthFailure, "authentication failed",
 		log.String("user", username),
 		log.String("remote_addr", st.remoteAddr),
@@ -611,9 +615,6 @@ func (s *Server) handleAuthMessage(c gnet.Conn, st *connState, value []byte) aut
 		// A truncated frame is still a rejected AUTH: record it like any other
 		// failure so ACL LOG shows attempted-but-undeliverable credentials. The
 		// username is unknown, so the entry carries an empty name.
-		if s.policy != nil {
-			s.policy.LogAuthFailure("", st.remoteAddr, "malformed request")
-		}
 		return authResult{respPayload: s.authFailed(st, "", "malformed request"), respType: MsgAuthErr}
 	}
 	// A JWT-shaped secret is a bearer token, not a password: route it to the
@@ -645,9 +646,8 @@ func (s *Server) handleAuthMessage(c gnet.Conn, st *connState, value []byte) aut
 		}
 		u := p.UserFor(name)
 		if u == nil {
-			// Unknown usernames fail synchronously; the worker only records
-			// failures for real users, so log the attempt here for ACL LOG.
-			s.policy.LogAuthFailure(name, st.remoteAddr, "unknown user")
+			// Unknown usernames fail synchronously; the worker never sees them,
+			// so the rejection is recorded here on the synchronous path.
 			return authResult{respPayload: s.authFailed(st, name, "unknown user"), respType: MsgAuthErr}
 		}
 		// Empty hash marks a nopass user that accepts any password (Redis
@@ -723,11 +723,6 @@ func (s *Server) authWorker() {
 					)
 				}
 			} else {
-				// Record the store-wide failure counter and ACL LOG entry with
-				// the attempted username before the per-connection handling.
-				if s.policy != nil {
-					s.policy.LogAuthFailure(job.username, st.remoteAddr, job.reason)
-				}
 				respPayload, respType = s.authFailed(st, job.username, job.reason), MsgAuthErr
 			}
 			var writeErr error

--- a/internal/network/server.go
+++ b/internal/network/server.go
@@ -462,18 +462,21 @@ func (s *Server) gateMessage(c gnet.Conn, st *connState, msg *Message) (respType
 		if st.session != nil {
 			user = st.session.Username
 		}
+		cmd := msg.Op.String()
+		keyStr := string(msg.Key)
+		s.policy.LogDenied(user, st.remoteAddr, cmd, keyStr)
 		s.audit.Record(audit.EventACLDeny, "command denied by rbac policy",
 			log.String("user", user),
-			log.String("command", msg.Op.String()),
-			log.String("key", string(msg.Key)),
+			log.String("command", cmd),
+			log.String("key", keyStr),
 			log.String("remote_addr", st.remoteAddr),
 			log.String("protocol", "binary"),
 		)
 		if s.logger.Enabled(log.LevelWarn) {
 			s.logger.Log(log.LevelWarn, "network: command denied by rbac policy",
 				log.String("remote_addr", st.remoteAddr),
-				log.String("command", msg.Op.String()),
-				log.String("key", string(msg.Key)),
+				log.String("command", cmd),
+				log.String("key", keyStr),
 			)
 		}
 		return MsgError, ResponseNotAuthorized, true, false

--- a/internal/network/server.go
+++ b/internal/network/server.go
@@ -641,7 +641,11 @@ func (s *Server) handleAuthMessage(c gnet.Conn, st *connState, value []byte) aut
 	if s.policy != nil {
 		p := s.policy.Load()
 		if p == nil {
-			return authResult{respPayload: ResponseAuthErr, respType: MsgAuthErr}
+			// Recorded like any other rejection rather than returned bare: this
+			// is still a failed AUTH, so it belongs in ACL LOG and the audit
+			// trail and must count against the per-connection limit. The RESP
+			// listener reports it under the same reason.
+			return authResult{respPayload: s.authFailed(st, string(username), "policy not loaded"), respType: MsgAuthErr}
 		}
 		name = "default"
 		if len(username) > 0 {

--- a/internal/rbac/log.go
+++ b/internal/rbac/log.go
@@ -84,6 +84,25 @@ func (s *Store) LogDenied(username, remoteAddr, cmd, key string) {
 	})
 }
 
+// SeedAuthLog pre-fills the buffer with entries recovered from a persisted
+// audit log, restoring ACL LOG's history across a restart. entries must be in
+// chronological order, oldest first, and are subject to the usual capacity —
+// seeding more than DefaultAuthLogCap keeps the newest.
+//
+// The failure counters are deliberately left alone: they count what this process
+// has seen, and a restart resetting them is the behavior rate() and increase()
+// already assume. Called once at startup, before any listener runs.
+func (s *Store) SeedAuthLog(entries []AuthLogEntry) {
+	if len(entries) == 0 {
+		return
+	}
+	s.logMu.Lock()
+	defer s.logMu.Unlock()
+	for _, entry := range entries {
+		s.appendLocked(entry)
+	}
+}
+
 // AuthLog returns the buffered auth-failure entries in chronological order,
 // oldest first. It returns a copy, so the caller may hold the result after the
 // buffer advances. Empty when nothing has failed. ACL LOG is the only consumer;

--- a/internal/rbac/log.go
+++ b/internal/rbac/log.go
@@ -2,10 +2,10 @@
 Package rbac
 Tellstone Role-Based Access Control
 File: log.go
-Description: The ACL auth-failure log behind ACL LOG. A mutex-protected circular buffer of
-recent rejected AUTH attempts (timestamp, username, remote address, reason) kept on the Store,
-so it survives policy hot-swaps and is shared by both protocol layers. Recording happens only
-on the failed-AUTH path — never on the hot path.
+Description: The security-event log behind ACL LOG. A mutex-protected circular buffer of
+recent rejected AUTH attempts and denied commands (timestamp, username, remote address,
+reason) kept on the Store, so it survives policy hot-swaps and is shared by both protocol
+layers. Recording happens only on the failed-AUTH and NOPERM paths — never on the hot path.
 
 Authors:
 
@@ -19,11 +19,15 @@ import (
 )
 
 // DefaultAuthLogCap is the capacity of the ACL LOG circular buffer: 100 recent
-// rejected AUTH attempts, oldest evicted once full.
+// security events, oldest evicted once full. Auth failures and command denials
+// share the capacity, matching Redis, where one bounded log holds both.
 const DefaultAuthLogCap = 100
 
-// AuthLogEntry is one rejected AUTH attempt. Timestamp is wall-clock time at
-// record time; Username may be empty when it was not parseable from the frame.
+// AuthLogEntry is one recorded security event — a rejected AUTH attempt or a
+// denied command. Timestamp is wall-clock time at record time; Username may be
+// empty when it was not parseable from the frame. Reason carries the failure
+// cause verbatim for AUTH rejections and a formatted "NOPERM command=<cmd>
+// key=<key>" string for denials, so both kinds share one wire encoding.
 type AuthLogEntry struct {
 	Timestamp  time.Time
 	Username   string
@@ -31,27 +35,53 @@ type AuthLogEntry struct {
 	Reason     string
 }
 
-// LogAuthFailure records one rejected AUTH attempt in the circular buffer and
-// bumps the store-wide auth-failure counter (the ACL LOG view of IncAuthFailure).
-// The buffer is lazily allocated at DefaultAuthLogCap and evicts the oldest
-// entry once full, newest last. Callers are the protocol AUTH paths only.
-func (s *Store) LogAuthFailure(username, remoteAddr, reason string) {
-	atomic.AddUint64(&s.authFailures, 1)
-	s.logMu.Lock()
-	defer s.logMu.Unlock()
+// appendLocked stores one entry in the circular buffer, lazily allocating it at
+// DefaultAuthLogCap and evicting the oldest once full, newest last. Callers must
+// hold logMu — logMu is not reentrant and every caller already holds it.
+func (s *Store) appendLocked(entry AuthLogEntry) {
 	if s.log == nil {
 		s.log = make([]AuthLogEntry, DefaultAuthLogCap)
 	}
-	s.log[s.logHead] = AuthLogEntry{
-		Timestamp:  time.Now(),
-		Username:   username,
-		RemoteAddr: remoteAddr,
-		Reason:     reason,
-	}
+	s.log[s.logHead] = entry
 	s.logHead = (s.logHead + 1) % len(s.log)
 	if s.logLen < len(s.log) {
 		s.logLen++
 	}
+}
+
+// LogAuthFailure records one rejected AUTH attempt in the circular buffer and
+// bumps the store-wide auth-failure counter (the ACL LOG view of IncAuthFailure).
+// Callers are the protocol AUTH paths only.
+func (s *Store) LogAuthFailure(username, remoteAddr, reason string) {
+	atomic.AddUint64(&s.authFailures, 1)
+	s.logMu.Lock()
+	defer s.logMu.Unlock()
+	s.appendLocked(AuthLogEntry{
+		Timestamp:  time.Now(),
+		Username:   username,
+		RemoteAddr: remoteAddr,
+		Reason:     reason,
+	})
+}
+
+// LogDenied records one command rejected by the policy (NOPERM) in the same
+// circular buffer as LogAuthFailure, so ACL LOG covers authorization denials and
+// not just authentication failures. cmd and key are folded into Reason rather
+// than carried as their own fields: the ACL LOG wire encodings on both protocols
+// are fixed at four length-prefixed fields per entry and carry no version tag,
+// so widening the entry would desynchronize existing clients mid-reply.
+//
+// The denied-command counter is not bumped here — IncDenied already runs at
+// these call sites.
+func (s *Store) LogDenied(username, remoteAddr, cmd, key string) {
+	s.logMu.Lock()
+	defer s.logMu.Unlock()
+	s.appendLocked(AuthLogEntry{
+		Timestamp:  time.Now(),
+		Username:   username,
+		RemoteAddr: remoteAddr,
+		Reason:     "NOPERM command=" + cmd + " key=" + key,
+	})
 }
 
 // AuthLog returns the buffered auth-failure entries in chronological order,

--- a/internal/rbac/log_test.go
+++ b/internal/rbac/log_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/Saxy/Tellstone/internal/log"
 )
@@ -188,6 +189,88 @@ func TestACLLogDeniedEviction(t *testing.T) {
 	}
 	if entries[len(entries)-1].Username != "u"+itoa(total-1) {
 		t.Fatalf("newest entry = %q, want u%d", entries[len(entries)-1].Username, total-1)
+	}
+}
+
+// TestSeedAuthLog verifies replayed history is restored verbatim, keeping the
+// timestamps the records carried rather than the time of the restore.
+func TestSeedAuthLog(t *testing.T) {
+	s := NewStore(&PolicyStore{}, log.NewNoOpLogger())
+	past := time.Date(2026, 8, 12, 10, 0, 0, 0, time.UTC)
+	s.SeedAuthLog([]AuthLogEntry{
+		{Timestamp: past, Username: "alice", RemoteAddr: "10.0.0.1:1", Reason: "invalid password"},
+		{Timestamp: past.Add(time.Minute), Username: "bob", RemoteAddr: "10.0.0.2:2", Reason: "NOPERM command=set key=k"},
+	})
+	entries := s.AuthLog()
+	if len(entries) != 2 {
+		t.Fatalf("AuthLog len = %d, want 2", len(entries))
+	}
+	if !entries[0].Timestamp.Equal(past) {
+		t.Fatalf("entry 0 timestamp = %v, want %v", entries[0].Timestamp, past)
+	}
+	if entries[0].Username != "alice" || entries[1].Username != "bob" {
+		t.Fatalf("entries = %+v, want alice then bob", entries)
+	}
+	if entries[1].Reason != "NOPERM command=set key=k" {
+		t.Fatalf("entry 1 Reason = %q", entries[1].Reason)
+	}
+}
+
+// TestSeedAuthLogEmpty verifies seeding nothing leaves the buffer untouched, the
+// case where no audit history existed to replay.
+func TestSeedAuthLogEmpty(t *testing.T) {
+	s := NewStore(&PolicyStore{}, log.NewNoOpLogger())
+	s.SeedAuthLog(nil)
+	if entries := s.AuthLog(); entries != nil {
+		t.Fatalf("AuthLog = %v, want nil", entries)
+	}
+}
+
+// TestSeedAuthLogDoesNotCount verifies restored history does not inflate the
+// counters, which report what this process has seen.
+func TestSeedAuthLogDoesNotCount(t *testing.T) {
+	s := NewStore(&PolicyStore{}, log.NewNoOpLogger())
+	s.SeedAuthLog([]AuthLogEntry{
+		{Timestamp: time.Now(), Username: "alice", Reason: "invalid password"},
+	})
+	if got := s.AuthFailures(); got != 0 {
+		t.Fatalf("AuthFailures = %d, want 0", got)
+	}
+}
+
+// TestSeedAuthLogEviction verifies seeded entries obey the buffer's capacity
+// instead of getting an exemption from it.
+func TestSeedAuthLogEviction(t *testing.T) {
+	s := NewStore(&PolicyStore{}, log.NewNoOpLogger())
+	total := DefaultAuthLogCap + 7
+	seed := make([]AuthLogEntry, 0, total)
+	for i := 0; i < total; i++ {
+		seed = append(seed, AuthLogEntry{Timestamp: time.Now(), Username: "u" + itoa(i), Reason: "invalid password"})
+	}
+	s.SeedAuthLog(seed)
+	entries := s.AuthLog()
+	if len(entries) != DefaultAuthLogCap {
+		t.Fatalf("AuthLog len = %d, want %d", len(entries), DefaultAuthLogCap)
+	}
+	if entries[0].Username != "u7" {
+		t.Fatalf("oldest survivor = %q, want u7", entries[0].Username)
+	}
+}
+
+// TestSeedAuthLogThenLive verifies live events append after restored history
+// rather than replacing it.
+func TestSeedAuthLogThenLive(t *testing.T) {
+	s := NewStore(&PolicyStore{}, log.NewNoOpLogger())
+	s.SeedAuthLog([]AuthLogEntry{
+		{Timestamp: time.Now().Add(-time.Hour), Username: "restored", Reason: "invalid password"},
+	})
+	s.LogAuthFailure("live", "10.0.0.9:9", "unknown user")
+	entries := s.AuthLog()
+	if len(entries) != 2 {
+		t.Fatalf("AuthLog len = %d, want 2", len(entries))
+	}
+	if entries[0].Username != "restored" || entries[1].Username != "live" {
+		t.Fatalf("entries = %+v, want restored then live", entries)
 	}
 }
 

--- a/internal/rbac/log_test.go
+++ b/internal/rbac/log_test.go
@@ -95,3 +95,129 @@ func TestACLLogConcurrent(t *testing.T) {
 		}
 	}
 }
+
+// TestACLLogDenied verifies a denial records the command and key folded into
+// Reason, the format both ACL LOG wire encodings render verbatim.
+func TestACLLogDenied(t *testing.T) {
+	s := NewStore(&PolicyStore{}, log.NewNoOpLogger())
+	s.LogDenied("bob", "10.0.0.5:5512", "SET", "forbidden:key")
+	entries := s.AuthLog()
+	if len(entries) != 1 {
+		t.Fatalf("AuthLog len = %d, want 1", len(entries))
+	}
+	e := entries[0]
+	if e.Username != "bob" || e.RemoteAddr != "10.0.0.5:5512" {
+		t.Fatalf("entry = %+v", e)
+	}
+	if want := "NOPERM command=SET key=forbidden:key"; e.Reason != want {
+		t.Fatalf("Reason = %q, want %q", e.Reason, want)
+	}
+	if e.Timestamp.IsZero() {
+		t.Fatal("entry has zero timestamp")
+	}
+}
+
+// TestACLLogDeniedKeyless covers keyless commands (ROLE/ACL have no key scope),
+// which pass an empty key through to the Reason string.
+func TestACLLogDeniedKeyless(t *testing.T) {
+	s := NewStore(&PolicyStore{}, log.NewNoOpLogger())
+	s.LogDenied("bob", "10.0.0.5:5512", "ACL", "")
+	entries := s.AuthLog()
+	if len(entries) != 1 {
+		t.Fatalf("AuthLog len = %d, want 1", len(entries))
+	}
+	if want := "NOPERM command=ACL key="; entries[0].Reason != want {
+		t.Fatalf("Reason = %q, want %q", entries[0].Reason, want)
+	}
+}
+
+// TestACLLogMixedAuthAndDenied verifies both event kinds share one buffer and
+// stay in chronological order relative to each other.
+func TestACLLogMixedAuthAndDenied(t *testing.T) {
+	s := NewStore(&PolicyStore{}, log.NewNoOpLogger())
+	s.LogAuthFailure("alice", "1.2.3.4:5", "invalid password")
+	s.LogDenied("bob", "1.2.3.4:6", "GET", "k1")
+	s.LogAuthFailure("carol", "1.2.3.4:7", "unknown user")
+	entries := s.AuthLog()
+	if len(entries) != 3 {
+		t.Fatalf("AuthLog len = %d, want 3", len(entries))
+	}
+	wantUsers := []string{"alice", "bob", "carol"}
+	for i, want := range wantUsers {
+		if entries[i].Username != want {
+			t.Fatalf("entry %d username = %q, want %q", i, entries[i].Username, want)
+		}
+	}
+	if entries[0].Reason != "invalid password" {
+		t.Fatalf("entry 0 Reason = %q", entries[0].Reason)
+	}
+	if entries[1].Reason != "NOPERM command=GET key=k1" {
+		t.Fatalf("entry 1 Reason = %q", entries[1].Reason)
+	}
+}
+
+// TestACLLogDeniedDoesNotCountAuthFailure guards the counter split: denials are
+// counted by IncDenied at the call sites, never by LogDenied.
+func TestACLLogDeniedDoesNotCountAuthFailure(t *testing.T) {
+	s := NewStore(&PolicyStore{}, log.NewNoOpLogger())
+	for i := 0; i < 3; i++ {
+		s.LogDenied("bob", "addr", "SET", "k")
+	}
+	if got := s.AuthFailures(); got != 0 {
+		t.Fatalf("AuthFailures = %d, want 0", got)
+	}
+	if got := s.DeniedCommands(); got != 0 {
+		t.Fatalf("DeniedCommands = %d, want 0 (IncDenied owns the counter)", got)
+	}
+}
+
+// TestACLLogDeniedEviction verifies denials share the buffer's bounded capacity
+// with auth failures rather than getting their own.
+func TestACLLogDeniedEviction(t *testing.T) {
+	s := NewStore(&PolicyStore{}, log.NewNoOpLogger())
+	total := DefaultAuthLogCap + 7
+	for i := 0; i < total; i++ {
+		s.LogDenied("u"+itoa(i), "addr", "GET", "k")
+	}
+	entries := s.AuthLog()
+	if len(entries) != DefaultAuthLogCap {
+		t.Fatalf("AuthLog len = %d, want %d", len(entries), DefaultAuthLogCap)
+	}
+	if entries[0].Username != "u7" {
+		t.Fatalf("oldest survivor = %q, want u7", entries[0].Username)
+	}
+	if entries[len(entries)-1].Username != "u"+itoa(total-1) {
+		t.Fatalf("newest entry = %q, want u%d", entries[len(entries)-1].Username, total-1)
+	}
+}
+
+// TestACLLogDeniedConcurrent exercises interleaved denial and auth-failure
+// writes; run with -race to prove appendLocked stays serialized.
+func TestACLLogDeniedConcurrent(t *testing.T) {
+	s := NewStore(&PolicyStore{}, log.NewNoOpLogger())
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < 200; i++ {
+				if g%2 == 0 {
+					s.LogDenied("bob", "1.2.3.4:5", "SET", "k")
+				} else {
+					s.LogAuthFailure("alice", "1.2.3.4:5", "invalid password")
+				}
+				_ = s.AuthLog()
+			}
+		}(g)
+	}
+	wg.Wait()
+	entries := s.AuthLog()
+	if len(entries) != DefaultAuthLogCap {
+		t.Fatalf("AuthLog len = %d, want %d", len(entries), DefaultAuthLogCap)
+	}
+	for i, e := range entries {
+		if strings.TrimSpace(e.Username) == "" || e.Reason == "" {
+			t.Fatalf("entry %d has empty fields: %+v", i, e)
+		}
+	}
+}

--- a/internal/resp/acl.go
+++ b/internal/resp/acl.go
@@ -115,10 +115,12 @@ func (s *Server) aclList(args [][]byte, out []byte) []byte {
 	return out
 }
 
-// aclLog implements ACL LOG: the recent auth-failure buffer in chronological
+// aclLog implements ACL LOG: the recent security-event buffer in chronological
 // order, each entry a [timestamp, username, remote address, reason] tuple.
-// Unlike Redis's keyed field map the response is a flat array of tuples; the
-// content (who failed, when, from where, why) is the same.
+// Rejected AUTH attempts carry the failure cause in reason; commands denied by
+// the policy carry "NOPERM command=<cmd> key=<key>". Unlike Redis's keyed field
+// map the response is a flat array of tuples; the content (who was rejected,
+// when, from where, why) is the same.
 func (s *Server) aclLog(args [][]byte, out []byte) []byte {
 	if len(args) != 2 {
 		return AppendError(out, "ERR wrong number of arguments for 'acl|log' command")

--- a/internal/resp/acl_test.go
+++ b/internal/resp/acl_test.go
@@ -182,3 +182,54 @@ func TestRESPServer_ACLLog(t *testing.T) {
 	expectReply(t, conn, "ACL LOG",
 		"*2\r\n$3\r\nACL\r\n$3\r\nLOG\r\n", string(want))
 }
+
+// TestRESPServer_ACLLogDenials verifies NOPERM denials land in the ACL LOG
+// buffer alongside auth failures, and that folding the command and key into
+// Reason keeps the reply at four fields per entry — the wire shape existing
+// clients decode.
+func TestRESPServer_ACLLogDenials(t *testing.T) {
+	addr, store := startACLServer(t)
+	conn := dialWithRetry(t, addr)
+	defer conn.Close()
+
+	// The limited role grants +get only, so SET (keyed) and ACL (keyless) are
+	// both denied, covering each deniedReply argument shape.
+	expectReply(t, conn, "AUTH limited",
+		"*3\r\n$4\r\nAUTH\r\n$7\r\nlimited\r\n$8\r\nwhatever\r\n", "+OK\r\n")
+	expectReply(t, conn, "SET denied",
+		"*3\r\n$3\r\nSET\r\n$6\r\nsecret\r\n$1\r\nv\r\n",
+		"-NOPERM no permission for 'set' command on this key\r\n")
+	expectReply(t, conn, "ACL LIST denied",
+		"*2\r\n$3\r\nACL\r\n$4\r\nLIST\r\n", "-NOPERM no permission for 'acl' command\r\n")
+
+	entries := store.AuthLog()
+	if len(entries) != 2 {
+		t.Fatalf("AuthLog len = %d, want 2", len(entries))
+	}
+	if entries[0].Username != "limited" || entries[0].Reason != "NOPERM command=set key=secret" {
+		t.Fatalf("entry 0 = %+v, want limited/NOPERM command=set key=secret", entries[0])
+	}
+	if entries[1].Username != "limited" || entries[1].Reason != "NOPERM command=acl key=" {
+		t.Fatalf("entry 1 = %+v, want limited/NOPERM command=acl key=", entries[1])
+	}
+	if entries[0].RemoteAddr == "" {
+		t.Fatal("entry 0 has empty remote address")
+	}
+
+	// Re-AUTH as admin: the limited role cannot run ACL LOG itself.
+	expectReply(t, conn, "AUTH admin",
+		"*3\r\n$4\r\nAUTH\r\n$5\r\nadmin\r\n$6\r\nsekret\r\n", "+OK\r\n")
+
+	entries = store.AuthLog()
+	var want []byte
+	want = AppendArray(want, len(entries))
+	for _, e := range entries {
+		want = AppendArray(want, 4)
+		want = AppendBulk(want, []byte(e.Timestamp.Format(time.RFC3339)))
+		want = AppendBulk(want, []byte(e.Username))
+		want = AppendBulk(want, []byte(e.RemoteAddr))
+		want = AppendBulk(want, []byte(e.Reason))
+	}
+	expectReply(t, conn, "ACL LOG with denials",
+		"*2\r\n$3\r\nACL\r\n$3\r\nLOG\r\n", string(want))
+}

--- a/internal/resp/server.go
+++ b/internal/resp/server.go
@@ -773,18 +773,24 @@ func (s *Server) countDenied() {
 	}
 }
 
-// deniedReply records one RBAC denial (NOPERM), writes it to the audit trail,
-// and logs the blocked command with the pinned user identity so operators see
-// who was denied. key holds the offending key for keyed commands and is nil for
-// keyless ones (ROLE/ACL have no key scope); keyless omits the key-scoped
-// suffix from the reply.
+// deniedReply records one RBAC denial (NOPERM) in the ACL LOG buffer and the
+// audit trail, and logs the blocked command with the pinned user identity so
+// operators see who was denied. key holds the offending key for keyed commands
+// and is nil for keyless ones (ROLE/ACL have no key scope); keyless omits the
+// key-scoped suffix from the reply.
 func (s *Server) deniedReply(st *connState, cmd string, key []byte, keyless bool, out []byte) []byte {
 	s.countDenied()
 	user := ""
 	if st.session != nil {
 		user = st.session.Username
 	}
+	// keyStr aliases the read buffer, so it stays valid only for this frame.
+	// LogDenied concatenates it into Reason, which copies, and Record encodes it
+	// synchronously — neither retains the alias past the call.
 	keyStr := *(*string)(unsafe.Pointer(&key))
+	if s.policy != nil {
+		s.policy.LogDenied(user, st.remoteAddr, cmd, keyStr)
+	}
 	s.audit.Record(audit.EventACLDeny, "command denied by rbac policy",
 		log.String("user", user),
 		log.String("command", cmd),

--- a/server/audit_replay_test.go
+++ b/server/audit_replay_test.go
@@ -1,0 +1,118 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/Saxy/Tellstone/config"
+	"github.com/Saxy/Tellstone/internal/app/tellstone"
+	"github.com/Saxy/Tellstone/internal/audit"
+	"github.com/Saxy/Tellstone/internal/crypto"
+	"github.com/Saxy/Tellstone/internal/log"
+	"github.com/Saxy/Tellstone/internal/rbac"
+)
+
+// newReplayServer builds a Server wired to the given flags, with RBAC enabled so
+// there is a buffer to seed. Run() is never called: seedAuditReplay is exercised
+// directly, since the surrounding startup opens listeners.
+func newReplayServer(t *testing.T, rbacEnabled bool, args ...string) *Server {
+	t.Helper()
+	app := &tellstone.App{}
+	app.Start(config.LoadConfig(args), log.NewNoOpLogger())
+	s := NewServer(app)
+	if rbacEnabled {
+		s.policy = rbac.NewStore(&rbac.PolicyStore{}, log.NewNoOpLogger())
+	}
+	return s
+}
+
+// writePriorAuditHistory simulates a previous run by writing audit records to
+// dir through a real engine and closing it.
+func writePriorAuditHistory(t *testing.T, dir string) {
+	t.Helper()
+	e := audit.NewLogEngine(true, audit.ParseEventTypes("all"), dir, log.NewNoOpLogger(), crypto.Engine{})
+	e.Record(audit.EventAuthFailure, "authentication failed",
+		log.String("user", "alice"),
+		log.String("remote_addr", "10.0.0.1:5000"),
+		log.String("reason", "invalid password"),
+	)
+	e.Record(audit.EventACLDeny, "command denied by rbac policy",
+		log.String("user", "bob"),
+		log.String("command", "set"),
+		log.String("key", "forbidden"),
+		log.String("remote_addr", "10.0.0.2:5001"),
+	)
+	if err := e.Close(); err != nil {
+		t.Fatal("Close:", err)
+	}
+}
+
+// TestSeedAuditReplayRestoresHistory verifies ACL LOG carries the previous run's
+// events across a restart when audit records go to a directory.
+func TestSeedAuditReplayRestoresHistory(t *testing.T) {
+	dir := t.TempDir()
+	writePriorAuditHistory(t, dir)
+
+	s := newReplayServer(t, true, "-enable-audit", "-audit-log-path", dir)
+	s.seedAuditReplay(nil)
+
+	entries := s.policy.AuthLog()
+	if len(entries) != 2 {
+		t.Fatalf("AuthLog len = %d, want 2", len(entries))
+	}
+	if entries[0].Username != "alice" || entries[0].Reason != "invalid password" {
+		t.Fatalf("entry 0 = %+v, want alice/invalid password", entries[0])
+	}
+	if entries[1].Username != "bob" || entries[1].Reason != "NOPERM command=set key=forbidden" {
+		t.Fatalf("entry 1 = %+v, want bob/NOPERM", entries[1])
+	}
+}
+
+// TestSeedAuditReplayNoopWhenAuditDisabled verifies nothing is restored when the
+// operator never enabled audit logging, even with files present.
+func TestSeedAuditReplayNoopWhenAuditDisabled(t *testing.T) {
+	dir := t.TempDir()
+	writePriorAuditHistory(t, dir)
+
+	s := newReplayServer(t, true, "-audit-log-path", dir)
+	s.seedAuditReplay(nil)
+
+	if entries := s.policy.AuthLog(); entries != nil {
+		t.Fatalf("AuthLog = %+v, want nil", entries)
+	}
+}
+
+// TestSeedAuditReplayNoopWhenStdout verifies the stdout sentinel is skipped
+// rather than treated as a directory name.
+func TestSeedAuditReplayNoopWhenStdout(t *testing.T) {
+	s := newReplayServer(t, true, "-enable-audit", "-audit-log-path", "stdout")
+	s.seedAuditReplay(nil)
+
+	if entries := s.policy.AuthLog(); entries != nil {
+		t.Fatalf("AuthLog = %+v, want nil", entries)
+	}
+}
+
+// TestSeedAuditReplayNoopWhenRBACDisabled verifies a nil policy is handled: with
+// RBAC off there is no ACL LOG to restore.
+func TestSeedAuditReplayNoopWhenRBACDisabled(t *testing.T) {
+	dir := t.TempDir()
+	writePriorAuditHistory(t, dir)
+
+	s := newReplayServer(t, false, "-enable-audit", "-audit-log-path", dir)
+	s.seedAuditReplay(nil)
+
+	if s.policy != nil {
+		t.Fatal("policy should stay nil when RBAC is disabled")
+	}
+}
+
+// TestSeedAuditReplayEmptyDirectory verifies a first run against a fresh audit
+// directory restores nothing and does not fail.
+func TestSeedAuditReplayEmptyDirectory(t *testing.T) {
+	s := newReplayServer(t, true, "-enable-audit", "-audit-log-path", t.TempDir())
+	s.seedAuditReplay(nil)
+
+	if entries := s.policy.AuthLog(); entries != nil {
+		t.Fatalf("AuthLog = %+v, want nil", entries)
+	}
+}

--- a/server/audit_replay_test.go
+++ b/server/audit_replay_test.go
@@ -21,6 +21,12 @@ func newReplayServer(t *testing.T, rbacEnabled bool, args ...string) *Server {
 	if rbacEnabled {
 		s.policy = rbac.NewStore(&rbac.PolicyStore{}, log.NewNoOpLogger())
 	}
+	// seedAuditReplay reads the engine's own state, so the engine has to exist
+	// first — the same order Run() uses.
+	if err := s.initAudit(nil, nil); err != nil {
+		t.Fatal("initAudit:", err)
+	}
+	t.Cleanup(func() { _ = s.audit.Close() })
 	return s
 }
 
@@ -55,7 +61,7 @@ func TestSeedAuditReplayRestoresHistory(t *testing.T) {
 	writePriorAuditHistory(t, dir)
 
 	s := newReplayServer(t, true, "-enable-audit", "-audit-log-path", dir)
-	s.seedAuditReplay(nil)
+	s.seedAuditReplay()
 
 	entries := s.policy.AuthLog()
 	if len(entries) != 2 {
@@ -76,7 +82,7 @@ func TestSeedAuditReplayNoopWhenAuditDisabled(t *testing.T) {
 	writePriorAuditHistory(t, dir)
 
 	s := newReplayServer(t, true, "-audit-log-path", dir)
-	s.seedAuditReplay(nil)
+	s.seedAuditReplay()
 
 	if entries := s.policy.AuthLog(); entries != nil {
 		t.Fatalf("AuthLog = %+v, want nil", entries)
@@ -87,7 +93,7 @@ func TestSeedAuditReplayNoopWhenAuditDisabled(t *testing.T) {
 // rather than treated as a directory name.
 func TestSeedAuditReplayNoopWhenStdout(t *testing.T) {
 	s := newReplayServer(t, true, "-enable-audit", "-audit-log-path", "stdout")
-	s.seedAuditReplay(nil)
+	s.seedAuditReplay()
 
 	if entries := s.policy.AuthLog(); entries != nil {
 		t.Fatalf("AuthLog = %+v, want nil", entries)
@@ -101,7 +107,7 @@ func TestSeedAuditReplayNoopWhenRBACDisabled(t *testing.T) {
 	writePriorAuditHistory(t, dir)
 
 	s := newReplayServer(t, false, "-enable-audit", "-audit-log-path", dir)
-	s.seedAuditReplay(nil)
+	s.seedAuditReplay()
 
 	if s.policy != nil {
 		t.Fatal("policy should stay nil when RBAC is disabled")
@@ -112,7 +118,7 @@ func TestSeedAuditReplayNoopWhenRBACDisabled(t *testing.T) {
 // directory restores nothing and does not fail.
 func TestSeedAuditReplayEmptyDirectory(t *testing.T) {
 	s := newReplayServer(t, true, "-enable-audit", "-audit-log-path", t.TempDir())
-	s.seedAuditReplay(nil)
+	s.seedAuditReplay()
 
 	if entries := s.policy.AuthLog(); entries != nil {
 		t.Fatalf("AuthLog = %+v, want nil", entries)

--- a/server/server.go
+++ b/server/server.go
@@ -118,6 +118,7 @@ func (s *Server) Run() error {
 	if err = s.initShards(cryptoEngine); err != nil {
 		return fmt.Errorf("shard init: %w", err)
 	}
+	s.seedAuditReplay(cryptoEngine)
 	s.initAudit(cryptoEngine)
 	s.netSrv = network.NewServer(
 		cfg.GetAddr(),
@@ -376,10 +377,7 @@ func (s *Server) initCrypto() (*crypto.Engine, error) {
 func (s *Server) initAudit(cryptoEngine *crypto.Engine) {
 	cfg := s.app.GetConfig()
 	logger := s.app.GetLogger()
-	var engine crypto.Engine
-	if cryptoEngine != nil {
-		engine = *cryptoEngine
-	}
+	engine := resolveCryptoEngine(cryptoEngine)
 	s.audit = audit.NewLogEngine(
 		cfg.AuditEnabled(),
 		audit.ParseEventTypes(strings.Join(cfg.AuditLogEvents(), ",")),
@@ -387,6 +385,56 @@ func (s *Server) initAudit(cryptoEngine *crypto.Engine) {
 		logger,
 		engine,
 	)
+}
+
+// resolveCryptoEngine turns the nil-when-disabled engine pointer into its value
+// form. Shared by initAudit and seedAuditReplay so the reader and the writer
+// always agree on whether the audit files are encrypted.
+func resolveCryptoEngine(cryptoEngine *crypto.Engine) crypto.Engine {
+	if cryptoEngine == nil {
+		return crypto.Engine{}
+	}
+	return *cryptoEngine
+}
+
+// seedAuditReplay restores the ACL LOG buffer from the audit files a previous
+// run left behind, so ACL LOG survives a restart instead of starting empty. It
+// applies only when RBAC is on and audit records are going to a directory:
+// stdout cannot be read back, and with audit disabled there is nothing to read.
+//
+// Called before initAudit so the glob cannot pick up the file this process is
+// about to create. Recovery is best-effort and never blocks startup — an
+// unreadable or mismatched log simply leaves the buffer empty.
+func (s *Server) seedAuditReplay(cryptoEngine *crypto.Engine) {
+	cfg := s.app.GetConfig()
+	logger := s.app.GetLogger()
+	if s.policy == nil || !cfg.AuditEnabled() {
+		return
+	}
+	dir := cfg.AuditLogPath()
+	if dir == "" || dir == "stdout" {
+		return
+	}
+	replayed := audit.ReplayAuthLog(dir, resolveCryptoEngine(cryptoEngine), rbac.DefaultAuthLogCap, logger)
+	if len(replayed) == 0 {
+		return
+	}
+	entries := make([]rbac.AuthLogEntry, len(replayed))
+	for i, r := range replayed {
+		entries[i] = rbac.AuthLogEntry{
+			Timestamp:  r.Timestamp,
+			Username:   r.Username,
+			RemoteAddr: r.RemoteAddr,
+			Reason:     r.Reason,
+		}
+	}
+	s.policy.SeedAuthLog(entries)
+	if logger.Enabled(log.LevelInfo) {
+		logger.Log(log.LevelInfo, "server: restored ACL LOG history from the audit log",
+			log.String("dir", dir),
+			log.Int("entries", len(entries)),
+		)
+	}
 }
 
 func (s *Server) initShards(cryptoEngine *crypto.Engine) error {

--- a/server/server.go
+++ b/server/server.go
@@ -720,10 +720,10 @@ func (s *Server) aclList(msg *network.Message) ([]byte, network.MessageType, err
 	return payload, network.MsgResponse, nil
 }
 
-// aclLog handles OpACLLog, returning the recent auth-failure buffer in
-// chronological order with timestamp, username, remote address, and reason —
-// the binary twin of the RESP ACL LOG handler. Entries are already ordered by
-// the store, so no sort is needed.
+// aclLog handles OpACLLog, returning the recent security-event buffer — rejected
+// AUTH attempts and denied commands — in chronological order with timestamp,
+// username, remote address, and reason, the binary twin of the RESP ACL LOG
+// handler. Entries are already ordered by the store, so no sort is needed.
 func (s *Server) aclLog(msg *network.Message) ([]byte, network.MessageType, error) {
 	src := s.policy.AuthLog()
 	entries := make([]network.AuthLogEntry, 0, len(src))

--- a/server/server.go
+++ b/server/server.go
@@ -115,10 +115,13 @@ func (s *Server) Run() error {
 	if err = s.initOAuth(); err != nil {
 		return fmt.Errorf("oauth init: %w", err)
 	}
-	s.seedAuditReplay(cryptoEngine)
 	if err = s.initAudit(key, cryptoEngine); err != nil {
 		return fmt.Errorf("audit init: %w", err)
 	}
+	// After initAudit so the engine has resolved the destination and the key
+	// that seals it, and before any listener starts so the restored history is
+	// in place by the time a client can read ACL LOG.
+	s.seedAuditReplay()
 	if err = s.initShards(key, cryptoEngine); err != nil {
 		return fmt.Errorf("shard init: %w", err)
 	}
@@ -400,35 +403,20 @@ func (s *Server) initAudit(key []byte, cryptoEngine *crypto.Engine) error {
 	return err
 }
 
-// resolveCryptoEngine turns the nil-when-disabled engine pointer into its value
-// form. Shared by initAudit and seedAuditReplay so the reader and the writer
-// always agree on whether the audit files are encrypted.
-func resolveCryptoEngine(cryptoEngine *crypto.Engine) crypto.Engine {
-	if cryptoEngine == nil {
-		return crypto.Engine{}
-	}
-	return *cryptoEngine
-}
-
 // seedAuditReplay restores the ACL LOG buffer from the audit files a previous
-// run left behind, so ACL LOG survives a restart instead of starting empty. It
-// applies only when RBAC is on and audit records are going to a directory:
-// stdout cannot be read back, and with audit disabled there is nothing to read.
+// run left behind, so ACL LOG survives a restart instead of starting empty.
 //
-// Called before initAudit so the glob cannot pick up the file this process is
-// about to create. Recovery is best-effort and never blocks startup — an
-// unreadable or mismatched log simply leaves the buffer empty.
-func (s *Server) seedAuditReplay(cryptoEngine *crypto.Engine) {
-	cfg := s.app.GetConfig()
+// With RBAC disabled there is no buffer to seed. Every other precondition —
+// audit enabled, records going to a directory rather than stdout, and the key
+// that seals them — belongs to the audit engine, so it decides what is
+// replayable. Recovery is best-effort and never blocks startup: an unreadable
+// or unrecoverable log simply leaves the buffer empty.
+func (s *Server) seedAuditReplay() {
+	if s.policy == nil {
+		return
+	}
 	logger := s.app.GetLogger()
-	if s.policy == nil || !cfg.AuditEnabled() {
-		return
-	}
-	dir := cfg.AuditLogPath()
-	if dir == "" || dir == "stdout" {
-		return
-	}
-	replayed := audit.ReplayAuthLog(dir, resolveCryptoEngine(cryptoEngine), rbac.DefaultAuthLogCap, logger)
+	replayed := s.audit.ReplayAuthLog(rbac.DefaultAuthLogCap)
 	if len(replayed) == 0 {
 		return
 	}
@@ -444,7 +432,7 @@ func (s *Server) seedAuditReplay(cryptoEngine *crypto.Engine) {
 	s.policy.SeedAuthLog(entries)
 	if logger.Enabled(log.LevelInfo) {
 		logger.Log(log.LevelInfo, "server: restored ACL LOG history from the audit log",
-			log.String("dir", dir),
+			log.String("dir", s.app.GetConfig().AuditLogPath()),
 			log.Int("entries", len(entries)),
 		)
 	}


### PR DESCRIPTION
## Description

<!-- Clear and concise description of what this PR changes or introduces -->

**Component:** (e.g., Networking/RESP, Storage Engine, Router/Shard, CLI, Build/CI)

**Type of Change:**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Performance optimization (no change in behavior, improved speed/memory)
- [x] Refactoring (no functional changes, code cleanup)
- [ ] Build / CI / Documentation

---

## Related Issue

<!-- Link to the issue this PR addresses, if any. Use "Closes #123" to auto-close. -->

---

## Technical Deep Dive & Context

<!-- Explain how you implemented it, especially if it touches:
  - Memory management or allocation patterns
  - Lock-free / concurrent data structures
  - Network primitives or protocol parsing
  - The shared-nothing shard architecture
  - Any trade-offs or alternatives considered
-->

---

## Performance & Benchmarks (If Applicable)

<!--
For performance-sensitive changes, provide before/after numbers.
Include go test -bench output, memtier_benchmark results, or native binary-protocol benchmark results.
If there is no measurable change, state "no measurable change".
-->

**Workload:** (e.g., 8t x 100c, pipeline 8, 1:9, 200k keys Gaussian)

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| Throughput | ? ops/s | ? ops/s | ?% |
| p50 latency | ? ms | ? ms | ?% |
| p99 latency | ? ms | ? ms | ?% |

```text
// Paste benchmark output here
```

---

## How Has This Been Tested?

<!-- Describe the testing you performed:
  - go test ./... output
  - go test -race ./... output
  - Manual testing steps, if any
  - Any edge cases considered
-->

---

## Checklist

- [x] My code follows the existing code style of this project
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally (`go test ./...` and `go test -race ./...`)
- [x] I have updated the documentation (README, comments, or any relevant docs)
- [ ] My changes generate no new `go vet` warnings
- [x] Any breaking changes are documented and communicated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `ACL LOG` now includes rejected authentication attempts and commands denied by access policies.
  * Denial entries include the username, remote address, command, key, and reason.
  * ACL history is restored after server restarts when persistent audit logging is enabled.

* **Bug Fixes**
  * Improved consistency of authentication and authorization event recording.
  * Invalid, incomplete, or unavailable audit records no longer prevent startup or history recovery.

* **Documentation**
  * Updated `ACL LOG` documentation to describe authentication failures and policy-denied commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->