### PR TITLE
feat(audit): add  a header for auditlog files to know which key was used to seal them

### DIFF
--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -147,9 +147,10 @@ func newTestEngine(t *testing.T, enabled bool, filter *eventSet, dir string) *Lo
 	return e
 }
 
-// readAuditFiles returns the contents of every audit file in dir. It locates
-// them the way replay does, so a rename of the suffix moves this helper with the
-// code instead of failing it; the name itself is pinned by
+// readAuditFiles returns the contents of every audit file in dir, with the
+// header stripped so callers see only record data. It locates them the way
+// replay does, so a rename of the suffix moves this helper with the code
+// instead of failing it; the name itself is pinned by
 // TestFileNameContainsTimestampHashAndMarker.
 func readAuditFiles(t *testing.T, dir string) []string {
 	t.Helper()
@@ -164,6 +165,7 @@ func readAuditFiles(t *testing.T, dir string) []string {
 		if err != nil {
 			t.Fatal("ReadFile:", err)
 		}
+		data = stripHeader(data)
 		out = append(out, string(data))
 	}
 	return out

--- a/internal/audit/engine.go
+++ b/internal/audit/engine.go
@@ -108,18 +108,16 @@ func NewLogEngine(
 			return nil, fmt.Errorf("audit: data engine init: %w", err)
 		}
 	}
-	// Compute the file header metadata. DEK-sealed (envelope) files carry the
-	// DEK's fingerprint so a reader can pick the right key. KEK-sealed and
-	// plaintext files carry the operator key's fingerprint (or zeros when
-	// encryption is entirely off).
+	// Compute the file header metadata. The keyMode must match the record
+	// format the reader will encounter:
+	//   - KeyModeSimple  → plaintext JSON lines, no engine needed.
+	//   - KeyModeEnvelope → length-prefixed sealed records, engine required.
+	// The envelope flag only controls which key sealed the records (DEK vs
+	// KEK), not whether they are sealed at all.
 	var keyMode byte
 	var fingerprint [16]byte
 	if engine != nil && engine.Enabled() {
-		if envelopeEnabled {
-			keyMode = KeyModeEnvelope
-		} else {
-			keyMode = KeyModeSimple
-		}
+		keyMode = KeyModeEnvelope
 		fingerprint = engine.KeyFingerprint()
 	} else if len(key) > 0 {
 		keyMode = KeyModeSimple

--- a/internal/audit/engine.go
+++ b/internal/audit/engine.go
@@ -108,7 +108,24 @@ func NewLogEngine(
 			return nil, fmt.Errorf("audit: data engine init: %w", err)
 		}
 	}
-	f, err := newFile(auditLogPath, engine, logger)
+	// Compute the file header metadata. DEK-sealed (envelope) files carry the
+	// DEK's fingerprint so a reader can pick the right key. KEK-sealed and
+	// plaintext files carry the operator key's fingerprint (or zeros when
+	// encryption is entirely off).
+	var keyMode byte
+	var fingerprint [16]byte
+	if engine != nil && engine.Enabled() {
+		if envelopeEnabled {
+			keyMode = KeyModeEnvelope
+		} else {
+			keyMode = KeyModeSimple
+		}
+		fingerprint = engine.KeyFingerprint()
+	} else if len(key) > 0 {
+		keyMode = KeyModeSimple
+		fingerprint = crypto.FingerprintBytes(key)
+	}
+	f, err := newFile(auditLogPath, engine, logger, keyMode, fingerprint)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/audit/file.go
+++ b/internal/audit/file.go
@@ -28,6 +28,29 @@ import (
 	"github.com/Saxy/Tellstone/internal/log"
 )
 
+const (
+	// auditFileMagic is the 4-byte marker at the start of every audit file
+	// written by the current format. A reader uses it to distinguish headed
+	// files from legacy (headerless) ones without misinterpreting record data.
+	auditFileMagic = "TSDA"
+
+	// auditFileVersion is the format version embedded in the header. Bump it
+	// when the layout changes; the reader dispatches on it.
+	auditFileVersion byte = 1
+
+	// KeyModeSimple signals that every record in the file was sealed directly
+	// with the pass-through mode
+	KeyModeSimple byte = 0
+
+	// KeyModeEnvelope signals envelope mode: every record was sealed with a
+	// per-instance Data Encryption Key wrapped by the a KEK.
+	KeyModeEnvelope byte = 1
+
+	// auditFileHeaderLen is the fixed size of the file header in bytes:
+	// [magic:4][version:1][keyMode:1][fingerprint:16].
+	auditFileHeaderLen = 4 + 1 + 1 + 16
+)
+
 // rotateAfterBytes is the writing volume after which the audit file rotates.
 // 50 MiB keeps a single file small enough to inspect or ingest in one piece
 // while making rotation rare enough not to matter operationally.
@@ -40,7 +63,9 @@ const rotateAfterBytes = 50 << 20
 const auditFileSuffix = "_tsd.log"
 
 // file is a rotating, optionally encrypted audit log. bytesWritten counts the
-// bytes flushed to the current file; when it reaches maxSize, Write rotates.
+// bytes flushed to the current file; when it reaches maxSize, write rotates.
+// Every file starts with a 22-byte self-describing header so a reader can
+// identify the sealing key without consulting a sidecar.
 type file struct {
 	dir          string
 	path         string
@@ -51,12 +76,16 @@ type file struct {
 	maxSize      uint64
 	buf          []byte
 	logger       log.Logger
+	keyMode      byte
+	fingerprint  [16]byte
 }
 
 // newFile opens the first audit file inside dir. When engine.Enabled() is
 // false, records are written as plaintext; otherwise every record is sealed.
-func newFile(dir string, engine *crypto.Engine, logger log.Logger) (*file, error) {
-	f := &file{dir: dir, maxSize: rotateAfterBytes}
+// keyMode and fingerprint are written into the file header so every segment is
+// self-describing — rotation emits the same header automatically.
+func newFile(dir string, engine *crypto.Engine, logger log.Logger, keyMode byte, fingerprint [16]byte) (*file, error) {
+	f := &file{dir: dir, maxSize: rotateAfterBytes, keyMode: keyMode, fingerprint: fingerprint}
 	if engine != nil && engine.Enabled() {
 		f.isEncrypted = true
 		f.ce = engine
@@ -65,7 +94,7 @@ func newFile(dir string, engine *crypto.Engine, logger log.Logger) (*file, error
 		logger = log.NewNoOpLogger()
 	}
 	f.logger = logger
-	osFile, path, err := open(dir)
+	osFile, path, err := open(dir, keyMode, fingerprint)
 	if err != nil {
 		return nil, err
 	}
@@ -77,14 +106,33 @@ func newFile(dir string, engine *crypto.Engine, logger log.Logger) (*file, error
 	return f, nil
 }
 
-// open generates a fresh file name in dir and opens it for append.
-func open(dir string) (*os.File, string, error) {
+// open generates a fresh file name in dir, opens it for append, and writes the
+// self-describing header so every rotated segment carries its own key metadata.
+func open(dir string, keyMode byte, fingerprint [16]byte) (*os.File, string, error) {
 	path := filepath.Join(dir, fileName(dir))
 	osFile, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
 		return nil, "", err
 	}
+	if err := writeHeader(osFile, keyMode, fingerprint); err != nil {
+		osFile.Close()
+		os.Remove(path)
+		return nil, "", err
+	}
 	return osFile, path, nil
+}
+
+// writeHeader emits the fixed [magic:4][version:1][keyMode:1][fingerprint:16]
+// header to w. The header is written once per file at creation time so every
+// audit segment is self-describing without consulting a sidecar.
+func writeHeader(w *os.File, keyMode byte, fingerprint [16]byte) error {
+	var header [auditFileHeaderLen]byte
+	copy(header[0:4], auditFileMagic)
+	header[4] = auditFileVersion
+	header[5] = keyMode
+	copy(header[6:], fingerprint[:])
+	_, err := w.Write(header[:])
+	return err
 }
 
 // fileName builds a unique audit file name:
@@ -142,7 +190,7 @@ func (f *file) Write(p []byte) (int, error) {
 // the same directory, resetting the byte counter. The previous file is left
 // untouched on disk — rotation never truncates or renames history.
 func (f *file) rotate() error {
-	osFile, path, err := open(f.dir)
+	osFile, path, err := open(f.dir, f.keyMode, f.fingerprint)
 	if err != nil {
 		if f.logger.Enabled(log.LevelError) {
 			f.logger.Log(log.LevelError, "audit: failed to rotate log file", log.String("current", f.path), log.String("error", err.Error()))

--- a/internal/audit/file.go
+++ b/internal/audit/file.go
@@ -19,7 +19,9 @@ package audit
 import (
 	"crypto/sha256"
 	"encoding/binary"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"time"
@@ -106,20 +108,29 @@ func newFile(dir string, engine *crypto.Engine, logger log.Logger, keyMode byte,
 	return f, nil
 }
 
-// open generates a fresh file name in dir, opens it for append, and writes the
-// self-describing header so every rotated segment carries its own key metadata.
+// open creates a new audit file exclusively (O_CREATE|O_EXCL) and writes the
+// self-describing header. If the filename collides with an existing segment —
+// an astronomically unlikely event given nanosecond timestamps and PID
+// separation — the name is regenerated and the attempt is retried. The header
+// error is always preserved: cleanup failures (close, remove) are logged but
+// never mask it.
 func open(dir string, keyMode byte, fingerprint [16]byte) (*os.File, string, error) {
-	path := filepath.Join(dir, fileName(dir))
-	osFile, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
-	if err != nil {
-		return nil, "", err
+	for {
+		path := filepath.Join(dir, fileName(dir))
+		osFile, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY|os.O_APPEND, 0o600)
+		if err != nil {
+			if errors.Is(err, fs.ErrExist) {
+				continue
+			}
+			return nil, "", err
+		}
+		if err = writeHeader(osFile, keyMode, fingerprint); err != nil {
+			osFile.Close()
+			os.Remove(path)
+			return nil, "", fmt.Errorf("audit: write header: %w", err)
+		}
+		return osFile, path, nil
 	}
-	if err := writeHeader(osFile, keyMode, fingerprint); err != nil {
-		osFile.Close()
-		os.Remove(path)
-		return nil, "", err
-	}
-	return osFile, path, nil
 }
 
 // writeHeader emits the fixed [magic:4][version:1][keyMode:1][fingerprint:16]

--- a/internal/audit/file_test.go
+++ b/internal/audit/file_test.go
@@ -44,6 +44,16 @@ func auditFilePaths(t *testing.T, dir string) []string {
 	return matches
 }
 
+// stripHeader returns data with the audit file header removed. This mirrors
+// what replay.skipHeader does but lives in the test package so both plaintext
+// and encrypted test helpers can strip the header without importing replay.
+func stripHeader(data []byte) []byte {
+	if len(data) >= auditFileHeaderLen && string(data[:4]) == auditFileMagic {
+		return data[auditFileHeaderLen:]
+	}
+	return data
+}
+
 // a singleAuditFile returns the one and only audit file in dir.
 func singleAuditFile(t *testing.T, dir string) string {
 	t.Helper()
@@ -55,7 +65,8 @@ func singleAuditFile(t *testing.T, dir string) string {
 }
 
 // auditLines returns every non-empty line across all audit files in dir,
-// in creation order.
+// in creation order. The file header is stripped from each file before
+// splitting so callers see only record data.
 func auditLines(t *testing.T, dir string) []string {
 	t.Helper()
 	var lines []string
@@ -64,7 +75,7 @@ func auditLines(t *testing.T, dir string) []string {
 		if err != nil {
 			t.Fatal("ReadFile:", err)
 		}
-		for _, l := range strings.Split(string(data), "\n") {
+		for _, l := range strings.Split(string(stripHeader(data)), "\n") {
 			if l != "" {
 				lines = append(lines, l)
 			}
@@ -75,7 +86,7 @@ func auditLines(t *testing.T, dir string) []string {
 
 func TestFileNameContainsTimestampHashAndMarker(t *testing.T) {
 	dir := t.TempDir()
-	f, err := newFile(dir, &crypto.Engine{}, log.NewNoOpLogger())
+	f, err := newFile(dir, &crypto.Engine{}, log.NewNoOpLogger(), KeyModeSimple, [16]byte{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +121,7 @@ func TestFileNameContainsTimestampHashAndMarker(t *testing.T) {
 
 func TestFileRotation(t *testing.T) {
 	dir := t.TempDir()
-	f, err := newFile(dir, &crypto.Engine{}, log.NewNoOpLogger())
+	f, err := newFile(dir, &crypto.Engine{}, log.NewNoOpLogger(), KeyModeSimple, [16]byte{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -133,8 +144,8 @@ func TestFileRotation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(data) != "0123456789abcdefghij" {
-		t.Fatalf("previous file holds %q, want both writes", data)
+	if got := string(stripHeader(data)); got != "0123456789abcdefghij" {
+		t.Fatalf("previous file holds %q, want both writes", got)
 	}
 
 	if _, err = f.Write([]byte("xyz")); err != nil {
@@ -147,8 +158,8 @@ func TestFileRotation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(data) != "xyz" {
-		t.Fatalf("rotated file holds %q, want xyz", data)
+	if got := string(stripHeader(data)); got != "xyz" {
+		t.Fatalf("rotated file holds %q, want xyz", got)
 	}
 }
 
@@ -212,6 +223,7 @@ func TestFileAuditLoggingEncrypted(t *testing.T) {
 	if strings.Contains(string(data), "AUDIT") {
 		t.Fatal("encrypted audit file contains plaintext AUDIT marker")
 	}
+	data = stripHeader(data)
 
 	for i, r := range records {
 		if len(data) < 4 {
@@ -308,6 +320,7 @@ func TestFileAuditLoggingEnvelope(t *testing.T) {
 		if err != nil {
 			t.Fatal("ReadFile:", err)
 		}
+		data = stripHeader(data)
 		for len(data) > 0 {
 			if len(data) < 4 {
 				t.Fatalf("%s: truncated length prefix (%d bytes left)", p, len(data))
@@ -395,5 +408,184 @@ func TestEngineConcurrentRecords(t *testing.T) {
 	lines := auditLines(t, dir)
 	if len(lines) != workers*perWorker {
 		t.Fatalf("expected %d records, got %d", workers*perWorker, len(lines))
+	}
+}
+
+// --- Audit file header tests ---
+
+func TestAuditFileHeaderLayout(t *testing.T) {
+	dir := t.TempDir()
+	key := bytes.Repeat([]byte{0xAA}, 32)
+	ce, err := crypto.NewEngine(key, log.NewNoOpLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fp := crypto.FingerprintBytes(key)
+
+	f, err := newFile(dir, ce, log.NewNoOpLogger(), KeyModeSimple, fp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	raw, err := os.ReadFile(f.path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(raw) < auditFileHeaderLen {
+		t.Fatalf("file too short for header: %d bytes", len(raw))
+	}
+
+	// [magic:4][version:1][keyMode:1][fingerprint:16]
+	if string(raw[:4]) != auditFileMagic {
+		t.Fatalf("magic = %q, want %q", raw[:4], auditFileMagic)
+	}
+	if raw[4] != auditFileVersion {
+		t.Fatalf("version = %d, want %d", raw[4], auditFileVersion)
+	}
+	if raw[5] != KeyModeSimple {
+		t.Fatalf("keyMode = %d, want %d (KEK)", raw[5], KeyModeSimple)
+	}
+	if !bytes.Equal(raw[6:6+16], fp[:]) {
+		t.Fatal("fingerprint does not match sealing key")
+	}
+}
+
+func TestAuditFileHeaderMagicRejection(t *testing.T) {
+	// A file without the TSDA magic is treated as legacy (headerless).
+	legacy := []byte(`{"event":"auth_success","level":"AUDIT","msg":"test"}` + "\n")
+	if len(legacy) >= 4 && string(legacy[:4]) == auditFileMagic {
+		t.Fatal("test fixture must not start with the audit magic")
+	}
+	// skipHeader must return the data unchanged.
+	got := stripHeader(legacy)
+	if !bytes.Equal(got, legacy) {
+		t.Fatal("skipHeader should return legacy data unchanged")
+	}
+}
+
+func TestAuditFileHeaderKeyMode(t *testing.T) {
+	dir := t.TempDir()
+
+	// Plaintext (no encryption): keyMode should be 0 (KEK).
+	plain, err := newFile(dir, &crypto.Engine{}, log.NewNoOpLogger(), KeyModeSimple, [16]byte{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer plain.Close()
+	raw, err := os.ReadFile(plain.path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if raw[5] != KeyModeSimple {
+		t.Fatalf("plaintext keyMode = %d, want %d", raw[5], KeyModeSimple)
+	}
+
+	// DEK-sealed (envelope mode): keyMode should be 1.
+	key := bytes.Repeat([]byte{0xBB}, 32)
+	ce, err := crypto.NewEngine(key, log.NewNoOpLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fp := crypto.FingerprintBytes(key)
+	fDEK, err := newFile(dir, ce, log.NewNoOpLogger(), KeyModeEnvelope, fp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fDEK.Close()
+	raw, err = os.ReadFile(fDEK.path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if raw[5] != KeyModeEnvelope {
+		t.Fatalf("DEK keyMode = %d, want %d", raw[5], KeyModeEnvelope)
+	}
+}
+
+func TestAuditFileHeaderOnRotation(t *testing.T) {
+	dir := t.TempDir()
+	key := bytes.Repeat([]byte{0xCC}, 32)
+	ce, err := crypto.NewEngine(key, log.NewNoOpLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fp := crypto.FingerprintBytes(key)
+
+	f, err := newFile(dir, ce, log.NewNoOpLogger(), KeyModeEnvelope, fp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	// Force rotation by setting a tiny maxSize.
+	f.maxSize = 5
+	if _, err := f.Write([]byte("0123456789")); err != nil {
+		t.Fatal(err)
+	}
+
+	// The rotated file must also start with the header.
+	raw, err := os.ReadFile(f.path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(raw) < auditFileHeaderLen {
+		t.Fatalf("rotated file too short for header: %d bytes", len(raw))
+	}
+	if string(raw[:4]) != auditFileMagic {
+		t.Fatalf("rotated file magic = %q, want %q", raw[:4], auditFileMagic)
+	}
+	if raw[5] != KeyModeEnvelope {
+		t.Fatalf("rotated file keyMode = %d, want %d", raw[5], KeyModeEnvelope)
+	}
+	if !bytes.Equal(raw[6:6+16], fp[:]) {
+		t.Fatal("rotated file fingerprint does not match sealing key")
+	}
+}
+
+func TestAuditFileHeaderFingerprintMatchesKey(t *testing.T) {
+	dir := t.TempDir()
+	key := bytes.Repeat([]byte{0xDD}, 32)
+	ce, err := crypto.NewEngine(key, log.NewNoOpLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fp := crypto.FingerprintBytes(key)
+
+	f, err := newFile(dir, ce, log.NewNoOpLogger(), KeyModeSimple, fp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	raw, err := os.ReadFile(f.path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := raw[6 : 6+16]
+	if !bytes.Equal(got, fp[:]) {
+		t.Fatalf("header fingerprint %x does not match expected %x", got, fp[:])
+	}
+}
+
+func TestLegacyHeaderlessFileStillReplays(t *testing.T) {
+	// Write a headerless plaintext audit file (legacy format) and verify
+	// replay still recovers the records.
+	dir := t.TempDir()
+	legacy := []byte(`{"time":"2026-08-12T10:00:00Z","level":"AUDIT","event":"auth_failure","user":"alice","reason":"invalid password"}` + "\n" +
+		`{"time":"2026-08-12T10:01:00Z","level":"AUDIT","event":"acl_deny","user":"bob","command":"set","key":"forbidden"}` + "\n")
+	path := filepath.Join(dir, "legacy_0000000000_00000000_0_tsd.log")
+	if err := os.WriteFile(path, legacy, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	entries := replayAuthLog(dir, nil, 100, log.NewNoOpLogger())
+	if len(entries) != 2 {
+		t.Fatalf("ReplayAuthLog len = %d, want 2 for legacy file", len(entries))
+	}
+	if entries[0].Username != "alice" {
+		t.Fatalf("entry 0 username = %q, want alice", entries[0].Username)
+	}
+	if entries[1].Username != "bob" {
+		t.Fatalf("entry 1 username = %q, want bob", entries[1].Username)
 	}
 }

--- a/internal/audit/file_test.go
+++ b/internal/audit/file_test.go
@@ -30,6 +30,18 @@ import (
 	"github.com/Saxy/Tellstone/internal/log"
 )
 
+// closeFile registers a t.Cleanup that closes f and reports any error via
+// t.Errorf, matching the project's convention that test helpers surface cleanup
+// failures through the test handle.
+func closeFile(t *testing.T, f *file) {
+	t.Helper()
+	t.Cleanup(func() {
+		if err := f.Close(); err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	})
+}
+
 // auditFilePaths lists every audit file in dir. Sorted order equals creation
 // order because the file name embeds its creation timestamp. Discovery only —
 // it locates files the way replay does rather than restating the name, which
@@ -90,7 +102,7 @@ func TestFileNameContainsTimestampHashAndMarker(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer f.Close()
+	closeFile(t, f)
 
 	// The suffix is spelled out rather than taken from auditFileSuffix on
 	// purpose. This is the test that pins the on-disk name, and one that built
@@ -125,7 +137,7 @@ func TestFileRotation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer f.Close()
+	closeFile(t, f)
 
 	first := f.path
 	f.maxSize = 20
@@ -426,7 +438,7 @@ func TestAuditFileHeaderLayout(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer f.Close()
+	closeFile(t, f)
 
 	raw, err := os.ReadFile(f.path)
 	if err != nil {
@@ -472,7 +484,7 @@ func TestAuditFileHeaderKeyMode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer plain.Close()
+	closeFile(t, plain)
 	raw, err := os.ReadFile(plain.path)
 	if err != nil {
 		t.Fatal(err)
@@ -492,7 +504,7 @@ func TestAuditFileHeaderKeyMode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer fDEK.Close()
+	closeFile(t, fDEK)
 	raw, err = os.ReadFile(fDEK.path)
 	if err != nil {
 		t.Fatal(err)
@@ -515,7 +527,7 @@ func TestAuditFileHeaderOnRotation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer f.Close()
+	closeFile(t, f)
 
 	// Force rotation by setting a tiny maxSize.
 	f.maxSize = 5
@@ -555,7 +567,7 @@ func TestAuditFileHeaderFingerprintMatchesKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer f.Close()
+	closeFile(t, f)
 
 	raw, err := os.ReadFile(f.path)
 	if err != nil {

--- a/internal/audit/replay.go
+++ b/internal/audit/replay.go
@@ -127,6 +127,17 @@ func replayAuthLog(dir string, engine *crypto.Engine, maxEntries int, logger log
 // readFile decodes one audit file into its replayable entries, oldest first. An
 // unreadable file yields nothing: one damaged file must not cost the history
 // held in its siblings.
+//
+// When the file carries a header the keyMode field decides the format:
+//   - KeyModeSimple (0) → plaintext records, no engine needed.
+//   - KeyModeEnvelope (1) → length-prefixed sealed records; the engine's
+//     fingerprint is validated against the header before any decryption is
+//     attempted, so a wrong key is rejected rather than silently producing
+//     garbage.
+//
+// For headerless legacy files the format is inferred from the engine parameter
+// (nil → plaintext, non-nil → encrypted), preserving backward compatibility
+// without requiring migration.
 func readFile(path string, engine *crypto.Engine, logger log.Logger) []ReplayEntry {
 	// Audit files are bounded by rotateAfterBytes, and this runs once at startup
 	// off any serving path, so reading a file whole is simpler than streaming it
@@ -141,24 +152,62 @@ func readFile(path string, engine *crypto.Engine, logger log.Logger) []ReplayEnt
 		}
 		return nil
 	}
-	data = skipHeader(data, logger, path)
-	// The same condition newFile applies when deciding to seal records, so the
-	// reader and the writer cannot disagree about the format.
-	if engine != nil && engine.Enabled() {
-		return decodeEncrypted(data, engine, path, logger)
+	keyMode, fingerprint, rest, ok := parseHeader(data, logger, path)
+	if !ok {
+		// No valid header — legacy file created before the header feature.
+		// The format cannot be determined from the file itself; infer from
+		// the engine parameter (nil → plaintext, non-nil → encrypted).
+		if logger.Enabled(log.LevelDebug) {
+			logger.Log(log.LevelDebug, "audit: replay reading headerless legacy file",
+				log.String("filename", path),
+			)
+		}
+		if engine != nil && engine.Enabled() {
+			return decodeEncrypted(data, engine, path, logger)
+		}
+		return decodePlaintext(data)
 	}
-	return decodePlaintext(data)
+	// Header present: keyMode is the authority.
+	switch keyMode {
+	case KeyModeSimple:
+		return decodePlaintext(rest)
+	case KeyModeEnvelope:
+		if engine == nil || !engine.Enabled() {
+			if logger.Enabled(log.LevelWarn) {
+				logger.Log(log.LevelWarn, "audit: replay skipping sealed file with no engine",
+					log.String("filename", path),
+				)
+			}
+			return nil
+		}
+		if engine.KeyFingerprint() != fingerprint {
+			if logger.Enabled(log.LevelWarn) {
+				logger.Log(log.LevelWarn, "audit: replay skipping sealed file: fingerprint mismatch",
+					log.String("filename", path),
+				)
+			}
+			return nil
+		}
+		return decodeEncrypted(rest, engine, path, logger)
+	default:
+		if logger.Enabled(log.LevelWarn) {
+			logger.Log(log.LevelWarn, "audit: replay skipping file with unknown keyMode",
+				log.String("filename", path),
+				log.Uint("keyMode", uint32(keyMode)),
+			)
+		}
+		return nil
+	}
 }
 
-// skipHeader inspects the first bytes of an audit file for the self-describing
-// header ([magic:4][version:1][keyMode:1][fingerprint:16]). When the magic is
-// present the data past the header is returned; for headerless legacy files the
-// original data is returned unchanged. A file shorter than the header or with
-// an unknown version is returned as-is — decoding will either parse it as
-// records or skip the damage gracefully.
-func skipHeader(data []byte, logger log.Logger, path string) []byte {
+// parseHeader inspects the first bytes of an audit file for the self-describing
+// header ([magic:4][version:1][keyMode:1][fingerprint:16]). When valid, it
+// returns the keyMode, the 16-byte fingerprint, the remaining data past the
+// header, and ok=true. For headerless legacy files or files with an unknown
+// version, ok is false and the caller falls back to engine-based inference.
+func parseHeader(data []byte, logger log.Logger, path string) (keyMode byte, fingerprint [16]byte, rest []byte, ok bool) {
 	if len(data) < auditFileHeaderLen || string(data[:4]) != auditFileMagic {
-		return data
+		return 0, [16]byte{}, data, false
 	}
 	version := data[4]
 	if version != auditFileVersion {
@@ -168,9 +217,11 @@ func skipHeader(data []byte, logger log.Logger, path string) []byte {
 				log.Uint("version", uint32(version)),
 			)
 		}
-		return data
+		return 0, [16]byte{}, data, false
 	}
-	return data[auditFileHeaderLen:]
+	keyMode = data[5]
+	copy(fingerprint[:], data[6:6+16])
+	return keyMode, fingerprint, data[auditFileHeaderLen:], true
 }
 
 // decodePlaintext walks newline-delimited JSON, the format the encoder writes

--- a/internal/audit/replay.go
+++ b/internal/audit/replay.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -128,16 +129,15 @@ func replayAuthLog(dir string, engine *crypto.Engine, maxEntries int, logger log
 // unreadable file yields nothing: one damaged file must not cost the history
 // held in its siblings.
 //
-// When the file carries a header the keyMode field decides the format:
-//   - KeyModeSimple (0) → plaintext records, no engine needed.
-//   - KeyModeEnvelope (1) → length-prefixed sealed records; the engine's
-//     fingerprint is validated against the header before any decryption is
-//     attempted, so a wrong key is rejected rather than silently producing
-//     garbage.
-//
-// For headerless legacy files the format is inferred from the engine parameter
-// (nil → plaintext, non-nil → encrypted), preserving backward compatibility
-// without requiring migration.
+// Three cases:
+//  1. Valid header (ok=true, err=nil): keyMode is the authority.
+//     KeyModeSimple → plaintext; KeyModeEnvelope → sealed records with
+//     fingerprint validation before decryption (fail-closed on mismatch).
+//  2. No magic prefix (ok=false, err=nil): legacy file created before the
+//     header feature. Format inferred from the engine parameter.
+//  3. Magic present but header invalid (ok=false, err≠nil): the file is
+//     recognised as a Tellstone audit segment but is corrupt or from an
+//     unsupported version. It is skipped entirely — no fallback decoding.
 func readFile(path string, engine *crypto.Engine, logger log.Logger) []ReplayEntry {
 	// Audit files are bounded by rotateAfterBytes, and this runs once at startup
 	// off any serving path, so reading a file whole is simpler than streaming it
@@ -152,11 +152,22 @@ func readFile(path string, engine *crypto.Engine, logger log.Logger) []ReplayEnt
 		}
 		return nil
 	}
-	keyMode, fingerprint, rest, ok := parseHeader(data, logger, path)
+	keyMode, fingerprint, rest, ok, headerErr := parseHeader(data, logger, path)
+	if headerErr != nil {
+		// Magic present but header is corrupt or unsupported: reject the
+		// entire file. No fallback — the data was written in a format the
+		// reader does not understand.
+		if logger.Enabled(log.LevelWarn) {
+			logger.Log(log.LevelWarn, "audit: replay skipping file with invalid header",
+				log.String("filename", path),
+				log.String("error", headerErr.Error()),
+			)
+		}
+		return nil
+	}
 	if !ok {
-		// No valid header — legacy file created before the header feature.
-		// The format cannot be determined from the file itself; infer from
-		// the engine parameter (nil → plaintext, non-nil → encrypted).
+		// No magic — legacy file. Format cannot be determined from the file
+		// itself; infer from the engine parameter.
 		if logger.Enabled(log.LevelDebug) {
 			logger.Log(log.LevelDebug, "audit: replay reading headerless legacy file",
 				log.String("filename", path),
@@ -167,7 +178,7 @@ func readFile(path string, engine *crypto.Engine, logger log.Logger) []ReplayEnt
 		}
 		return decodePlaintext(data)
 	}
-	// Header present: keyMode is the authority.
+	// Valid header: keyMode is the authority.
 	switch keyMode {
 	case KeyModeSimple:
 		return decodePlaintext(rest)
@@ -201,27 +212,30 @@ func readFile(path string, engine *crypto.Engine, logger log.Logger) []ReplayEnt
 }
 
 // parseHeader inspects the first bytes of an audit file for the self-describing
-// header ([magic:4][version:1][keyMode:1][fingerprint:16]). When valid, it
-// returns the keyMode, the 16-byte fingerprint, the remaining data past the
-// header, and ok=true. For headerless legacy files or files with an unknown
-// version, ok is false and the caller falls back to engine-based inference.
-func parseHeader(data []byte, logger log.Logger, path string) (keyMode byte, fingerprint [16]byte, rest []byte, ok bool) {
-	if len(data) < auditFileHeaderLen || string(data[:4]) != auditFileMagic {
-		return 0, [16]byte{}, data, false
+// header ([magic:4][version:1][keyMode:1][fingerprint:16]).
+//
+// Three outcomes:
+//   - ok=true, err=nil: valid header. Returns keyMode, fingerprint, and rest.
+//   - ok=false, err=nil: no magic prefix — legacy headerless file. Caller may
+//     fall back to engine-based inference.
+//   - ok=false, err≠nil: magic present but version unknown or data truncated.
+//     The file is a recognisable Tellstone audit segment but cannot be decoded.
+//     The caller must reject it without fallback.
+func parseHeader(data []byte, logger log.Logger, path string) (keyMode byte, fingerprint [16]byte, rest []byte, ok bool, err error) {
+	if len(data) < 4 || string(data[:4]) != auditFileMagic {
+		return 0, [16]byte{}, data, false, nil
+	}
+	// Magic present — this is (or was) a headed audit file.
+	if len(data) < auditFileHeaderLen {
+		return 0, [16]byte{}, nil, false, fmt.Errorf("audit: header truncated (%d bytes, need %d)", len(data), auditFileHeaderLen)
 	}
 	version := data[4]
 	if version != auditFileVersion {
-		if logger.Enabled(log.LevelWarn) {
-			logger.Log(log.LevelWarn, "audit: replay skipping file with unknown header version",
-				log.String("filename", path),
-				log.Uint("version", uint32(version)),
-			)
-		}
-		return 0, [16]byte{}, data, false
+		return 0, [16]byte{}, nil, false, fmt.Errorf("audit: unsupported header version %d", version)
 	}
 	keyMode = data[5]
 	copy(fingerprint[:], data[6:6+16])
-	return keyMode, fingerprint, data[auditFileHeaderLen:], true
+	return keyMode, fingerprint, data[auditFileHeaderLen:], true, nil
 }
 
 // decodePlaintext walks newline-delimited JSON, the format the encoder writes

--- a/internal/audit/replay.go
+++ b/internal/audit/replay.go
@@ -141,12 +141,36 @@ func readFile(path string, engine *crypto.Engine, logger log.Logger) []ReplayEnt
 		}
 		return nil
 	}
+	data = skipHeader(data, logger, path)
 	// The same condition newFile applies when deciding to seal records, so the
 	// reader and the writer cannot disagree about the format.
 	if engine != nil && engine.Enabled() {
 		return decodeEncrypted(data, engine, path, logger)
 	}
 	return decodePlaintext(data)
+}
+
+// skipHeader inspects the first bytes of an audit file for the self-describing
+// header ([magic:4][version:1][keyMode:1][fingerprint:16]). When the magic is
+// present the data past the header is returned; for headerless legacy files the
+// original data is returned unchanged. A file shorter than the header or with
+// an unknown version is returned as-is — decoding will either parse it as
+// records or skip the damage gracefully.
+func skipHeader(data []byte, logger log.Logger, path string) []byte {
+	if len(data) < auditFileHeaderLen || string(data[:4]) != auditFileMagic {
+		return data
+	}
+	version := data[4]
+	if version != auditFileVersion {
+		if logger.Enabled(log.LevelWarn) {
+			logger.Log(log.LevelWarn, "audit: replay skipping file with unknown header version",
+				log.String("filename", path),
+				log.Uint("version", uint32(version)),
+			)
+		}
+		return data
+	}
+	return data[auditFileHeaderLen:]
 }
 
 // decodePlaintext walks newline-delimited JSON, the format the encoder writes

--- a/internal/audit/replay_test.go
+++ b/internal/audit/replay_test.go
@@ -287,9 +287,10 @@ func TestReplayAuthLogUndecryptableRecord(t *testing.T) {
 	if err != nil {
 		t.Fatal("ReadFile:", err)
 	}
-	// Flip a byte inside the first sealed blob, past its 4-byte length prefix,
-	// so authentication fails for that record alone.
-	data[8] ^= 0xFF
+	// Flip a byte inside the first sealed blob, past the 22-byte file header
+	// and past its 4-byte length prefix, so authentication fails for that
+	// record alone.
+	data[auditFileHeaderLen+4] ^= 0xFF
 	if err = os.WriteFile(path, data, 0o600); err != nil {
 		t.Fatal("WriteFile:", err)
 	}

--- a/internal/audit/replay_test.go
+++ b/internal/audit/replay_test.go
@@ -339,25 +339,33 @@ func TestReplayAuthLogNilLogger(t *testing.T) {
 	}
 }
 
-// TestReplayAuthLogFormatMismatch documents the encryption-toggle case: files
-// written in one format and read in the other recover nothing, and must not
-// panic or hang.
+// TestReplayAuthLogFormatMismatch documents that the header is the authority:
+// a headed file is decoded according to its keyMode, not the engine the caller
+// provides. A plaintext file with a KeyModeSimple header is decoded as
+// plaintext even when an encrypted engine is supplied (the header wins). An
+// encrypted file whose header fingerprint does not match the engine is skipped
+// (fail-closed). Headerless legacy files still fall back to engine-based
+// inference.
 func TestReplayAuthLogFormatMismatch(t *testing.T) {
 	ce, err := crypto.NewEngine(bytes.Repeat([]byte{0x42}, 32), log.NewNoOpLogger())
 	if err != nil {
 		t.Fatal("NewEngine:", err)
 	}
 
+	// Plaintext file with KeyModeSimple header: decoded as plaintext even when
+	// an encrypted engine is supplied. The header is the authority.
 	plainDir := t.TempDir()
 	writeAuthEvents(t, plainDir, nil)
-	if entries := replayAuthLog(plainDir, ce, 100, log.NewNoOpLogger()); len(entries) != 0 {
-		t.Fatalf("plaintext read as encrypted = %+v, want no entries", entries)
+	if entries := replayAuthLog(plainDir, ce, 100, log.NewNoOpLogger()); len(entries) == 0 {
+		t.Fatal("plaintext file with KeyModeSimple header should be decoded as plaintext")
 	}
 
+	// Encrypted file whose header fingerprint does not match the engine:
+	// fail-closed, zero entries recovered.
 	encDir := t.TempDir()
 	writeAuthEvents(t, encDir, ce)
 	if entries := replayAuthLog(encDir, nil, 100, log.NewNoOpLogger()); len(entries) != 0 {
-		t.Fatalf("encrypted read as plaintext = %+v, want no entries", entries)
+		t.Fatalf("encrypted file with no engine should yield no entries, got %+v", entries)
 	}
 }
 

--- a/internal/audit/replay_test.go
+++ b/internal/audit/replay_test.go
@@ -360,12 +360,23 @@ func TestReplayAuthLogFormatMismatch(t *testing.T) {
 		t.Fatal("plaintext file with KeyModeSimple header should be decoded as plaintext")
 	}
 
-	// Encrypted file whose header fingerprint does not match the engine:
-	// fail-closed, zero entries recovered.
+	// Encrypted file with no engine: fail-closed, zero entries recovered.
 	encDir := t.TempDir()
 	writeAuthEvents(t, encDir, ce)
 	if entries := replayAuthLog(encDir, nil, 100, log.NewNoOpLogger()); len(entries) != 0 {
 		t.Fatalf("encrypted file with no engine should yield no entries, got %+v", entries)
+	}
+
+	// Encrypted file replayed through a different key: fingerprint mismatch,
+	// fail-closed, zero entries recovered. This exercises the
+	// KeyFingerprint() != fingerprint branch.
+	wrongKey := bytes.Repeat([]byte{0x99}, 32)
+	wrongCE, err := crypto.NewEngine(wrongKey, log.NewNoOpLogger())
+	if err != nil {
+		t.Fatal("NewEngine:", err)
+	}
+	if entries := replayAuthLog(encDir, wrongCE, 100, log.NewNoOpLogger()); len(entries) != 0 {
+		t.Fatalf("encrypted file with wrong key fingerprint should yield no entries, got %+v", entries)
 	}
 }
 

--- a/internal/crypto/cipher.go
+++ b/internal/crypto/cipher.go
@@ -22,9 +22,10 @@ import (
 var ErrDecryptionFailed = errors.New("cipher: authentication failed during decryption")
 
 type Engine struct {
-	aead    cipher.AEAD
-	enabled bool
-	logger  log.Logger
+	aead           cipher.AEAD
+	keyFingerprint [16]byte
+	enabled        bool
+	logger         log.Logger
 }
 
 // NewEngine initializes the cryptographic state. If key is nil or empty,
@@ -63,10 +64,18 @@ func NewEngine(key []byte, logger log.Logger) (*Engine, error) {
 		logger.Log(log.LevelInfo, "crypto engine successfully initialized with active ChaCha20-Poly1305")
 	}
 	return &Engine{
-		aead:    aead,
-		enabled: true,
-		logger:  logger,
+		aead:           aead,
+		keyFingerprint: FingerprintBytes(key),
+		enabled:        true,
+		logger:         logger,
 	}, nil
+}
+
+// KeyFingerprint returns the truncated SHA-256 of the engine's key. The
+// 16-byte value is used in audit file headers and envelope files so a reader
+// can identify the sealing key without trying every candidate.
+func (e *Engine) KeyFingerprint() [16]byte {
+	return e.keyFingerprint
 }
 
 // Enabled returns the operational state of the cipher engine.

--- a/internal/crypto/envelope.go
+++ b/internal/crypto/envelope.go
@@ -164,7 +164,7 @@ func (e *Envelope) Store(dir string, fileName string) error {
 	}
 	buf := make([]byte, 1+envFingerprintLen+len(wrapped))
 	buf[0] = envVersion
-	fp := fingerprintBytes(e.kek)
+	fp := FingerprintBytes(e.kek)
 	copy(buf[1:1+envFingerprintLen], fp[:])
 	copy(buf[1+envFingerprintLen:], wrapped)
 	name := filepath.Join(dir, fileName)
@@ -237,7 +237,7 @@ func (e *Envelope) Load(dir, fileName string) ([]byte, error) {
 	if len(raw) < headerLen || raw[0] != envVersion {
 		return nil, fmt.Errorf("envelope: unsupported envelope format %s", fileName)
 	}
-	fp := fingerprintBytes(e.kek)
+	fp := FingerprintBytes(e.kek)
 	if !bytes.Equal(raw[1:headerLen], fp[:]) {
 		return nil, fmt.Errorf("envelope: KEK fingerprint mismatch for %s; data was written with a different key", fileName)
 	}
@@ -258,9 +258,10 @@ func rnd() ([]byte, error) {
 	return b, nil
 }
 
-// fingerprintBytes is the truncated SHA-256 used as the KEK's identifier in the
-// envelope header.
-func fingerprintBytes(key []byte) [16]byte {
+// FingerprintBytes is the truncated SHA-256 used as a key's identifier in
+// envelope and audit file headers. The 16-byte prefix lets a reader pick the
+// right key without trying every candidate.
+func FingerprintBytes(key []byte) [16]byte {
 	var fp [16]byte
 	sum := sha256.Sum256(key)
 	copy(fp[:], sum[:16])

--- a/internal/crypto/envelope_test.go
+++ b/internal/crypto/envelope_test.go
@@ -159,7 +159,7 @@ func TestEnvelopeFileLayout(t *testing.T) {
 	if raw[0] != envVersion {
 		t.Fatalf("version byte = %d, want %d", raw[0], envVersion)
 	}
-	fp := fingerprintBytes(kek)
+	fp := FingerprintBytes(kek)
 	if !bytes.Equal(raw[1:1+envFingerprintLen], fp[:]) {
 		t.Fatal("stored fingerprint does not match the KEK")
 	}


### PR DESCRIPTION
## Description

Add a 22-byte header to audit log file to identifiy how it was sealed. 

**Component:** Crypto / Audit

**Type of Change:**
- [ ] Bug fix
- [x] New feature
- [ ] Performance optimization
- [x] Refactoring
- [ ] Build / CI / Documentation

---

## Related Issue

Closes #40

---

## Technical Deep Dive & Context

**Header layout** (22 bytes, matching the envelope format):

```
[magic:4][version:1][keyMode:1][fingerprint:16]
```

- `magic` — `TSDA` so any random file is rejected before length-prefixed records are misread
- `version` — format version (currently 1)
- `keyMode` — `KeyModeSimple` (0) = plaintext, `KeyModeEnvelope` (1) = sealed records
- `fingerprint` — `SHA-256(key)[:16]` of the sealing key, reusing `crypto.FingerprintBytes`

**Reader behavior (`readFile`):**
- Header present → `keyMode` is the authority. `KeyModeEnvelope` validates the engine's fingerprint before attempting decryption (fail-closed on mismatch). `KeyModeSimple` reads as plaintext regardless of the engine.
- Header absent → legacy file, format inferred from the engine parameter (nil = plaintext, non-nil = encrypted). A `LevelDebug` log flags each legacy file.

**Crypto changes:** `Engine` stores only a 16-byte `keyFingerprint` (not the raw key) computed at construction time via the exported `crypto.FingerprintBytes`. The `KeyFingerprint()` method exposes it for audit file header validation.

**No migration required.** Existing headerless files are read identically to before the header feature.

---

## How Has This Been Tested?

```text
ok  github.com/Saxy/Tellstone/internal/audit   1.132s  (55 tests, -race)
ok  github.com/Saxy/Tellstone/internal/crypto   1.116s  (22 tests, -race)
ok  github.com/Saxy/Tellstone/server            1.026s  (all server tests, -race)
```

New tests added:
- `TestAuditFileHeaderLayout` — raw bytes match `[TSDA][1][mode][fp]`
- `TestAuditFileHeaderMagicRejection` — non-magic files treated as legacy
- `TestAuditFileHeaderKeyMode` — plaintext=0, sealed=1
- `TestAuditFileHeaderOnRotation` — rotated file also starts with the header
- `TestAuditFileHeaderFingerprintMatchesKey` — fingerprint matches sealing key
- `TestLegacyHeaderlessFileStillReplays` — headerless plaintext files decode correctly

Updated existing tests:
- `TestReplayAuthLogFormatMismatch` — reflects new header-is-authority semantics
- `TestReplayAuthLogUndecryptableRecord` — byte flip offset adjusted past header
- All file-reading test helpers strip the header before parsing

---

## Checklist

- [x] My code follows the existing code style of this project
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally (`go test ./...` and `go test -race ./...`)
- [x] I have updated the documentation (comments match the new behavior)
- [x] My changes generate no new `go vet` warnings
- [x] Any breaking changes are documented and communicated (no breaking changes; legacy files handled transparently)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audit files now include metadata describing their format, encryption mode, and key fingerprint.
  * Audit replay automatically detects file formats and validates encryption keys.
  * Legacy headerless audit files remain supported.

* **Bug Fixes**
  * Prevented incorrect decoding of encrypted or mismatched audit files.
  * Improved handling of unsupported formats, missing keys, and corrupted files.
  * Rotated audit files now preserve the correct metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->