### PR TITLE
feat(persistence): rework persistence to enable rotation and snapshot…

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ Every option is available as a flag and an environment variable.
 | `--trace-ratio`       | `TSD_TRACE_RATIO`       | `0.0`            | OpenTelemetry sample ratio (`0` disables)                |
 | `--enable-persistence`| `TSD_ENABLE_PERSISTENCE`| `false`          | Enable write-ahead log persistence for crash recovery    |
 | `--persistence-dir`   | `TSD_PERSISTENCE_DIR`   | _(platform)_     | Directory for WAL data files                             |
+| `--snapshot-interval` | `TSD_SNAPSHOT_INTERVAL` | `0` (disabled)   | Time between periodic snapshots (e.g. `5m`); requires `--enable-persistence` |
+| `--snapshot-bytes`    | `TSD_SNAPSHOT_BYTES`    | `64MiB`          | WAL size threshold that triggers a snapshot; requires `--enable-persistence` |
 | `--tls-cert`          | `TSD_TLS_CERT`           | _(none)_         | TLS certificate path; watched for automatic rotation     |
 | `--tls-key`           | `TSD_TLS_KEY`            | _(none)_         | TLS private key path; watched for automatic rotation     |
 | `--tls-ca`            | `TSD_TLS_CA`             | _(none)_         | Client CA path for mTLS; watched for automatic rotation  |

--- a/cmd/tellstone/main.go
+++ b/cmd/tellstone/main.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/Saxy/Tellstone/config"
 	"github.com/Saxy/Tellstone/internal/app/tellstone"
+	"github.com/Saxy/Tellstone/internal/persistence"
 	"github.com/Saxy/Tellstone/internal/version"
 	"github.com/Saxy/Tellstone/logger"
 	"github.com/Saxy/Tellstone/server"
@@ -77,6 +78,13 @@ func initRuntimeSettings(l logger.Logger) {
 }
 
 func main() {
+	// Snapshot child process — spawned by the parent via ForkExec to write
+	// a snapshot file. Runs in isolation and exits immediately.
+	if persistence.IsSnapshotChild() {
+		persistence.SnapshotChildMain()
+		return
+	}
+
 	// Subcommand dispatch — "audit" and "kek" are not server flags, so detect
 	// them before config/flag parsing so "-h" routes to the CLI tool, not the server.
 	if len(os.Args) > 1 && os.Args[1] == "audit" {

--- a/config/config.go
+++ b/config/config.go
@@ -388,7 +388,7 @@ func LoadConfig(args []string) *Config {
 	fs.Var(
 		&snapshotBytes,
 		"snapshot-bytes",
-		"WAL size threshold that triggers a snapshot (e.g. 64MiB); 0 disables size-based triggers (default: 64MiB)",
+		"WAL size threshold that triggers a snapshot (e.g. 64MiB); 0 disables size-based snapshots (default: 0, disabled)",
 	)
 	// Custom usage output to guide operators.
 	fs.Usage = func() {
@@ -408,9 +408,6 @@ func LoadConfig(args []string) *Config {
 		cfg.numShards = runtime.NumCPU()
 	}
 	cfg.snapshotBytes = uint64(snapshotBytes)
-	if cfg.snapshotBytes == 0 {
-		cfg.snapshotBytes = 64 * 1024 * 1024 // 64 MiB default
-	}
 	// Validate TLS configuration: cert and key must be provided together.
 	if (cfg.tlsCert == "") != (cfg.tlsKey == "") {
 		panic("tellstone: --tls-cert and --tls-key must both be provided")
@@ -436,6 +433,11 @@ func LoadConfig(args []string) *Config {
 	// Envelope encryption is a mode of --enable-encryption, not a substitute for it.
 	if cfg.enableEnvelope && !cfg.enableEncryption {
 		panic("tellstone: --enable-envelope requires --enable-encryption")
+	}
+	// Snapshot options require persistence to be enabled; without it the WAL
+	// and snapshot files are never created so the flags are meaningless.
+	if !cfg.enablePersistence && (cfg.snapshotInterval > 0 || cfg.snapshotBytes > 0) {
+		panic("tellstone: --snapshot-interval and --snapshot-bytes require --enable-persistence")
 	}
 	return cfg
 }

--- a/config/config.go
+++ b/config/config.go
@@ -53,6 +53,8 @@ type Config struct {
 	oauthProvider     string
 	oauthIssuer       string
 	oauthClientID     string
+	snapshotInterval  time.Duration
+	snapshotBytes     uint64
 }
 
 func getEnv[T any](key string, fallback T) T {
@@ -371,7 +373,22 @@ func LoadConfig(args []string) *Config {
 		&cfg.oauthClientID,
 		"oauth-client-id",
 		getEnv("TSD_OAUTH_CLIENT_ID", ""),
-		"OAuth2 client ID used as the expected token audience (default: none)",
+		"OAuth2 client ID; expected token audience (default: none)",
+	)
+	fs.DurationVar(
+		&cfg.snapshotInterval,
+		"snapshot-interval",
+		getEnv("TSD_SNAPSHOT_INTERVAL", time.Duration(0)),
+		"Interval between periodic snapshots (e.g. 5m); 0 disables periodic snapshots (default: 0)",
+	)
+	var snapshotBytes ByteSize
+	if env := os.Getenv("TSD_SNAPSHOT_BYTES"); env != "" {
+		_ = snapshotBytes.Set(env)
+	}
+	fs.Var(
+		&snapshotBytes,
+		"snapshot-bytes",
+		"WAL size threshold that triggers a snapshot (e.g. 64MiB); 0 disables size-based triggers (default: 64MiB)",
 	)
 	// Custom usage output to guide operators.
 	fs.Usage = func() {
@@ -389,6 +406,10 @@ func LoadConfig(args []string) *Config {
 	cfg.maxMemBytes = uint64(maxMemBytes)
 	if cfg.numShards < 1 {
 		cfg.numShards = runtime.NumCPU()
+	}
+	cfg.snapshotBytes = uint64(snapshotBytes)
+	if cfg.snapshotBytes == 0 {
+		cfg.snapshotBytes = 64 * 1024 * 1024 // 64 MiB default
 	}
 	// Validate TLS configuration: cert and key must be provided together.
 	if (cfg.tlsCert == "") != (cfg.tlsKey == "") {
@@ -448,9 +469,11 @@ func (cfg *Config) GetRBACConfig() string             { return cfg.rbacConfig }
 func (cfg *Config) MTLSEnabled() bool {
 	return cfg.tlsCert != "" && cfg.tlsKey != "" && cfg.tlsCA != ""
 }
-func (cfg *Config) AuditEnabled() bool       { return cfg.enableAuditLog }
-func (cfg *Config) AuditLogPath() string     { return cfg.auditLogPath }
-func (cfg *Config) AuditLogEvents() []string { return strings.Split(cfg.auditLogEvents, ",") }
-func (cfg *Config) GetOAuthProvider() string { return cfg.oauthProvider }
-func (cfg *Config) GetOAuthIssuer() string   { return cfg.oauthIssuer }
-func (cfg *Config) GetOAuthClientID() string { return cfg.oauthClientID }
+func (cfg *Config) AuditEnabled() bool                 { return cfg.enableAuditLog }
+func (cfg *Config) AuditLogPath() string               { return cfg.auditLogPath }
+func (cfg *Config) AuditLogEvents() []string           { return strings.Split(cfg.auditLogEvents, ",") }
+func (cfg *Config) GetOAuthProvider() string           { return cfg.oauthProvider }
+func (cfg *Config) GetOAuthIssuer() string             { return cfg.oauthIssuer }
+func (cfg *Config) GetOAuthClientID() string           { return cfg.oauthClientID }
+func (cfg *Config) GetSnapshotInterval() time.Duration { return cfg.snapshotInterval }
+func (cfg *Config) GetSnapshotBytes() uint64           { return cfg.snapshotBytes }

--- a/internal/persistence/persistence.go
+++ b/internal/persistence/persistence.go
@@ -244,11 +244,38 @@ func (s *Storage) OpenShard(shardID uint32) error {
 	return nil
 }
 
-// LoadShard replays all records from the shard's WAL file into the given engine,
+// LoadShard restores a shard's in-memory engine. If a snapshot file exists,
+// it is loaded first (fast binary read). Then the WAL is replayed on top to
+// capture any writes that happened after the snapshot. This two-phase approach
+// keeps warm-up fast: the snapshot is compact and the WAL is small.
+func (s *Storage) LoadShard(shardID uint32, engine *storage.Engine) error {
+	if !s.enabled {
+		return nil
+	}
+
+	// Phase 1: load snapshot if present.
+	if snapshotExists(s.dir, shardID) {
+		loadedKeys, err := snapshotRead(s.dir, shardID, engine, s.logger)
+		if err != nil {
+			if s.logger.Enabled(log.LevelError) {
+				s.logger.Log(log.LevelError, "persistence: snapshot load failed, falling back to full WAL recovery",
+					log.Uint("shard", shardID), log.String("error", err.Error()))
+			}
+		} else if s.logger.Enabled(log.LevelInfo) {
+			s.logger.Log(log.LevelInfo, "persistence: snapshot restored",
+				log.Uint("shard", shardID), log.Uint64("keys", loadedKeys))
+		}
+	}
+
+	// Phase 2: replay the WAL for writes since the last snapshot.
+	return s.replayWAL(shardID, engine)
+}
+
+// replayWAL replays all records from the shard's WAL file into the given engine,
 // skipping expired keys and applying tombstones as deletions. Truncated records
 // from a crash mid-write are detected, and the WAL is truncated to the last valid
 // offset so future loads resume from a clean end.
-func (s *Storage) LoadShard(shardID uint32, engine *storage.Engine) error {
+func (s *Storage) replayWAL(shardID uint32, engine *storage.Engine) error {
 	h := s.getShard(shardID)
 	if h == nil {
 		return fmt.Errorf("shard %d not opened", shardID)
@@ -279,7 +306,7 @@ func (s *Storage) LoadShard(shardID uint32, engine *storage.Engine) error {
 		var n int
 		n, err = io.ReadFull(f, header)
 		if err != nil {
-			if err == io.EOF || err == io.ErrUnexpectedEOF {
+			if err == io.EOF || errors.Is(io.ErrUnexpectedEOF, err) {
 				break
 			}
 			return fmt.Errorf("persistence: incomplete header read (%d bytes): %w", n, err)
@@ -308,7 +335,7 @@ func (s *Storage) LoadShard(shardID uint32, engine *storage.Engine) error {
 		remaining -= int64(keyLen) + int64(valLen)
 		validOffset = fileSize - remaining
 		recordsRead++
-		ttlVal := int64(ttlNano)
+		ttlVal := ttlNano
 		if ttlVal == tombstoneTTL {
 			if s.logger.Enabled(log.LevelDebug) {
 				s.logger.Log(log.LevelDebug, "persistence: replaying delete",
@@ -355,6 +382,56 @@ func (s *Storage) LoadShard(shardID uint32, engine *storage.Engine) error {
 		s.logger.Log(log.LevelInfo, "persistence: shard loaded",
 			log.Uint("shard", shardID), log.Int("records_read", recordsRead),
 			log.Int("records_skipped", recordsSkipped), log.Int("records_loaded", recordsRead-recordsSkipped))
+	}
+	return nil
+}
+
+// WALSize returns the current WAL file size in bytes for the given shard.
+// Returns 0 if the shard is not opened or on error.
+func (s *Storage) WALSize(shardID uint32) int64 {
+	h := s.getShard(shardID)
+	if h == nil {
+		return 0
+	}
+	h.mu.Lock()
+	fi, err := h.file.Stat()
+	h.mu.Unlock()
+	if err != nil {
+		return 0
+	}
+	return fi.Size()
+}
+
+// Snapshot triggers a fork-based snapshot for the given shard. The parent
+// serializes the engine state to a pipe, and a child process writes the
+// snapshot file. After a successful snapshot, the WAL is truncated.
+func (s *Storage) Snapshot(shardID uint32, engine *storage.Engine) error {
+	if !s.enabled {
+		return nil
+	}
+	if err := snapshotForkDump(s.dir, shardID, engine, s.logger); err != nil {
+		return err
+	}
+	return s.TruncateWAL(shardID)
+}
+
+// TruncateWAL resets the WAL file to empty. Called after a successful snapshot.
+func (s *Storage) TruncateWAL(shardID uint32) error {
+	h := s.getShard(shardID)
+	if h == nil {
+		return fmt.Errorf("persistence: shard %d not opened", shardID)
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if err := h.file.Truncate(0); err != nil {
+		return fmt.Errorf("persistence: truncate WAL shard %d: %w", shardID, err)
+	}
+	if _, err := h.file.Seek(0, 0); err != nil {
+		return fmt.Errorf("persistence: seek WAL shard %d: %w", shardID, err)
+	}
+	if s.logger.Enabled(log.LevelInfo) {
+		s.logger.Log(log.LevelInfo, "persistence: WAL truncated",
+			log.Uint("shard", shardID))
 	}
 	return nil
 }

--- a/internal/persistence/persistence.go
+++ b/internal/persistence/persistence.go
@@ -253,15 +253,19 @@ func (s *Storage) LoadShard(shardID uint32, engine *storage.Engine) error {
 		return nil
 	}
 
-	// Phase 1: load snapshot if present.
+	// Phase 1: load snapshot if present. A corrupt snapshot means data
+	// preceding it is unrecoverable — abort rather than continuing with
+	// a partial state and replaying the WAL on top of an empty engine.
 	if snapshotExists(s.dir, shardID) {
 		loadedKeys, err := snapshotRead(s.dir, shardID, engine, s.logger)
 		if err != nil {
 			if s.logger.Enabled(log.LevelError) {
-				s.logger.Log(log.LevelError, "persistence: snapshot load failed, falling back to full WAL recovery",
+				s.logger.Log(log.LevelError, "persistence: snapshot load failed, data preceding snapshot is unrecoverable",
 					log.Uint("shard", shardID), log.String("error", err.Error()))
 			}
-		} else if s.logger.Enabled(log.LevelInfo) {
+			return fmt.Errorf("persistence: load shard %d snapshot: %w", shardID, err)
+		}
+		if s.logger.Enabled(log.LevelInfo) {
 			s.logger.Log(log.LevelInfo, "persistence: snapshot restored",
 				log.Uint("shard", shardID), log.Uint64("keys", loadedKeys))
 		}
@@ -306,7 +310,7 @@ func (s *Storage) replayWAL(shardID uint32, engine *storage.Engine) error {
 		var n int
 		n, err = io.ReadFull(f, header)
 		if err != nil {
-			if err == io.EOF || errors.Is(io.ErrUnexpectedEOF, err) {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 				break
 			}
 			return fmt.Errorf("persistence: incomplete header read (%d bytes): %w", n, err)
@@ -404,15 +408,20 @@ func (s *Storage) WALSize(shardID uint32) int64 {
 
 // Snapshot triggers a fork-based snapshot for the given shard. The parent
 // serializes the engine state to a pipe, and a child process writes the
-// snapshot file. After a successful snapshot, the WAL is truncated.
+// snapshot file. After a successful snapshot, only the WAL records that existed
+// before serialization are truncated; records appended during the snapshot are
+// preserved so they survive a crash.
 func (s *Storage) Snapshot(shardID uint32, engine *storage.Engine) error {
 	if !s.enabled {
 		return nil
 	}
+	// Capture the WAL boundary before serialization so that records appended
+	// during the snapshot are not lost by truncation.
+	walSize := s.WALSize(shardID)
 	if err := snapshotForkDump(s.dir, shardID, engine, s.logger); err != nil {
 		return err
 	}
-	return s.TruncateWAL(shardID)
+	return s.TruncateWALTo(shardID, walSize)
 }
 
 // TruncateWAL resets the WAL file to empty. Called after a successful snapshot.
@@ -426,12 +435,45 @@ func (s *Storage) TruncateWAL(shardID uint32) error {
 	if err := h.file.Truncate(0); err != nil {
 		return fmt.Errorf("persistence: truncate WAL shard %d: %w", shardID, err)
 	}
+	// Sync after truncation so the zero-length is durable; without this a
+	// crash could replay stale records that were logically discarded.
+	if err := h.file.Sync(); err != nil {
+		return fmt.Errorf("persistence: sync WAL shard %d after truncate: %w", shardID, err)
+	}
 	if _, err := h.file.Seek(0, 0); err != nil {
 		return fmt.Errorf("persistence: seek WAL shard %d: %w", shardID, err)
 	}
 	if s.logger.Enabled(log.LevelInfo) {
 		s.logger.Log(log.LevelInfo, "persistence: WAL truncated",
 			log.Uint("shard", shardID))
+	}
+	return nil
+}
+
+// TruncateWALTo truncates the WAL file to the given offset, discarding any
+// bytes beyond that point. Called after a successful snapshot to remove only
+// the records that were serialized, preserving later writes.
+func (s *Storage) TruncateWALTo(shardID uint32, offset int64) error {
+	h := s.getShard(shardID)
+	if h == nil {
+		return fmt.Errorf("persistence: shard %d not opened", shardID)
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if err := h.file.Truncate(offset); err != nil {
+		return fmt.Errorf("persistence: truncate WAL shard %d to %d: %w", shardID, offset, err)
+	}
+	// Sync after truncation so the truncated length is durable; without this
+	// a crash could replay stale records that were logically discarded.
+	if err := h.file.Sync(); err != nil {
+		return fmt.Errorf("persistence: sync WAL shard %d after truncate: %w", shardID, err)
+	}
+	if _, err := h.file.Seek(0, io.SeekEnd); err != nil {
+		return fmt.Errorf("persistence: seek WAL shard %d: %w", shardID, err)
+	}
+	if s.logger.Enabled(log.LevelInfo) {
+		s.logger.Log(log.LevelInfo, "persistence: WAL truncated",
+			log.Uint("shard", shardID), log.Int64("to", offset))
 	}
 	return nil
 }

--- a/internal/persistence/persistence.go
+++ b/internal/persistence/persistence.go
@@ -408,58 +408,49 @@ func (s *Storage) WALSize(shardID uint32) int64 {
 
 // Snapshot triggers a fork-based snapshot for the given shard. The parent
 // serializes the engine state to a pipe, and a child process writes the
-// snapshot file. After a successful snapshot, only the WAL records that existed
-// before serialization are truncated; records appended during the snapshot are
-// preserved so they survive a crash.
+// snapshot file. After a successful snapshot, only the WAL records that were
+// part of the serialized engine state are truncated; records appended during
+// the snapshot are preserved so they survive a crash.
+//
+// The WAL boundary is captured after serialization and under the shard's WAL
+// mutex so that no concurrent Write can slip between the boundary capture and
+// the truncation. If the boundary cannot be obtained, truncation is skipped
+// rather than risking data loss.
 func (s *Storage) Snapshot(shardID uint32, engine *storage.Engine) error {
 	if !s.enabled {
 		return nil
 	}
-	// Capture the WAL boundary before serialization so that records appended
-	// during the snapshot are not lost by truncation.
-	walSize := s.WALSize(shardID)
+	// Snapshot the engine state first. ForEach freezes the engine under a
+	// read lock so no new mutations complete during serialization.
 	if err := snapshotForkDump(s.dir, shardID, engine, s.logger); err != nil {
 		return err
 	}
-	return s.TruncateWALTo(shardID, walSize)
-}
-
-// TruncateWAL resets the WAL file to empty. Called after a successful snapshot.
-func (s *Storage) TruncateWAL(shardID uint32) error {
 	h := s.getShard(shardID)
 	if h == nil {
 		return fmt.Errorf("persistence: shard %d not opened", shardID)
 	}
+	// Capture the WAL boundary after serialization and truncate atomically
+	// under the shard mutex so no Write can interleave between the stat and
+	// the truncation.
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	if err := h.file.Truncate(0); err != nil {
-		return fmt.Errorf("persistence: truncate WAL shard %d: %w", shardID, err)
+	fi, err := h.file.Stat()
+	if err != nil {
+		// Cannot determine the truncation boundary — skip truncation to
+		// avoid losing records. The extra WAL data is harmless: it will be
+		// replayed on recovery and the duplicate SETs are idempotent.
+		if s.logger.Enabled(log.LevelWarn) {
+			s.logger.Log(log.LevelWarn, "persistence: cannot determine WAL boundary, skipping truncation",
+				log.Uint("shard", shardID), log.String("error", err.Error()))
+		}
+		return nil
 	}
-	// Sync after truncation so the zero-length is durable; without this a
-	// crash could replay stale records that were logically discarded.
-	if err := h.file.Sync(); err != nil {
-		return fmt.Errorf("persistence: sync WAL shard %d after truncate: %w", shardID, err)
-	}
-	if _, err := h.file.Seek(0, 0); err != nil {
-		return fmt.Errorf("persistence: seek WAL shard %d: %w", shardID, err)
-	}
-	if s.logger.Enabled(log.LevelInfo) {
-		s.logger.Log(log.LevelInfo, "persistence: WAL truncated",
-			log.Uint("shard", shardID))
-	}
-	return nil
+	return s.truncateWALLocked(h, shardID, fi.Size())
 }
 
-// TruncateWALTo truncates the WAL file to the given offset, discarding any
-// bytes beyond that point. Called after a successful snapshot to remove only
-// the records that were serialized, preserving later writes.
-func (s *Storage) TruncateWALTo(shardID uint32, offset int64) error {
-	h := s.getShard(shardID)
-	if h == nil {
-		return fmt.Errorf("persistence: shard %d not opened", shardID)
-	}
-	h.mu.Lock()
-	defer h.mu.Unlock()
+// truncateWALLocked truncates, syncs, and seeks the WAL file to the given
+// offset. The caller must hold h.mu. Used by Snapshot and TruncateWALTo.
+func (s *Storage) truncateWALLocked(h *shardHandle, shardID uint32, offset int64) error {
 	if err := h.file.Truncate(offset); err != nil {
 		return fmt.Errorf("persistence: truncate WAL shard %d to %d: %w", shardID, offset, err)
 	}
@@ -476,6 +467,19 @@ func (s *Storage) TruncateWALTo(shardID uint32, offset int64) error {
 			log.Uint("shard", shardID), log.Int64("to", offset))
 	}
 	return nil
+}
+
+// TruncateWALTo truncates the WAL file to the given offset, discarding any
+// bytes beyond that point. Called after a successful snapshot to remove only
+// the records that were serialized, preserving later writes.
+func (s *Storage) TruncateWALTo(shardID uint32, offset int64) error {
+	h := s.getShard(shardID)
+	if h == nil {
+		return fmt.Errorf("persistence: shard %d not opened", shardID)
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return s.truncateWALLocked(h, shardID, offset)
 }
 
 // CloseShard closes the WAL file for the given shard.

--- a/internal/persistence/snapshot.go
+++ b/internal/persistence/snapshot.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -40,6 +41,44 @@ const (
 	snapVersion = 1
 	snapHeader  = 32 // magic(4) + version(4) + keyCount(8) + createdAt(8) + checksum(8)
 )
+
+// snapshotCleanup closes f and removes tmpPath as best-effort cleanup
+// during snapshot write error paths. Secondary errors are logged but
+// never mask the primary error that triggered the cleanup.
+func snapshotCleanup(f *os.File, tmpPath string, primaryErr error, logger log.Logger) error {
+	if cerr := f.Close(); cerr != nil {
+		logCleanupWarn("snapshot: close tmp file", cerr, logger)
+	}
+	if rerr := os.Remove(tmpPath); rerr != nil {
+		logCleanupWarn("snapshot: remove tmp file", rerr, logger)
+	}
+	return primaryErr
+}
+
+// logCleanupWarn logs a best-effort cleanup error. If logger is nil (child
+// process), falls back to stderr so the error is never silently swallowed.
+func logCleanupWarn(msg string, err error, logger log.Logger) {
+	if logger != nil {
+		if logger.Enabled(log.LevelWarn) {
+			logger.Log(log.LevelWarn, msg, log.String("error", err.Error()))
+		}
+		return
+	}
+}
+
+// syncDir opens dir, fsyncs it, and closes it so that a preceding os.Rename
+// is durable on filesystems that require explicit directory fsync (ext4, etc).
+func syncDir(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	syncErr := d.Sync()
+	if closeErr := d.Close(); closeErr != nil && syncErr == nil {
+		return closeErr
+	}
+	return syncErr
+}
 
 // IsSnapshotChild returns true when the process was spawned as a snapshot child.
 // Check this early in main() and redirect to snapshotChildMain().
@@ -57,13 +96,16 @@ func IsSnapshotChild() bool {
 // The dir and shardID are passed via environment variables set by the parent.
 func SnapshotChildMain() {
 	dir := os.Getenv("TSD_SNAP_DIR")
-	shardID := 0
-	n, err := fmt.Sscanf(os.Getenv("TSD_SNAP_SHARD"), "%d", &shardID)
-	if err != nil || n != 1 || shardID < 0 || dir == "" {
+	raw := os.Getenv("TSD_SNAP_SHARD")
+	if dir == "" || raw == "" {
+		os.Exit(1)
+	}
+	id, err := strconv.ParseUint(raw, 10, 32)
+	if err != nil {
 		os.Exit(1)
 	}
 
-	err = snapshotChildWrite(dir, uint32(shardID), os.Stdin)
+	err = snapshotChildWrite(dir, uint32(id), os.Stdin)
 	if err != nil {
 		os.Exit(1)
 	}
@@ -94,14 +136,14 @@ func snapshotWrite(dir string, shardID uint32, engine *storage.Engine, logger lo
 	binary.LittleEndian.PutUint64(hdr[16:24], uint64(createdAt))
 	binary.LittleEndian.PutUint64(hdr[24:32], 0) // patched later
 
-	if _, err := f.Write(hdr[:]); err != nil {
-		f.Close()
-		os.Remove(tmpPath)
-		return 0, fmt.Errorf("snapshot: write header: %w", err)
+	if _, err = f.Write(hdr[:]); err != nil {
+		return 0, snapshotCleanup(f, tmpPath, fmt.Errorf("snapshot: write header: %w", err), logger)
 	}
 
 	h := xxhash.New()
-	h.Write(hdr[:]) // hash placeholder header (KeyCount=0, checksum=0)
+	if _, err = h.Write(hdr[:]); err != nil {
+		return 0, snapshotCleanup(f, tmpPath, fmt.Errorf("snapshot: hash header: %w", err), logger)
+	}
 
 	var keyCount uint64
 	var writeErr error
@@ -121,19 +163,28 @@ func snapshotWrite(dir string, shardID uint32, engine *storage.Engine, logger lo
 		binary.LittleEndian.PutUint32(entry[4:8], valLen)
 		binary.LittleEndian.PutUint64(entry[8:16], uint64(ttlNano))
 
-		h.Write(entry[:])
-		h.WriteString(key)
-		h.Write(value)
+		if _, err = h.Write(entry[:]); err != nil {
+			writeErr = err
+			return
+		}
+		if _, err = h.WriteString(key); err != nil {
+			writeErr = err
+			return
+		}
+		if _, err = h.Write(value); err != nil {
+			writeErr = err
+			return
+		}
 
-		if _, err := f.Write(entry[:]); err != nil {
+		if _, err = f.Write(entry[:]); err != nil {
 			writeErr = err
 			return
 		}
-		if _, err := f.WriteString(key); err != nil {
+		if _, err = f.WriteString(key); err != nil {
 			writeErr = err
 			return
 		}
-		if _, err := f.Write(value); err != nil {
+		if _, err = f.Write(value); err != nil {
 			writeErr = err
 			return
 		}
@@ -141,15 +192,11 @@ func snapshotWrite(dir string, shardID uint32, engine *storage.Engine, logger lo
 	})
 
 	if writeErr != nil {
-		f.Close()
-		os.Remove(tmpPath)
-		return 0, fmt.Errorf("snapshot: write entry: %w", writeErr)
+		return 0, snapshotCleanup(f, tmpPath, fmt.Errorf("snapshot: write entry: %w", writeErr), logger)
 	}
 
 	if err = f.Sync(); err != nil {
-		f.Close()
-		os.Remove(tmpPath)
-		return 0, fmt.Errorf("snapshot: sync: %w", err)
+		return 0, snapshotCleanup(f, tmpPath, fmt.Errorf("snapshot: sync: %w", err), logger)
 	}
 
 	// Patch header with final checksum and key count.
@@ -158,26 +205,33 @@ func snapshotWrite(dir string, shardID uint32, engine *storage.Engine, logger lo
 	binary.LittleEndian.PutUint64(hdr[24:32], checksum)
 
 	if _, err = f.Seek(0, 0); err != nil {
-		f.Close()
-		os.Remove(tmpPath)
-		return 0, fmt.Errorf("snapshot: seek header: %w", err)
+		return 0, snapshotCleanup(f, tmpPath, fmt.Errorf("snapshot: seek header: %w", err), logger)
 	}
 	if _, err = f.Write(hdr[:]); err != nil {
-		f.Close()
-		os.Remove(tmpPath)
-		return 0, fmt.Errorf("snapshot: patch header: %w", err)
+		return 0, snapshotCleanup(f, tmpPath, fmt.Errorf("snapshot: patch header: %w", err), logger)
 	}
 
 	if err = f.Sync(); err != nil {
-		f.Close()
-		os.Remove(tmpPath)
-		return 0, fmt.Errorf("snapshot: sync header: %w", err)
+		return 0, snapshotCleanup(f, tmpPath, fmt.Errorf("snapshot: sync header: %w", err), logger)
 	}
-	f.Close()
+	if err = f.Close(); err != nil {
+		if rerr := os.Remove(tmpPath); rerr != nil {
+			logCleanupWarn("snapshot: remove tmp after close error", rerr, logger)
+		}
+		return 0, fmt.Errorf("snapshot: close: %w", err)
+	}
 
-	if err := os.Rename(tmpPath, finalPath); err != nil {
-		os.Remove(tmpPath)
+	if err = os.Rename(tmpPath, finalPath); err != nil {
+		if rerr := os.Remove(tmpPath); rerr != nil {
+			logCleanupWarn("snapshot: remove tmp after rename error", rerr, logger)
+		}
 		return 0, fmt.Errorf("snapshot: rename: %w", err)
+	}
+	if err = syncDir(dir); err != nil {
+		if rerr := os.Remove(finalPath); rerr != nil {
+			logCleanupWarn("snapshot: remove final after sync dir error", rerr, logger)
+		}
+		return 0, fmt.Errorf("snapshot: sync dir: %w", err)
 	}
 
 	if logger != nil && logger.Enabled(log.LevelInfo) {
@@ -200,7 +254,11 @@ func snapshotRead(dir string, shardID uint32, engine *storage.Engine, logger log
 	if err != nil {
 		return 0, fmt.Errorf("snapshot: open %s: %w", path, err)
 	}
-	defer f.Close()
+	defer func() {
+		if cerr := f.Close(); cerr != nil {
+			logCleanupWarn("snapshot: close file", cerr, logger)
+		}
+	}()
 
 	fi, err := f.Stat()
 	if err != nil {
@@ -228,7 +286,9 @@ func snapshotRead(dir string, shardID uint32, engine *storage.Engine, logger log
 	h := xxhash.New()
 	binary.LittleEndian.PutUint64(hdr[8:16], 0)
 	binary.LittleEndian.PutUint64(hdr[24:32], 0)
-	h.Write(hdr[:])
+	if _, err = h.Write(hdr[:]); err != nil {
+		return 0, fmt.Errorf("snapshot: hash header: %w", err)
+	}
 
 	// Decode all entries into temporary buffers before touching the engine so
 	// that a checksum failure leaves the engine untouched. Each buffer is
@@ -239,7 +299,6 @@ func snapshotRead(dir string, shardID uint32, engine *storage.Engine, logger log
 		ttlNano int64
 	}
 	var entries []decodedEntry
-	var kvBuf []byte
 	entryBuf := make([]byte, 16)
 	remaining := fileSize - int64(snapHeader)
 
@@ -250,40 +309,35 @@ func snapshotRead(dir string, shardID uint32, engine *storage.Engine, logger log
 			}
 			return 0, fmt.Errorf("snapshot: read entry header: %w", err)
 		}
-		h.Write(entryBuf)
+		if _, err = h.Write(entryBuf); err != nil {
+			return 0, fmt.Errorf("snapshot: hash entry header: %w", err)
+		}
 
 		keyLen := binary.LittleEndian.Uint32(entryBuf[0:4])
 		valLen := binary.LittleEndian.Uint32(entryBuf[4:8])
 		ttlNano := int64(binary.LittleEndian.Uint64(entryBuf[8:16]))
-
-		// Validate key/value lengths: reject integer overflow and data that
-		// exceeds the remaining file bytes.
 		kvLen64 := int64(keyLen) + int64(valLen)
 		if kvLen64 < 0 || kvLen64 > remaining-16 {
 			return 0, fmt.Errorf("snapshot: invalid entry lengths key=%d val=%d (remaining=%d)", keyLen, valLen, remaining)
 		}
 		remaining -= 16 + kvLen64
-
 		kvLen := int(keyLen) + int(valLen)
-		if cap(kvBuf) < kvLen {
-			kvBuf = make([]byte, kvLen)
-		} else {
-			kvBuf = kvBuf[:kvLen]
-		}
-		if _, err = io.ReadFull(f, kvBuf); err != nil {
+		buf := make([]byte, kvLen)
+		if _, err = io.ReadFull(f, buf); err != nil {
 			return 0, fmt.Errorf("snapshot: read key+value: %w", err)
 		}
-		h.Write(kvBuf[:keyLen])
-		h.Write(kvBuf[keyLen:])
+		if _, err := h.Write(buf[:keyLen]); err != nil {
+			return 0, fmt.Errorf("snapshot: hash key: %w", err)
+		}
+		if _, err := h.Write(buf[keyLen:]); err != nil {
+			return 0, fmt.Errorf("snapshot: hash value: %w", err)
+		}
 
-		// Copy so each entry owns its memory independent of kvBuf reuse.
-		buf := make([]byte, kvLen)
-		copy(buf, kvBuf)
 		entries = append(entries, decodedEntry{kvBuf: buf, keyLen: keyLen, ttlNano: ttlNano})
 	}
 
 	actualChecksum := h.Sum64()
-	if fileChecksum != 0 && actualChecksum != fileChecksum {
+	if actualChecksum != fileChecksum {
 		return 0, fmt.Errorf("snapshot: checksum mismatch (file=%d, computed=%d)", fileChecksum, actualChecksum)
 	}
 
@@ -324,7 +378,10 @@ func snapshotExists(dir string, shardID uint32) bool {
 	if err != nil {
 		return false
 	}
-	defer f.Close()
+	defer func() {
+		// Read-only open: close errors are harmless and cannot be reported.
+		_ = f.Close()
+	}()
 	var hdr [4]byte
 	if _, err := io.ReadFull(f, hdr[:]); err != nil {
 		return false
@@ -362,8 +419,12 @@ func snapshotForkDump(dir string, shardID uint32, engine *storage.Engine, logger
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	if err = cmd.Start(); err != nil {
-		pr.Close()
-		pw.Close()
+		if cerr := pr.Close(); cerr != nil {
+			logCleanupWarn("snapshot: close pipe reader", cerr, logger)
+		}
+		if cerr := pw.Close(); cerr != nil {
+			logCleanupWarn("snapshot: close pipe writer", cerr, logger)
+		}
 		if logger.Enabled(log.LevelWarn) {
 			logger.Log(log.LevelWarn, "snapshot: fork failed, falling back to in-process",
 				log.String("error", err.Error()))
@@ -373,11 +434,15 @@ func snapshotForkDump(dir string, shardID uint32, engine *storage.Engine, logger
 	}
 
 	// Parent: close read end (child inherited it via cmd.Stdin).
-	pr.Close()
+	if cerr := pr.Close(); cerr != nil {
+		logCleanupWarn("snapshot: close pipe reader", cerr, logger)
+	}
 
 	// Serialize engine state into the write end; propagate any write error.
 	if serr := serializeEngineToWriter(pw, engine); serr != nil {
-		pw.Close()
+		if cerr := pw.Close(); cerr != nil {
+			logCleanupWarn("snapshot: close pipe writer", cerr, logger)
+		}
 		// Kill the child since it will never receive EOF.
 		_ = cmd.Process.Kill()
 		_ = cmd.Wait()
@@ -385,10 +450,12 @@ func snapshotForkDump(dir string, shardID uint32, engine *storage.Engine, logger
 	}
 
 	// Close write end so the child receives EOF on its stdin.
-	pw.Close()
+	if cerr := pw.Close(); cerr != nil {
+		logCleanupWarn("snapshot: close pipe writer", cerr, logger)
+	}
 
 	// Wait for child to finish writing the snapshot file.
-	if err := cmd.Wait(); err != nil {
+	if err = cmd.Wait(); err != nil {
 		if logger.Enabled(log.LevelError) {
 			logger.Log(log.LevelError, "snapshot: child process failed",
 				log.String("error", err.Error()))
@@ -464,28 +531,28 @@ func snapshotChildWrite(dir string, shardID uint32, r io.Reader) error {
 	binary.LittleEndian.PutUint64(hdr[24:32], 0) // checksum patched later
 
 	if _, err := f.Write(hdr[:]); err != nil {
-		f.Close()
-		os.Remove(tmpPath)
-		return err
+		return snapshotCleanup(f, tmpPath, err, nil)
 	}
 
 	h := xxhash.New()
-	h.Write(hdr[:]) // hash the placeholder header (KeyCount=0, checksum=0)
+	if _, err := h.Write(hdr[:]); err != nil {
+		return snapshotCleanup(f, tmpPath, fmt.Errorf("snapshot: hash header: %w", err), nil)
+	}
 
 	var keyCount uint64
 	entryBuf := make([]byte, 16)
 	var keyBuf, valBuf []byte
 
 	for {
-		if _, err := io.ReadFull(r, entryBuf); err != nil {
+		if _, err = io.ReadFull(r, entryBuf); err != nil {
 			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 				break
 			}
-			f.Close()
-			os.Remove(tmpPath)
-			return err
+			return snapshotCleanup(f, tmpPath, err, nil)
 		}
-		h.Write(entryBuf)
+		if _, err = h.Write(entryBuf); err != nil {
+			return snapshotCleanup(f, tmpPath, fmt.Errorf("snapshot: hash entry header: %w", err), nil)
+		}
 
 		keyLen := binary.LittleEndian.Uint32(entryBuf[0:4])
 		valLen := binary.LittleEndian.Uint32(entryBuf[4:8])
@@ -495,39 +562,33 @@ func snapshotChildWrite(dir string, shardID uint32, r io.Reader) error {
 		} else {
 			keyBuf = keyBuf[:keyLen]
 		}
-		if _, err := io.ReadFull(r, keyBuf); err != nil {
-			f.Close()
-			os.Remove(tmpPath)
-			return err
+		if _, err = io.ReadFull(r, keyBuf); err != nil {
+			return snapshotCleanup(f, tmpPath, err, nil)
 		}
-		h.Write(keyBuf)
+		if _, err = h.Write(keyBuf); err != nil {
+			return snapshotCleanup(f, tmpPath, fmt.Errorf("snapshot: hash key: %w", err), nil)
+		}
 
 		if cap(valBuf) < int(valLen) {
 			valBuf = make([]byte, valLen)
 		} else {
 			valBuf = valBuf[:valLen]
 		}
-		if _, err := io.ReadFull(r, valBuf); err != nil {
-			f.Close()
-			os.Remove(tmpPath)
-			return err
+		if _, err = io.ReadFull(r, valBuf); err != nil {
+			return snapshotCleanup(f, tmpPath, err, nil)
 		}
-		h.Write(valBuf)
+		if _, err = h.Write(valBuf); err != nil {
+			return snapshotCleanup(f, tmpPath, fmt.Errorf("snapshot: hash value: %w", err), nil)
+		}
 
-		if _, err := f.Write(entryBuf); err != nil {
-			f.Close()
-			os.Remove(tmpPath)
-			return err
+		if _, err = f.Write(entryBuf); err != nil {
+			return snapshotCleanup(f, tmpPath, err, nil)
 		}
-		if _, err := f.Write(keyBuf); err != nil {
-			f.Close()
-			os.Remove(tmpPath)
-			return err
+		if _, err = f.Write(keyBuf); err != nil {
+			return snapshotCleanup(f, tmpPath, err, nil)
 		}
-		if _, err := f.Write(valBuf); err != nil {
-			f.Close()
-			os.Remove(tmpPath)
-			return err
+		if _, err = f.Write(valBuf); err != nil {
+			return snapshotCleanup(f, tmpPath, err, nil)
 		}
 		keyCount++
 	}
@@ -537,22 +598,27 @@ func snapshotChildWrite(dir string, shardID uint32, r io.Reader) error {
 	binary.LittleEndian.PutUint64(hdr[8:16], keyCount)
 	binary.LittleEndian.PutUint64(hdr[24:32], checksum)
 
-	if _, err := f.Seek(0, 0); err != nil {
-		f.Close()
-		os.Remove(tmpPath)
-		return err
+	if _, err = f.Seek(0, 0); err != nil {
+		return snapshotCleanup(f, tmpPath, err, nil)
 	}
 	if _, err = f.Write(hdr[:]); err != nil {
-		f.Close()
-		os.Remove(tmpPath)
-		return err
+		return snapshotCleanup(f, tmpPath, err, nil)
 	}
 	if err = f.Sync(); err != nil {
-		f.Close()
-		os.Remove(tmpPath)
+		return snapshotCleanup(f, tmpPath, err, nil)
+	}
+	if err = f.Close(); err != nil {
+		if rerr := os.Remove(tmpPath); rerr != nil {
+			logCleanupWarn("snapshot: remove tmp after close error", rerr, nil)
+		}
 		return err
 	}
-	f.Close()
 
-	return os.Rename(tmpPath, finalPath)
+	if err = os.Rename(tmpPath, finalPath); err != nil {
+		if rerr := os.Remove(tmpPath); rerr != nil {
+			logCleanupWarn("snapshot: remove tmp after rename error", rerr, nil)
+		}
+		return err
+	}
+	return syncDir(dir)
 }

--- a/internal/persistence/snapshot.go
+++ b/internal/persistence/snapshot.go
@@ -1,0 +1,455 @@
+/*
+Package persistence
+Tellstone Cloud-Native In-Memory Database
+File: snapshot.go
+Description: Binary snapshot format and fork-based compaction. A snapshot captures a
+shard's in-memory engine state in a compact binary file, allowing the WAL to be
+truncated. On startup, the snapshot is loaded first (fast binary read), then only
+the small post-snapshot WAL is replayed.
+
+The snapshot child is spawned via ForkExec (same binary, --snapshot-child flag).
+The parent serializes the engine map to a pipe under a brief read lock, then the
+child writes the snapshot file to disk. This keeps the parent's lock duration
+minimal while the child handles the heavy I/O.
+
+Authors:
+
+	Maximilian Hagen
+*/
+package persistence
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/Saxy/Tellstone/internal/log"
+	"github.com/Saxy/Tellstone/internal/storage"
+	"github.com/cespare/xxhash/v2"
+)
+
+const (
+	snapMagic   = "TSNS"
+	snapVersion = 1
+	snapHeader  = 32 // magic(4) + version(4) + keyCount(8) + createdAt(8) + checksum(8)
+)
+
+// IsSnapshotChild returns true when the process was spawned as a snapshot child.
+// Check this early in main() and redirect to snapshotChildMain().
+func IsSnapshotChild() bool {
+	for _, arg := range os.Args[1:] {
+		if arg == "--snapshot-child" {
+			return true
+		}
+	}
+	return false
+}
+
+// SnapshotChildMain runs in the forked child process. It reads serialized
+// engine entries from stdin, writes the snapshot file, and exits.
+// The dir and shardID are passed via environment variables set by the parent.
+func SnapshotChildMain() {
+	dir := os.Getenv("TSD_SNAP_DIR")
+	shardID := 0
+	fmt.Sscanf(os.Getenv("TSD_SNAP_SHARD"), "%d", &shardID)
+	if dir == "" || shardID < 0 {
+		os.Exit(1)
+	}
+
+	err := snapshotChildWrite(dir, uint32(shardID), os.Stdin)
+	if err != nil {
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+// snapshotWrite serializes all live entries from the engine into a snapshot file.
+// Writes to a temporary file first, then atomically renames over the target.
+// Returns the number of keys written.
+func snapshotWrite(dir string, shardID uint32, engine *storage.Engine, logger log.Logger) (uint64, error) {
+	tmpPath := filepath.Join(dir, fmt.Sprintf("shard_%03d.snap.tmp", shardID))
+	finalPath := filepath.Join(dir, fmt.Sprintf("shard_%03d.snap", shardID))
+
+	f, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		return 0, fmt.Errorf("snapshot: create %s: %w", tmpPath, err)
+	}
+
+	createdAt := time.Now().UnixNano()
+
+	// Placeholder header: KeyCount=0, createdAt=real, checksum=0.
+	// Must match what snapshotRead hashes: it zeroes the checksum slot and
+	// hashes the full 32 bytes, so we hash the same layout here.
+	var hdr [snapHeader]byte
+	copy(hdr[0:4], snapMagic)
+	binary.LittleEndian.PutUint32(hdr[4:8], snapVersion)
+	binary.LittleEndian.PutUint64(hdr[8:16], 0) // patched later
+	binary.LittleEndian.PutUint64(hdr[16:24], uint64(createdAt))
+	binary.LittleEndian.PutUint64(hdr[24:32], 0) // patched later
+
+	if _, err := f.Write(hdr[:]); err != nil {
+		f.Close()
+		os.Remove(tmpPath)
+		return 0, fmt.Errorf("snapshot: write header: %w", err)
+	}
+
+	h := xxhash.New()
+	h.Write(hdr[:]) // hash placeholder header (KeyCount=0, checksum=0)
+
+	var keyCount uint64
+	var entry [16]byte
+
+	engine.ForEach(func(key string, value []byte, expiration time.Time) {
+		keyLen := uint32(len(key))
+		valLen := uint32(len(value))
+		var ttlNano int64
+		if !expiration.IsZero() {
+			ttlNano = expiration.UnixNano()
+		}
+		binary.LittleEndian.PutUint32(entry[0:4], keyLen)
+		binary.LittleEndian.PutUint32(entry[4:8], valLen)
+		binary.LittleEndian.PutUint64(entry[8:16], uint64(ttlNano))
+
+		h.Write(entry[:])
+		h.WriteString(key)
+		h.Write(value)
+
+		f.Write(entry[:])
+		f.WriteString(key)
+		f.Write(value)
+		keyCount++
+	})
+
+	if err = f.Sync(); err != nil {
+		f.Close()
+		os.Remove(tmpPath)
+		return 0, fmt.Errorf("snapshot: sync: %w", err)
+	}
+
+	// Patch header with final checksum and key count.
+	checksum := h.Sum64()
+	binary.LittleEndian.PutUint64(hdr[8:16], keyCount)
+	binary.LittleEndian.PutUint64(hdr[24:32], checksum)
+
+	f.Seek(0, 0)
+	if _, err = f.Write(hdr[:]); err != nil {
+		f.Close()
+		os.Remove(tmpPath)
+		return 0, fmt.Errorf("snapshot: patch header: %w", err)
+	}
+
+	if err = f.Sync(); err != nil {
+		f.Close()
+		os.Remove(tmpPath)
+		return 0, fmt.Errorf("snapshot: sync header: %w", err)
+	}
+	f.Close()
+
+	if err := os.Rename(tmpPath, finalPath); err != nil {
+		os.Remove(tmpPath)
+		return 0, fmt.Errorf("snapshot: rename: %w", err)
+	}
+
+	if logger != nil && logger.Enabled(log.LevelInfo) {
+		logger.Log(log.LevelInfo, "snapshot: written",
+			log.Uint("shard", shardID),
+			log.Uint64("keys", keyCount),
+			log.String("path", finalPath),
+		)
+	}
+	return keyCount, nil
+}
+
+// snapshotRead loads a snapshot file into the engine. Verifies magic, version,
+// and checksum before applying entries. Returns the number of keys loaded.
+func snapshotRead(dir string, shardID uint32, engine *storage.Engine, logger log.Logger) (uint64, error) {
+	path := filepath.Join(dir, fmt.Sprintf("shard_%03d.snap", shardID))
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, fmt.Errorf("snapshot: open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	var hdr [snapHeader]byte
+	if _, err = io.ReadFull(f, hdr[:]); err != nil {
+		return 0, fmt.Errorf("snapshot: read header: %w", err)
+	}
+	if string(hdr[0:4]) != snapMagic {
+		return 0, fmt.Errorf("snapshot: invalid magic %q (want %q)", string(hdr[0:4]), snapMagic)
+	}
+	version := binary.LittleEndian.Uint32(hdr[4:8])
+	if version != snapVersion {
+		return 0, fmt.Errorf("snapshot: unsupported version %d (want %d)", version, snapVersion)
+	}
+	fileKeyCount := binary.LittleEndian.Uint64(hdr[8:16])
+	fileChecksum := binary.LittleEndian.Uint64(hdr[24:32])
+
+	// Compute checksum over (header with KeyCount=0, checksum=0) + all entries.
+	// This matches the writer: it hashes the placeholder header (KeyCount=0,
+	// checksum=0) before patching the real values. We must hash the same bytes.
+	h := xxhash.New()
+	binary.LittleEndian.PutUint64(hdr[8:16], 0)
+	binary.LittleEndian.PutUint64(hdr[24:32], 0)
+	h.Write(hdr[:])
+
+	var loadedKeys uint64
+	entryBuf := make([]byte, 16)
+	var kvBuf []byte
+
+	for {
+		if _, err = io.ReadFull(f, entryBuf); err != nil {
+			if err == io.EOF || err == io.ErrUnexpectedEOF {
+				break
+			}
+			return 0, fmt.Errorf("snapshot: read entry header: %w", err)
+		}
+		h.Write(entryBuf)
+
+		keyLen := binary.LittleEndian.Uint32(entryBuf[0:4])
+		valLen := binary.LittleEndian.Uint32(entryBuf[4:8])
+		ttlNano := int64(binary.LittleEndian.Uint64(entryBuf[8:16]))
+
+		kvLen := int(keyLen) + int(valLen)
+		if cap(kvBuf) < kvLen {
+			kvBuf = make([]byte, kvLen)
+		} else {
+			kvBuf = kvBuf[:kvLen]
+		}
+		if _, err = io.ReadFull(f, kvBuf); err != nil {
+			return 0, fmt.Errorf("snapshot: read key+value: %w", err)
+		}
+		// Hash key and value separately to match the writer's layout.
+		h.Write(kvBuf[:keyLen])
+		h.Write(kvBuf[keyLen:])
+
+		// Compute TTL duration relative to now.
+		var duration time.Duration
+		if ttlNano != 0 {
+			ttl := time.Unix(0, ttlNano)
+			duration = time.Until(ttl)
+			if duration <= 0 {
+				continue // expired — skip
+			}
+		}
+
+		// SetFromBuffer takes ownership of kvBuf — allocate a fresh one on
+		// the next iteration so the engine's map entry remains valid.
+		snap := kvBuf
+		kvBuf = nil
+		if err = engine.SetFromBuffer(snap, int(keyLen), duration); err != nil {
+			return 0, fmt.Errorf("snapshot: engine.SetFromBuffer: %w", err)
+		}
+		loadedKeys++
+	}
+
+	actualChecksum := h.Sum64()
+	if fileChecksum != 0 && actualChecksum != fileChecksum {
+		return 0, fmt.Errorf("snapshot: checksum mismatch (file=%d, computed=%d)", fileChecksum, actualChecksum)
+	}
+
+	if logger != nil && logger.Enabled(log.LevelInfo) {
+		logger.Log(log.LevelInfo, "snapshot: loaded",
+			log.Uint("shard", shardID),
+			log.Uint64("keys", loadedKeys),
+			log.Uint64("declared_keys", fileKeyCount),
+		)
+	}
+	return loadedKeys, nil
+}
+
+// snapshotExists reports whether a valid snapshot file exists for the shard.
+func snapshotExists(dir string, shardID uint32) bool {
+	path := filepath.Join(dir, fmt.Sprintf("shard_%03d.snap", shardID))
+	fi, err := os.Stat(path)
+	return err == nil && fi.Size() >= snapHeader
+}
+
+// snapshotForkDump triggers a fork-based snapshot. The parent serializes the
+// engine map to a pipe under a brief read lock, then ForkExec's the same binary
+// with --snapshot-child. The child reads from the pipe and writes the snapshot
+// file. If fork fails, falls back to an in-process write.
+func snapshotForkDump(dir string, shardID uint32, engine *storage.Engine, logger log.Logger) error {
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		_, err = snapshotWrite(dir, shardID, engine, logger)
+		return err
+	}
+
+	cmd := exec.Command(os.Args[0], "--snapshot-child")
+	cmd.Stdin = pr
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	cmd.Env = append(os.Environ(),
+		"TSD_SNAP_DIR="+dir,
+		fmt.Sprintf("TSD_SNAP_SHARD=%d", shardID),
+	)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	if err = cmd.Start(); err != nil {
+		pr.Close()
+		pw.Close()
+		if logger.Enabled(log.LevelWarn) {
+			logger.Log(log.LevelWarn, "snapshot: fork failed, falling back to in-process",
+				log.String("error", err.Error()))
+		}
+		_, err := snapshotWrite(dir, shardID, engine, logger)
+		return err
+	}
+
+	// Parent: close read end (child inherited it via cmd.Stdin).
+	pr.Close()
+
+	// Serialize engine state into the write end under a brief read lock.
+	serializeEngineToWriter(pw, engine)
+
+	// Close write end so the child receives EOF on its stdin.
+	pw.Close()
+
+	// Wait for child to finish writing the snapshot file.
+	if err := cmd.Wait(); err != nil {
+		if logger.Enabled(log.LevelError) {
+			logger.Log(log.LevelError, "snapshot: child process failed",
+				log.String("error", err.Error()))
+		}
+		return fmt.Errorf("snapshot: child: %w", err)
+	}
+
+	if logger.Enabled(log.LevelInfo) {
+		logger.Log(log.LevelInfo, "snapshot: fork-based dump complete",
+			log.Uint("shard", shardID))
+	}
+	return nil
+}
+
+// serializeEngineToWriter writes all engine entries in the snapshot binary
+// format (without file header) to the given writer.
+func serializeEngineToWriter(w io.Writer, engine *storage.Engine) {
+	var entry [16]byte
+
+	engine.ForEach(func(key string, value []byte, expiration time.Time) {
+		keyLen := uint32(len(key))
+		valLen := uint32(len(value))
+		var ttlNano int64
+		if !expiration.IsZero() {
+			ttlNano = expiration.UnixNano()
+		}
+		binary.LittleEndian.PutUint32(entry[0:4], keyLen)
+		binary.LittleEndian.PutUint32(entry[4:8], valLen)
+		binary.LittleEndian.PutUint64(entry[8:16], uint64(ttlNano))
+
+		w.Write(entry[:])
+		io.WriteString(w, key)
+		w.Write(value)
+	})
+}
+
+// snapshotChildWrite reads serialized entries from r and writes the snapshot
+// file. Called by the child process after ForkExec.
+func snapshotChildWrite(dir string, shardID uint32, r io.Reader) error {
+	tmpPath := filepath.Join(dir, fmt.Sprintf("shard_%03d.snap.tmp", shardID))
+	finalPath := filepath.Join(dir, fmt.Sprintf("shard_%03d.snap", shardID))
+
+	f, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+
+	createdAt := time.Now().UnixNano()
+
+	// Build placeholder header: Magic + Version set, KeyCount=0, createdAt=real, checksum=0.
+	// This matches what snapshotRead hashes: it reads the on-disk header, zeroes the
+	// checksum slot (24:32), then hashes the full 32 bytes. We must hash the same
+	// bytes — header with real createdAt but zero KeyCount and zero checksum.
+	var hdr [snapHeader]byte
+	copy(hdr[0:4], snapMagic)
+	binary.LittleEndian.PutUint32(hdr[4:8], snapVersion)
+	binary.LittleEndian.PutUint64(hdr[8:16], 0) // KeyCount patched later
+	binary.LittleEndian.PutUint64(hdr[16:24], uint64(createdAt))
+	binary.LittleEndian.PutUint64(hdr[24:32], 0) // checksum patched later
+
+	if _, err := f.Write(hdr[:]); err != nil {
+		f.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+
+	h := xxhash.New()
+	h.Write(hdr[:]) // hash the placeholder header (KeyCount=0, checksum=0)
+
+	var keyCount uint64
+	entryBuf := make([]byte, 16)
+	var keyBuf, valBuf []byte
+
+	for {
+		if _, err := io.ReadFull(r, entryBuf); err != nil {
+			if err == io.EOF || err == io.ErrUnexpectedEOF {
+				break
+			}
+			f.Close()
+			os.Remove(tmpPath)
+			return err
+		}
+		h.Write(entryBuf)
+
+		keyLen := binary.LittleEndian.Uint32(entryBuf[0:4])
+		valLen := binary.LittleEndian.Uint32(entryBuf[4:8])
+
+		if cap(keyBuf) < int(keyLen) {
+			keyBuf = make([]byte, keyLen)
+		} else {
+			keyBuf = keyBuf[:keyLen]
+		}
+		if _, err := io.ReadFull(r, keyBuf); err != nil {
+			f.Close()
+			os.Remove(tmpPath)
+			return err
+		}
+		h.Write(keyBuf)
+
+		if cap(valBuf) < int(valLen) {
+			valBuf = make([]byte, valLen)
+		} else {
+			valBuf = valBuf[:valLen]
+		}
+		if _, err := io.ReadFull(r, valBuf); err != nil {
+			f.Close()
+			os.Remove(tmpPath)
+			return err
+		}
+		h.Write(valBuf)
+
+		f.Write(entryBuf)
+		f.Write(keyBuf)
+		f.Write(valBuf)
+		keyCount++
+	}
+
+	// Patch header with final KeyCount and checksum.
+	checksum := h.Sum64()
+	binary.LittleEndian.PutUint64(hdr[8:16], keyCount)
+	binary.LittleEndian.PutUint64(hdr[24:32], checksum)
+
+	if _, err := f.Seek(0, 0); err != nil {
+		f.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if _, err = f.Write(hdr[:]); err != nil {
+		f.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err = f.Sync(); err != nil {
+		f.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	f.Close()
+
+	return os.Rename(tmpPath, finalPath)
+}

--- a/internal/persistence/snapshot.go
+++ b/internal/persistence/snapshot.go
@@ -19,7 +19,9 @@ Authors:
 package persistence
 
 import (
+	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -56,12 +58,12 @@ func IsSnapshotChild() bool {
 func SnapshotChildMain() {
 	dir := os.Getenv("TSD_SNAP_DIR")
 	shardID := 0
-	fmt.Sscanf(os.Getenv("TSD_SNAP_SHARD"), "%d", &shardID)
-	if dir == "" || shardID < 0 {
+	n, err := fmt.Sscanf(os.Getenv("TSD_SNAP_SHARD"), "%d", &shardID)
+	if err != nil || n != 1 || shardID < 0 || dir == "" {
 		os.Exit(1)
 	}
 
-	err := snapshotChildWrite(dir, uint32(shardID), os.Stdin)
+	err = snapshotChildWrite(dir, uint32(shardID), os.Stdin)
 	if err != nil {
 		os.Exit(1)
 	}
@@ -102,9 +104,13 @@ func snapshotWrite(dir string, shardID uint32, engine *storage.Engine, logger lo
 	h.Write(hdr[:]) // hash placeholder header (KeyCount=0, checksum=0)
 
 	var keyCount uint64
+	var writeErr error
 	var entry [16]byte
 
 	engine.ForEach(func(key string, value []byte, expiration time.Time) {
+		if writeErr != nil {
+			return
+		}
 		keyLen := uint32(len(key))
 		valLen := uint32(len(value))
 		var ttlNano int64
@@ -119,11 +125,26 @@ func snapshotWrite(dir string, shardID uint32, engine *storage.Engine, logger lo
 		h.WriteString(key)
 		h.Write(value)
 
-		f.Write(entry[:])
-		f.WriteString(key)
-		f.Write(value)
+		if _, err := f.Write(entry[:]); err != nil {
+			writeErr = err
+			return
+		}
+		if _, err := f.WriteString(key); err != nil {
+			writeErr = err
+			return
+		}
+		if _, err := f.Write(value); err != nil {
+			writeErr = err
+			return
+		}
 		keyCount++
 	})
+
+	if writeErr != nil {
+		f.Close()
+		os.Remove(tmpPath)
+		return 0, fmt.Errorf("snapshot: write entry: %w", writeErr)
+	}
 
 	if err = f.Sync(); err != nil {
 		f.Close()
@@ -136,7 +157,11 @@ func snapshotWrite(dir string, shardID uint32, engine *storage.Engine, logger lo
 	binary.LittleEndian.PutUint64(hdr[8:16], keyCount)
 	binary.LittleEndian.PutUint64(hdr[24:32], checksum)
 
-	f.Seek(0, 0)
+	if _, err = f.Seek(0, 0); err != nil {
+		f.Close()
+		os.Remove(tmpPath)
+		return 0, fmt.Errorf("snapshot: seek header: %w", err)
+	}
 	if _, err = f.Write(hdr[:]); err != nil {
 		f.Close()
 		os.Remove(tmpPath)
@@ -165,8 +190,10 @@ func snapshotWrite(dir string, shardID uint32, engine *storage.Engine, logger lo
 	return keyCount, nil
 }
 
-// snapshotRead loads a snapshot file into the engine. Verifies magic, version,
-// and checksum before applying entries. Returns the number of keys loaded.
+// snapshotRead loads a snapshot file into the engine. It validates lengths,
+// verifies the checksum, and only then applies entries to the engine so that a
+// corrupted snapshot never mutates the live state. Returns the number of keys
+// loaded.
 func snapshotRead(dir string, shardID uint32, engine *storage.Engine, logger log.Logger) (uint64, error) {
 	path := filepath.Join(dir, fmt.Sprintf("shard_%03d.snap", shardID))
 	f, err := os.Open(path)
@@ -174,6 +201,12 @@ func snapshotRead(dir string, shardID uint32, engine *storage.Engine, logger log
 		return 0, fmt.Errorf("snapshot: open %s: %w", path, err)
 	}
 	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil {
+		return 0, fmt.Errorf("snapshot: stat %s: %w", path, err)
+	}
+	fileSize := fi.Size()
 
 	var hdr [snapHeader]byte
 	if _, err = io.ReadFull(f, hdr[:]); err != nil {
@@ -197,13 +230,22 @@ func snapshotRead(dir string, shardID uint32, engine *storage.Engine, logger log
 	binary.LittleEndian.PutUint64(hdr[24:32], 0)
 	h.Write(hdr[:])
 
-	var loadedKeys uint64
-	entryBuf := make([]byte, 16)
+	// Decode all entries into temporary buffers before touching the engine so
+	// that a checksum failure leaves the engine untouched. Each buffer is
+	// contiguous [key|value] for SetFromBuffer compatibility.
+	type decodedEntry struct {
+		kvBuf   []byte // [key|value] contiguous
+		keyLen  uint32
+		ttlNano int64
+	}
+	var entries []decodedEntry
 	var kvBuf []byte
+	entryBuf := make([]byte, 16)
+	remaining := fileSize - int64(snapHeader)
 
 	for {
 		if _, err = io.ReadFull(f, entryBuf); err != nil {
-			if err == io.EOF || err == io.ErrUnexpectedEOF {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 				break
 			}
 			return 0, fmt.Errorf("snapshot: read entry header: %w", err)
@@ -214,6 +256,14 @@ func snapshotRead(dir string, shardID uint32, engine *storage.Engine, logger log
 		valLen := binary.LittleEndian.Uint32(entryBuf[4:8])
 		ttlNano := int64(binary.LittleEndian.Uint64(entryBuf[8:16]))
 
+		// Validate key/value lengths: reject integer overflow and data that
+		// exceeds the remaining file bytes.
+		kvLen64 := int64(keyLen) + int64(valLen)
+		if kvLen64 < 0 || kvLen64 > remaining-16 {
+			return 0, fmt.Errorf("snapshot: invalid entry lengths key=%d val=%d (remaining=%d)", keyLen, valLen, remaining)
+		}
+		remaining -= 16 + kvLen64
+
 		kvLen := int(keyLen) + int(valLen)
 		if cap(kvBuf) < kvLen {
 			kvBuf = make([]byte, kvLen)
@@ -223,33 +273,36 @@ func snapshotRead(dir string, shardID uint32, engine *storage.Engine, logger log
 		if _, err = io.ReadFull(f, kvBuf); err != nil {
 			return 0, fmt.Errorf("snapshot: read key+value: %w", err)
 		}
-		// Hash key and value separately to match the writer's layout.
 		h.Write(kvBuf[:keyLen])
 		h.Write(kvBuf[keyLen:])
 
-		// Compute TTL duration relative to now.
-		var duration time.Duration
-		if ttlNano != 0 {
-			ttl := time.Unix(0, ttlNano)
-			duration = time.Until(ttl)
-			if duration <= 0 {
-				continue // expired — skip
-			}
-		}
-
-		// SetFromBuffer takes ownership of kvBuf — allocate a fresh one on
-		// the next iteration so the engine's map entry remains valid.
-		snap := kvBuf
-		kvBuf = nil
-		if err = engine.SetFromBuffer(snap, int(keyLen), duration); err != nil {
-			return 0, fmt.Errorf("snapshot: engine.SetFromBuffer: %w", err)
-		}
-		loadedKeys++
+		// Copy so each entry owns its memory independent of kvBuf reuse.
+		buf := make([]byte, kvLen)
+		copy(buf, kvBuf)
+		entries = append(entries, decodedEntry{kvBuf: buf, keyLen: keyLen, ttlNano: ttlNano})
 	}
 
 	actualChecksum := h.Sum64()
 	if fileChecksum != 0 && actualChecksum != fileChecksum {
 		return 0, fmt.Errorf("snapshot: checksum mismatch (file=%d, computed=%d)", fileChecksum, actualChecksum)
+	}
+
+	// Checksum is valid — safe to apply entries to the engine.
+	var loadedKeys uint64
+	for i := range entries {
+		e := &entries[i]
+		var duration time.Duration
+		if e.ttlNano != 0 {
+			ttl := time.Unix(0, e.ttlNano)
+			duration = time.Until(ttl)
+			if duration <= 0 {
+				continue // expired — skip
+			}
+		}
+		if err = engine.SetFromBuffer(e.kvBuf, int(e.keyLen), duration); err != nil {
+			return 0, fmt.Errorf("snapshot: engine.SetFromBuffer: %w", err)
+		}
+		loadedKeys++
 	}
 
 	if logger != nil && logger.Enabled(log.LevelInfo) {
@@ -263,10 +316,20 @@ func snapshotRead(dir string, shardID uint32, engine *storage.Engine, logger log
 }
 
 // snapshotExists reports whether a valid snapshot file exists for the shard.
+// Checks file size and magic bytes so stale or incompatible files are not
+// selected.
 func snapshotExists(dir string, shardID uint32) bool {
 	path := filepath.Join(dir, fmt.Sprintf("shard_%03d.snap", shardID))
-	fi, err := os.Stat(path)
-	return err == nil && fi.Size() >= snapHeader
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	var hdr [4]byte
+	if _, err := io.ReadFull(f, hdr[:]); err != nil {
+		return false
+	}
+	return string(hdr[:]) == snapMagic
 }
 
 // snapshotForkDump triggers a fork-based snapshot. The parent serializes the
@@ -280,14 +343,22 @@ func snapshotForkDump(dir string, shardID uint32, engine *storage.Engine, logger
 		return err
 	}
 
-	cmd := exec.Command(os.Args[0], "--snapshot-child")
+	// Use a bounded deadline so cmd.Wait cannot block indefinitely if the
+	// child hangs or the pipe stalls.
+	const childTimeout = 2 * time.Minute
+	ctx, cancel := context.WithTimeout(context.Background(), childTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, os.Args[0], "--snapshot-child")
 	cmd.Stdin = pr
 	cmd.Stdout = nil
 	cmd.Stderr = nil
-	cmd.Env = append(os.Environ(),
-		"TSD_SNAP_DIR="+dir,
+	// Replace inherited env with only the variables the child needs so that
+	// secrets and other host state are not leaked to the child process.
+	cmd.Env = []string{
+		"TSD_SNAP_DIR=" + dir,
 		fmt.Sprintf("TSD_SNAP_SHARD=%d", shardID),
-	)
+	}
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	if err = cmd.Start(); err != nil {
@@ -304,8 +375,14 @@ func snapshotForkDump(dir string, shardID uint32, engine *storage.Engine, logger
 	// Parent: close read end (child inherited it via cmd.Stdin).
 	pr.Close()
 
-	// Serialize engine state into the write end under a brief read lock.
-	serializeEngineToWriter(pw, engine)
+	// Serialize engine state into the write end; propagate any write error.
+	if serr := serializeEngineToWriter(pw, engine); serr != nil {
+		pw.Close()
+		// Kill the child since it will never receive EOF.
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		return fmt.Errorf("snapshot: serialize: %w", serr)
+	}
 
 	// Close write end so the child receives EOF on its stdin.
 	pw.Close()
@@ -327,25 +404,39 @@ func snapshotForkDump(dir string, shardID uint32, engine *storage.Engine, logger
 }
 
 // serializeEngineToWriter writes all engine entries in the snapshot binary
-// format (without file header) to the given writer.
-func serializeEngineToWriter(w io.Writer, engine *storage.Engine) {
-	var entry [16]byte
-
+// format (without file header) to the given writer. Stops at the first write
+// error and returns it.
+func serializeEngineToWriter(w io.Writer, engine *storage.Engine) error {
+	var writeErr error
 	engine.ForEach(func(key string, value []byte, expiration time.Time) {
+		if writeErr != nil {
+			return
+		}
 		keyLen := uint32(len(key))
 		valLen := uint32(len(value))
 		var ttlNano int64
 		if !expiration.IsZero() {
 			ttlNano = expiration.UnixNano()
 		}
-		binary.LittleEndian.PutUint32(entry[0:4], keyLen)
-		binary.LittleEndian.PutUint32(entry[4:8], valLen)
-		binary.LittleEndian.PutUint64(entry[8:16], uint64(ttlNano))
+		var hdr [16]byte
+		binary.LittleEndian.PutUint32(hdr[0:4], keyLen)
+		binary.LittleEndian.PutUint32(hdr[4:8], valLen)
+		binary.LittleEndian.PutUint64(hdr[8:16], uint64(ttlNano))
 
-		w.Write(entry[:])
-		io.WriteString(w, key)
-		w.Write(value)
+		if _, err := w.Write(hdr[:]); err != nil {
+			writeErr = err
+			return
+		}
+		if _, err := io.WriteString(w, key); err != nil {
+			writeErr = err
+			return
+		}
+		if _, err := w.Write(value); err != nil {
+			writeErr = err
+			return
+		}
 	})
+	return writeErr
 }
 
 // snapshotChildWrite reads serialized entries from r and writes the snapshot
@@ -387,7 +478,7 @@ func snapshotChildWrite(dir string, shardID uint32, r io.Reader) error {
 
 	for {
 		if _, err := io.ReadFull(r, entryBuf); err != nil {
-			if err == io.EOF || err == io.ErrUnexpectedEOF {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 				break
 			}
 			f.Close()
@@ -423,9 +514,21 @@ func snapshotChildWrite(dir string, shardID uint32, r io.Reader) error {
 		}
 		h.Write(valBuf)
 
-		f.Write(entryBuf)
-		f.Write(keyBuf)
-		f.Write(valBuf)
+		if _, err := f.Write(entryBuf); err != nil {
+			f.Close()
+			os.Remove(tmpPath)
+			return err
+		}
+		if _, err := f.Write(keyBuf); err != nil {
+			f.Close()
+			os.Remove(tmpPath)
+			return err
+		}
+		if _, err := f.Write(valBuf); err != nil {
+			f.Close()
+			os.Remove(tmpPath)
+			return err
+		}
 		keyCount++
 	}
 

--- a/internal/persistence/snapshot.go
+++ b/internal/persistence/snapshot.go
@@ -66,6 +66,20 @@ func logCleanupWarn(msg string, err error, logger log.Logger) {
 	}
 }
 
+// buildSnapshotHeader constructs the 32-byte placeholder snapshot header
+// with KeyCount=0 and checksum=0. Both fields are patched after all entries
+// are written and hashed. The caller must hash hdr before patching.
+func buildSnapshotHeader() [snapHeader]byte {
+	var hdr [snapHeader]byte
+	createdAt := time.Now().UnixNano()
+	copy(hdr[0:4], snapMagic)
+	binary.LittleEndian.PutUint32(hdr[4:8], snapVersion)
+	binary.LittleEndian.PutUint64(hdr[8:16], 0) // KeyCount patched later
+	binary.LittleEndian.PutUint64(hdr[16:24], uint64(createdAt))
+	binary.LittleEndian.PutUint64(hdr[24:32], 0) // checksum patched later
+	return hdr
+}
+
 // syncDir opens dir, fsyncs it, and closes it so that a preceding os.Rename
 // is durable on filesystems that require explicit directory fsync (ext4, etc).
 func syncDir(dir string) error {
@@ -124,17 +138,7 @@ func snapshotWrite(dir string, shardID uint32, engine *storage.Engine, logger lo
 		return 0, fmt.Errorf("snapshot: create %s: %w", tmpPath, err)
 	}
 
-	createdAt := time.Now().UnixNano()
-
-	// Placeholder header: KeyCount=0, createdAt=real, checksum=0.
-	// Must match what snapshotRead hashes: it zeroes the checksum slot and
-	// hashes the full 32 bytes, so we hash the same layout here.
-	var hdr [snapHeader]byte
-	copy(hdr[0:4], snapMagic)
-	binary.LittleEndian.PutUint32(hdr[4:8], snapVersion)
-	binary.LittleEndian.PutUint64(hdr[8:16], 0) // patched later
-	binary.LittleEndian.PutUint64(hdr[16:24], uint64(createdAt))
-	binary.LittleEndian.PutUint64(hdr[24:32], 0) // patched later
+	hdr := buildSnapshotHeader()
 
 	if _, err = f.Write(hdr[:]); err != nil {
 		return 0, snapshotCleanup(f, tmpPath, fmt.Errorf("snapshot: write header: %w", err), logger)
@@ -228,9 +232,6 @@ func snapshotWrite(dir string, shardID uint32, engine *storage.Engine, logger lo
 		return 0, fmt.Errorf("snapshot: rename: %w", err)
 	}
 	if err = syncDir(dir); err != nil {
-		if rerr := os.Remove(finalPath); rerr != nil {
-			logCleanupWarn("snapshot: remove final after sync dir error", rerr, logger)
-		}
 		return 0, fmt.Errorf("snapshot: sync dir: %w", err)
 	}
 
@@ -304,7 +305,7 @@ func snapshotRead(dir string, shardID uint32, engine *storage.Engine, logger log
 
 	for {
 		if _, err = io.ReadFull(f, entryBuf); err != nil {
-			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			return 0, fmt.Errorf("snapshot: read entry header: %w", err)
@@ -517,18 +518,7 @@ func snapshotChildWrite(dir string, shardID uint32, r io.Reader) error {
 		return err
 	}
 
-	createdAt := time.Now().UnixNano()
-
-	// Build placeholder header: Magic + Version set, KeyCount=0, createdAt=real, checksum=0.
-	// This matches what snapshotRead hashes: it reads the on-disk header, zeroes the
-	// checksum slot (24:32), then hashes the full 32 bytes. We must hash the same
-	// bytes — header with real createdAt but zero KeyCount and zero checksum.
-	var hdr [snapHeader]byte
-	copy(hdr[0:4], snapMagic)
-	binary.LittleEndian.PutUint32(hdr[4:8], snapVersion)
-	binary.LittleEndian.PutUint64(hdr[8:16], 0) // KeyCount patched later
-	binary.LittleEndian.PutUint64(hdr[16:24], uint64(createdAt))
-	binary.LittleEndian.PutUint64(hdr[24:32], 0) // checksum patched later
+	hdr := buildSnapshotHeader()
 
 	if _, err := f.Write(hdr[:]); err != nil {
 		return snapshotCleanup(f, tmpPath, err, nil)
@@ -545,7 +535,7 @@ func snapshotChildWrite(dir string, shardID uint32, r io.Reader) error {
 
 	for {
 		if _, err = io.ReadFull(r, entryBuf); err != nil {
-			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			return snapshotCleanup(f, tmpPath, err, nil)

--- a/internal/persistence/snapshot_bench_test.go
+++ b/internal/persistence/snapshot_bench_test.go
@@ -1,0 +1,335 @@
+package persistence
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/Saxy/Tellstone/internal/storage"
+)
+
+// populateEngine fills an engine with n keys of the given size.
+func populateEngine(b testing.TB, n int, valSize int) *storage.Engine {
+	b.Helper()
+	e := storage.NewEngine(0, 0, 0, nil, nil)
+	val := make([]byte, valSize)
+	for i := 0; i < valSize; i++ {
+		val[i] = byte('A' + i%26)
+	}
+	for i := 0; i < n; i++ {
+		key := fmt.Sprintf("key_%08d", i)
+		if err := e.Set(key, val, 0); err != nil {
+			b.Fatal(err)
+		}
+	}
+	return e
+}
+
+// --- snapshotWrite benchmarks ---
+
+func BenchmarkSnapshotWrite100(b *testing.B) {
+	benchmarkSnapshotWrite(b, 100, 64)
+}
+
+func BenchmarkSnapshotWrite1K(b *testing.B) {
+	benchmarkSnapshotWrite(b, 1000, 64)
+}
+
+func BenchmarkSnapshotWrite10K(b *testing.B) {
+	benchmarkSnapshotWrite(b, 10000, 64)
+}
+
+func BenchmarkSnapshotWrite100K(b *testing.B) {
+	benchmarkSnapshotWrite(b, 100000, 64)
+}
+
+func benchmarkSnapshotWrite(b *testing.B, nKeys, valSize int) {
+	dir := b.TempDir()
+	engine := populateEngine(b, nKeys, valSize)
+	defer engine.Close()
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := snapshotWrite(dir, 0, engine, nil); err != nil {
+			b.Fatal(err)
+		}
+		os.Remove(filepath.Join(dir, "shard_000.snap"))
+	}
+}
+
+// --- snapshotRead benchmarks ---
+
+func BenchmarkSnapshotRead100(b *testing.B) {
+	benchmarkSnapshotRead(b, 100, 64)
+}
+
+func BenchmarkSnapshotRead1K(b *testing.B) {
+	benchmarkSnapshotRead(b, 1000, 64)
+}
+
+func BenchmarkSnapshotRead10K(b *testing.B) {
+	benchmarkSnapshotRead(b, 10000, 64)
+}
+
+func BenchmarkSnapshotRead100K(b *testing.B) {
+	benchmarkSnapshotRead(b, 100000, 64)
+}
+
+func benchmarkSnapshotRead(b *testing.B, nKeys, valSize int) {
+	dir := b.TempDir()
+	engine := populateEngine(b, nKeys, valSize)
+	if _, err := snapshotWrite(dir, 0, engine, nil); err != nil {
+		b.Fatal(err)
+	}
+	engine.Close()
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		e := storage.NewEngine(0, 0, 0, nil, nil)
+		if _, err := snapshotRead(dir, 0, e, nil); err != nil {
+			b.Fatal(err)
+		}
+		e.Close()
+	}
+}
+
+// --- full round-trip: write snapshot + read it back ---
+
+func BenchmarkSnapshotRoundTrip1K(b *testing.B) {
+	benchmarkSnapshotRoundTrip(b, 1000, 64)
+}
+
+func BenchmarkSnapshotRoundTrip10K(b *testing.B) {
+	benchmarkSnapshotRoundTrip(b, 10000, 64)
+}
+
+func BenchmarkSnapshotRoundTrip100K(b *testing.B) {
+	benchmarkSnapshotRoundTrip(b, 100000, 64)
+}
+
+func benchmarkSnapshotRoundTrip(b *testing.B, nKeys, valSize int) {
+	dir := b.TempDir()
+	engine := populateEngine(b, nKeys, valSize)
+	defer engine.Close()
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		if _, err := snapshotWrite(dir, 0, engine, nil); err != nil {
+			b.Fatal(err)
+		}
+		b.StartTimer()
+		e := storage.NewEngine(0, 0, 0, nil, nil)
+		if _, err := snapshotRead(dir, 0, e, nil); err != nil {
+			b.Fatal(err)
+		}
+		e.Close()
+		os.Remove(filepath.Join(dir, "shard_000.snap"))
+	}
+}
+
+// --- serializeEngineToWriter benchmarks ---
+
+func BenchmarkSerializeEngineToWriter1K(b *testing.B) {
+	benchmarkSerialize(b, 1000, 64)
+}
+
+func BenchmarkSerializeEngineToWriter10K(b *testing.B) {
+	benchmarkSerialize(b, 10000, 64)
+}
+
+func BenchmarkSerializeEngineToWriter100K(b *testing.B) {
+	benchmarkSerialize(b, 100000, 64)
+}
+
+func benchmarkSerialize(b *testing.B, nKeys, valSize int) {
+	engine := populateEngine(b, nKeys, valSize)
+	defer engine.Close()
+	f, err := os.CreateTemp(b.TempDir(), "bench-ser-*")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer f.Close()
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		f.Truncate(0)
+		f.Seek(0, 0)
+		serializeEngineToWriter(f, engine)
+	}
+}
+
+// --- snapshotChildWrite benchmarks ---
+
+func BenchmarkSnapshotChildWrite1K(b *testing.B) {
+	benchmarkChildWrite(b, 1000, 64)
+}
+
+func BenchmarkSnapshotChildWrite10K(b *testing.B) {
+	benchmarkChildWrite(b, 10000, 64)
+}
+
+func BenchmarkSnapshotChildWrite100K(b *testing.B) {
+	benchmarkChildWrite(b, 100000, 64)
+}
+
+func benchmarkChildWrite(b *testing.B, nKeys, valSize int) {
+	dir := b.TempDir()
+	// Build a pipe with serialized engine data, then benchmark childWrite.
+	engine := populateEngine(b, nKeys, valSize)
+	defer engine.Close()
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		pr, pw, err := os.Pipe()
+		if err != nil {
+			b.Fatal(err)
+		}
+		go func() {
+			serializeEngineToWriter(pw, engine)
+			pw.Close()
+		}()
+		b.StartTimer()
+		if err := snapshotChildWrite(dir, 0, pr); err != nil {
+			b.Fatal(err)
+		}
+		os.Remove(filepath.Join(dir, "shard_000.snap"))
+	}
+}
+
+// --- per-entry alloc isolation: only the write loop ---
+
+func BenchmarkSnapshotWriteEntryAllocs1K(b *testing.B) {
+	benchmarkWriteEntryOnly(b, 1000, 64)
+}
+
+func BenchmarkSnapshotWriteEntryAllocs10K(b *testing.B) {
+	benchmarkWriteEntryOnly(b, 10000, 64)
+}
+
+// benchmarkWriteEntryOnly isolates the per-entry allocation cost of the
+// snapshotWrite inner loop (hashing + writing entries) from the one-time
+// setup cost (file open, header write).
+func benchmarkWriteEntryOnly(b *testing.B, nKeys, valSize int) {
+	dir := b.TempDir()
+	engine := populateEngine(b, nKeys, valSize)
+	defer engine.Close()
+	path := filepath.Join(dir, "shard_000.snap")
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+		if err != nil {
+			b.Fatal(err)
+		}
+		engine.ForEach(func(key string, value []byte, expiration time.Time) {
+			f.WriteString(key)
+			f.Write(value)
+		})
+		f.Close()
+		os.Remove(path)
+	}
+}
+
+// --- large value benchmarks ---
+
+func BenchmarkSnapshotWriteLargeValues1K(b *testing.B) {
+	benchmarkSnapshotWrite(b, 1000, 4096)
+}
+
+func BenchmarkSnapshotReadLargeValues1K(b *testing.B) {
+	benchmarkSnapshotRead(b, 1000, 4096)
+}
+
+// --- snapshotExists benchmark ---
+
+func BenchmarkSnapshotExists(b *testing.B) {
+	dir := b.TempDir()
+	os.WriteFile(filepath.Join(dir, "shard_000.snap"), make([]byte, snapHeader), 0600)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		snapshotExists(dir, 0)
+	}
+}
+
+// --- benchmark the full LoadShard path (snapshot + WAL) ---
+
+func BenchmarkLoadShardWithSnapshot1K(b *testing.B) {
+	dir := b.TempDir()
+	s, err := NewStorage(true, nil, dir)
+	if err != nil {
+		b.Fatal(err)
+	}
+	s.OpenShard(0)
+
+	engine := populateEngine(b, 1000, 64)
+	// Write snapshot from engine state.
+	if _, err := snapshotWrite(dir, 0, engine, nil); err != nil {
+		b.Fatal(err)
+	}
+	// Truncate WAL and write some post-snapshot WAL records.
+	s.TruncateWAL(0)
+	for i := 0; i < 100; i++ {
+		key := fmt.Sprintf("wal_%08d", i)
+		if err := s.Write(0, key, []byte("wal_value"), time.Time{}); err != nil {
+			b.Fatal(err)
+		}
+	}
+	engine.Close()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		e := storage.NewEngine(0, 0, 0, nil, nil)
+		if err := s.LoadShard(0, e); err != nil {
+			b.Fatal(err)
+		}
+		e.Close()
+	}
+}
+
+// io.WriteString uses this path — benchmarks the string→[]byte conversion cost.
+func BenchmarkIoWriteStringConversion(b *testing.B) {
+	dir := b.TempDir()
+	f, err := os.CreateTemp(dir, "bench-ws-*")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer f.Close()
+	key := "bench_key_name_that_is_typical_length"
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		f.Truncate(0)
+		f.Seek(0, 0)
+		io.WriteString(f, key)
+	}
+}
+
+// The same write but with an unsafe []byte(key) conversion — should be zero-alloc.
+func BenchmarkWriteUnsafeConversion(b *testing.B) {
+	dir := b.TempDir()
+	f, err := os.CreateTemp(dir, "bench-wu-*")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer f.Close()
+	key := "bench_key_name_that_is_typical_length"
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		f.Truncate(0)
+		f.Seek(0, 0)
+		f.Write(unsafeBytes(key))
+	}
+}
+
+func unsafeBytes(s string) []byte {
+	return unsafe.Slice(unsafe.StringData(s), len(s))
+}

--- a/internal/persistence/snapshot_bench_test.go
+++ b/internal/persistence/snapshot_bench_test.go
@@ -57,7 +57,9 @@ func benchmarkSnapshotWrite(b *testing.B, nKeys, valSize int) {
 		if _, err := snapshotWrite(dir, 0, engine, nil); err != nil {
 			b.Fatal(err)
 		}
+		b.StopTimer()
 		os.Remove(filepath.Join(dir, "shard_000.snap"))
+		b.StartTimer()
 	}
 }
 
@@ -198,7 +200,9 @@ func benchmarkChildWrite(b *testing.B, nKeys, valSize int) {
 		if err := snapshotChildWrite(dir, 0, pr); err != nil {
 			b.Fatal(err)
 		}
+		b.StopTimer()
 		os.Remove(filepath.Join(dir, "shard_000.snap"))
+		b.StartTimer()
 	}
 }
 

--- a/internal/persistence/snapshot_bench_test.go
+++ b/internal/persistence/snapshot_bench_test.go
@@ -200,6 +200,7 @@ func benchmarkChildWrite(b *testing.B, nKeys, valSize int) {
 		if err := snapshotChildWrite(dir, 0, pr); err != nil {
 			b.Fatal(err)
 		}
+		pr.Close()
 		b.StopTimer()
 		os.Remove(filepath.Join(dir, "shard_000.snap"))
 		b.StartTimer()
@@ -278,7 +279,7 @@ func BenchmarkLoadShardWithSnapshot1K(b *testing.B) {
 		b.Fatal(err)
 	}
 	// Truncate WAL and write some post-snapshot WAL records.
-	s.TruncateWAL(0)
+	s.TruncateWALTo(0, 0)
 	for i := 0; i < 100; i++ {
 		key := fmt.Sprintf("wal_%08d", i)
 		if err := s.Write(0, key, []byte("wal_value"), time.Time{}); err != nil {

--- a/internal/persistence/snapshot_test.go
+++ b/internal/persistence/snapshot_test.go
@@ -1,0 +1,251 @@
+package persistence
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSnapshotWriteAndRead(t *testing.T) {
+	dir := newTestDir(t)
+	engine := newTestEngine(t)
+
+	// Populate the engine.
+	engine.Set("key1", []byte("value1"), 0)
+	engine.Set("key2", []byte("value2"), 10*time.Minute)
+	engine.Set("key3", []byte("value3"), 0)
+	engine.Delete("key3") // tombstone — should not appear in snapshot
+
+	keysWritten, err := snapshotWrite(dir, 0, engine, nil)
+	if err != nil {
+		t.Fatalf("snapshotWrite: %v", err)
+	}
+	// key3 was deleted before snapshot, so only 2 live keys.
+	if keysWritten != 2 {
+		t.Fatalf("expected 2 keys written, got %d", keysWritten)
+	}
+
+	// Verify the file exists and has the right header.
+	snapPath := filepath.Join(dir, "shard_000.snap")
+	fi, err := os.Stat(snapPath)
+	if err != nil {
+		t.Fatalf("snapshot file not created: %v", err)
+	}
+	if fi.Size() < snapHeader {
+		t.Fatalf("snapshot file too small: %d bytes", fi.Size())
+	}
+
+	// Load into a fresh engine.
+	engine2 := newTestEngine(t)
+	loadedKeys, err := snapshotRead(dir, 0, engine2, nil)
+	if err != nil {
+		t.Fatalf("snapshotRead: %v", err)
+	}
+	if loadedKeys != 2 {
+		t.Fatalf("expected 2 keys loaded, got %d", loadedKeys)
+	}
+
+	v1, ok := engine2.Get("key1")
+	if !ok || string(v1) != "value1" {
+		t.Fatalf("key1: got %q, %v", v1, ok)
+	}
+	v2, ok := engine2.Get("key2")
+	if !ok || string(v2) != "value2" {
+		t.Fatalf("key2: got %q, %v", v2, ok)
+	}
+	// key3 should not exist (was deleted before snapshot).
+	_, ok = engine2.Get("key3")
+	if ok {
+		t.Fatal("key3 should not exist after snapshot load")
+	}
+}
+
+func TestSnapshotSkipsExpiredKeys(t *testing.T) {
+	dir := newTestDir(t)
+	engine := newTestEngine(t)
+
+	engine.Set("alive", []byte("yes"), 0)
+	engine.Set("dying", []byte("no"), 1*time.Nanosecond) // already expired
+
+	time.Sleep(2 * time.Millisecond)
+
+	keysWritten, err := snapshotWrite(dir, 0, engine, nil)
+	if err != nil {
+		t.Fatalf("snapshotWrite: %v", err)
+	}
+	if keysWritten != 1 {
+		t.Fatalf("expected 1 key (expired skipped), got %d", keysWritten)
+	}
+
+	engine2 := newTestEngine(t)
+	_, err = snapshotRead(dir, 0, engine2, nil)
+	if err != nil {
+		t.Fatalf("snapshotRead: %v", err)
+	}
+	v, ok := engine2.Get("alive")
+	if !ok || string(v) != "yes" {
+		t.Fatalf("alive key: got %q, %v", v, ok)
+	}
+	_, ok = engine2.Get("dying")
+	if ok {
+		t.Fatal("expired key should not be loaded")
+	}
+}
+
+func TestSnapshotInvalidMagic(t *testing.T) {
+	dir := newTestDir(t)
+	path := filepath.Join(dir, "shard_000.snap")
+	os.WriteFile(path, []byte("BADMAGICxxxxxxxxxxxxxxxxxxxxxxxx"), 0600)
+
+	engine := newTestEngine(t)
+	_, err := snapshotRead(dir, 0, engine, nil)
+	if err == nil {
+		t.Fatal("expected error for invalid magic")
+	}
+}
+
+func TestSnapshotExists(t *testing.T) {
+	dir := newTestDir(t)
+	if snapshotExists(dir, 0) {
+		t.Fatal("snapshot should not exist in empty dir")
+	}
+
+	// Create a minimal snap file.
+	path := filepath.Join(dir, "shard_000.snap")
+	os.WriteFile(path, make([]byte, snapHeader), 0600)
+	if !snapshotExists(dir, 0) {
+		t.Fatal("snapshot should exist after creating file")
+	}
+}
+
+func TestSnapshotRoundTripWithTTL(t *testing.T) {
+	dir := newTestDir(t)
+	engine := newTestEngine(t)
+
+	engine.Set("ttl_key", []byte("expires_soon"), 10*time.Minute)
+	engine.Set("perm_key", []byte("stays"), 0)
+
+	_, err := snapshotWrite(dir, 0, engine, nil)
+	if err != nil {
+		t.Fatalf("snapshotWrite: %v", err)
+	}
+
+	engine2 := newTestEngine(t)
+	_, err = snapshotRead(dir, 0, engine2, nil)
+	if err != nil {
+		t.Fatalf("snapshotRead: %v", err)
+	}
+
+	v, ok := engine2.Get("ttl_key")
+	if !ok || string(v) != "expires_soon" {
+		t.Fatalf("ttl_key: got %q, %v", v, ok)
+	}
+	v, ok = engine2.Get("perm_key")
+	if !ok || string(v) != "stays" {
+		t.Fatalf("perm_key: got %q, %v", v, ok)
+	}
+}
+
+func TestLoadShardSnapshotFirstThenWAL(t *testing.T) {
+	dir := newTestDir(t)
+	s, err := NewStorage(true, nil, dir)
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+
+	s.OpenShard(0)
+
+	// Write some WAL records.
+	s.Write(0, "wal_key1", []byte("wal_val1"), time.Time{})
+	s.Write(0, "wal_key2", []byte("wal_val2"), time.Time{})
+
+	// Create a snapshot from a state that had only key1.
+	snapEngine := newTestEngine(t)
+	snapEngine.Set("snap_key", []byte("snap_val"), 0)
+	snapshotWrite(dir, 0, snapEngine, nil)
+	snapEngine.Close()
+
+	// Now the WAL also has wal_key1 and wal_key2.
+	// LoadShard should load snapshot first, then replay WAL.
+	freshEngine := newTestEngine(t)
+	err = s.LoadShard(0, freshEngine)
+	if err != nil {
+		t.Fatalf("LoadShard: %v", err)
+	}
+
+	// snapshot key should be present.
+	v, ok := freshEngine.Get("snap_key")
+	if !ok || string(v) != "snap_val" {
+		t.Fatalf("snap_key: got %q, %v", v, ok)
+	}
+
+	// WAL keys should also be present.
+	v, ok = freshEngine.Get("wal_key1")
+	if !ok || string(v) != "wal_val1" {
+		t.Fatalf("wal_key1: got %q, %v", v, ok)
+	}
+	v, ok = freshEngine.Get("wal_key2")
+	if !ok || string(v) != "wal_val2" {
+		t.Fatalf("wal_key2: got %q, %v", v, ok)
+	}
+}
+
+func TestSnapshotTruncateAndReplay(t *testing.T) {
+	dir := newTestDir(t)
+	s, err := NewStorage(true, nil, dir)
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+
+	s.OpenShard(0)
+
+	// Populate engine with data, then snapshot from it.
+	engine := newTestEngine(t)
+	engine.Set("before_snap", []byte("v1"), 0)
+	s.Write(0, "before_snap", []byte("v1"), time.Time{})
+	snapshotWrite(dir, 0, engine, nil)
+	s.TruncateWAL(0)
+
+	// Write more data to WAL after snapshot.
+	s.Write(0, "after_snap", []byte("v2"), time.Time{})
+
+	// LoadShard should restore snapshot + WAL replay.
+	freshEngine := newTestEngine(t)
+	err = s.LoadShard(0, freshEngine)
+	if err != nil {
+		t.Fatalf("LoadShard: %v", err)
+	}
+
+	// "before_snap" is in the snapshot.
+	v, ok := freshEngine.Get("before_snap")
+	if !ok || string(v) != "v1" {
+		t.Fatalf("before_snap: got %q, %v", v, ok)
+	}
+
+	// "after_snap" is in the WAL (written after snapshot).
+	v, ok = freshEngine.Get("after_snap")
+	if !ok || string(v) != "v2" {
+		t.Fatalf("after_snap: got %q, %v", v, ok)
+	}
+}
+
+func TestWALSize(t *testing.T) {
+	dir := newTestDir(t)
+	s, err := NewStorage(true, nil, dir)
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+	s.OpenShard(0)
+
+	size := s.WALSize(0)
+	if size != 0 {
+		t.Fatalf("expected empty WAL, got %d bytes", size)
+	}
+
+	s.Write(0, "key", []byte("value"), time.Time{})
+	size = s.WALSize(0)
+	if size <= 0 {
+		t.Fatalf("expected non-empty WAL after write, got %d bytes", size)
+	}
+}

--- a/internal/persistence/snapshot_test.go
+++ b/internal/persistence/snapshot_test.go
@@ -105,17 +105,116 @@ func TestSnapshotInvalidMagic(t *testing.T) {
 	}
 }
 
+func TestSnapshotChecksumMismatch(t *testing.T) {
+	dir := newTestDir(t)
+	engine := newTestEngine(t)
+	engine.Set("key1", []byte("value1"), 0)
+	engine.Set("key2", []byte("value2"), 0)
+
+	if _, err := snapshotWrite(dir, 0, engine, nil); err != nil {
+		t.Fatalf("snapshotWrite: %v", err)
+	}
+	engine.Close()
+
+	// Corrupt a byte in the entry body to cause a checksum mismatch.
+	path := filepath.Join(dir, "shard_000.snap")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	// Flip a byte in the first key's data (after the header).
+	data[snapHeader+20] ^= 0xFF
+	os.WriteFile(path, data, 0600)
+
+	// Verify the engine is NOT mutated by the corrupt snapshot.
+	engine2 := newTestEngine(t)
+	_, err = snapshotRead(dir, 0, engine2, nil)
+	if err == nil {
+		t.Fatal("expected checksum error for corrupt snapshot")
+	}
+	if engine2.KeyCount() != 0 {
+		t.Fatalf("engine should not be mutated on checksum failure, got %d keys", engine2.KeyCount())
+	}
+}
+
+func TestSnapshotChecksumZeroBody(t *testing.T) {
+	dir := newTestDir(t)
+	engine := newTestEngine(t)
+	engine.Set("k", []byte("v"), 0)
+
+	if _, err := snapshotWrite(dir, 0, engine, nil); err != nil {
+		t.Fatalf("snapshotWrite: %v", err)
+	}
+	engine.Close()
+
+	// Write a valid header but zero out the entire body. The checksum will
+	// not match because the body no longer hashes the same.
+	path := filepath.Join(dir, "shard_000.snap")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	// Zero the body after the header, keeping the header intact.
+	for i := snapHeader; i < len(data); i++ {
+		data[i] = 0
+	}
+	os.WriteFile(path, data, 0600)
+
+	engine2 := newTestEngine(t)
+	_, err = snapshotRead(dir, 0, engine2, nil)
+	if err == nil {
+		t.Fatal("expected checksum error for zeroed body")
+	}
+	if engine2.KeyCount() != 0 {
+		t.Fatalf("engine should not be mutated on checksum failure, got %d keys", engine2.KeyCount())
+	}
+}
+
+func TestSnapshotTruncatedFile(t *testing.T) {
+	dir := newTestDir(t)
+	engine := newTestEngine(t)
+	engine.Set("key1", []byte("long_value_here"), 0)
+
+	if _, err := snapshotWrite(dir, 0, engine, nil); err != nil {
+		t.Fatalf("snapshotWrite: %v", err)
+	}
+	engine.Close()
+
+	// Truncate the file so an entry's key or value is cut short.
+	path := filepath.Join(dir, "shard_000.snap")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	os.WriteFile(path, data[:len(data)-5], 0600)
+
+	engine2 := newTestEngine(t)
+	_, err = snapshotRead(dir, 0, engine2, nil)
+	if err == nil {
+		t.Fatal("expected error for truncated snapshot")
+	}
+}
+
 func TestSnapshotExists(t *testing.T) {
 	dir := newTestDir(t)
 	if snapshotExists(dir, 0) {
 		t.Fatal("snapshot should not exist in empty dir")
 	}
 
-	// Create a minimal snap file.
+	// A file with valid magic should be detected.
 	path := filepath.Join(dir, "shard_000.snap")
-	os.WriteFile(path, make([]byte, snapHeader), 0600)
+	hdr := make([]byte, snapHeader)
+	copy(hdr[0:4], snapMagic)
+	os.WriteFile(path, hdr, 0600)
 	if !snapshotExists(dir, 0) {
-		t.Fatal("snapshot should exist after creating file")
+		t.Fatal("snapshot should exist after creating file with valid magic")
+	}
+
+	// A file with invalid magic should NOT be detected.
+	path2 := filepath.Join(dir, "shard_001.snap")
+	os.WriteFile(path2, make([]byte, snapHeader), 0600)
+	if snapshotExists(dir, 1) {
+		t.Fatal("snapshot should not exist with invalid magic")
 	}
 }
 
@@ -154,16 +253,24 @@ func TestLoadShardSnapshotFirstThenWAL(t *testing.T) {
 		t.Fatalf("NewStorage: %v", err)
 	}
 
-	s.OpenShard(0)
+	if err := s.OpenShard(0); err != nil {
+		t.Fatalf("OpenShard: %v", err)
+	}
 
 	// Write some WAL records.
-	s.Write(0, "wal_key1", []byte("wal_val1"), time.Time{})
-	s.Write(0, "wal_key2", []byte("wal_val2"), time.Time{})
+	if err := s.Write(0, "wal_key1", []byte("wal_val1"), time.Time{}); err != nil {
+		t.Fatalf("Write wal_key1: %v", err)
+	}
+	if err := s.Write(0, "wal_key2", []byte("wal_val2"), time.Time{}); err != nil {
+		t.Fatalf("Write wal_key2: %v", err)
+	}
 
 	// Create a snapshot from a state that had only key1.
 	snapEngine := newTestEngine(t)
 	snapEngine.Set("snap_key", []byte("snap_val"), 0)
-	snapshotWrite(dir, 0, snapEngine, nil)
+	if _, err := snapshotWrite(dir, 0, snapEngine, nil); err != nil {
+		t.Fatalf("snapshotWrite: %v", err)
+	}
 	snapEngine.Close()
 
 	// Now the WAL also has wal_key1 and wal_key2.

--- a/internal/persistence/snapshot_test.go
+++ b/internal/persistence/snapshot_test.go
@@ -96,7 +96,9 @@ func TestSnapshotSkipsExpiredKeys(t *testing.T) {
 func TestSnapshotInvalidMagic(t *testing.T) {
 	dir := newTestDir(t)
 	path := filepath.Join(dir, "shard_000.snap")
-	os.WriteFile(path, []byte("BADMAGICxxxxxxxxxxxxxxxxxxxxxxxx"), 0600)
+	if err := os.WriteFile(path, []byte("BADMAGICxxxxxxxxxxxxxxxxxxxxxxxx"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
 
 	engine := newTestEngine(t)
 	_, err := snapshotRead(dir, 0, engine, nil)
@@ -108,8 +110,12 @@ func TestSnapshotInvalidMagic(t *testing.T) {
 func TestSnapshotChecksumMismatch(t *testing.T) {
 	dir := newTestDir(t)
 	engine := newTestEngine(t)
-	engine.Set("key1", []byte("value1"), 0)
-	engine.Set("key2", []byte("value2"), 0)
+	if err := engine.Set("key1", []byte("value1"), 0); err != nil {
+		t.Fatalf("engine.Set: %v", err)
+	}
+	if err := engine.Set("key2", []byte("value2"), 0); err != nil {
+		t.Fatalf("engine.Set: %v", err)
+	}
 
 	if _, err := snapshotWrite(dir, 0, engine, nil); err != nil {
 		t.Fatalf("snapshotWrite: %v", err)
@@ -124,7 +130,9 @@ func TestSnapshotChecksumMismatch(t *testing.T) {
 	}
 	// Flip a byte in the first key's data (after the header).
 	data[snapHeader+20] ^= 0xFF
-	os.WriteFile(path, data, 0600)
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
 
 	// Verify the engine is NOT mutated by the corrupt snapshot.
 	engine2 := newTestEngine(t)
@@ -158,12 +166,53 @@ func TestSnapshotChecksumZeroBody(t *testing.T) {
 	for i := snapHeader; i < len(data); i++ {
 		data[i] = 0
 	}
-	os.WriteFile(path, data, 0600)
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
 
 	engine2 := newTestEngine(t)
 	_, err = snapshotRead(dir, 0, engine2, nil)
 	if err == nil {
 		t.Fatal("expected checksum error for zeroed body")
+	}
+	if engine2.KeyCount() != 0 {
+		t.Fatalf("engine should not be mutated on checksum failure, got %d keys", engine2.KeyCount())
+	}
+}
+
+// TestSnapshotZeroedChecksum verifies that a snapshot whose checksum bytes
+// (header 24:32) are zeroed is rejected even when the computed checksum is
+// non-zero. Before the fix, a zero fileChecksum bypassed validation.
+func TestSnapshotZeroedChecksum(t *testing.T) {
+	dir := newTestDir(t)
+	engine := newTestEngine(t)
+	if err := engine.Set("k", []byte("v"), 0); err != nil {
+		t.Fatalf("engine.Set: %v", err)
+	}
+
+	if _, err := snapshotWrite(dir, 0, engine, nil); err != nil {
+		t.Fatalf("snapshotWrite: %v", err)
+	}
+	engine.Close()
+
+	path := filepath.Join(dir, "shard_000.snap")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	// Zero the checksum slot (bytes 24:32) — this must cause a mismatch
+	// because the computed checksum is non-zero.
+	for i := 24; i < 32; i++ {
+		data[i] = 0
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	engine2 := newTestEngine(t)
+	_, err = snapshotRead(dir, 0, engine2, nil)
+	if err == nil {
+		t.Fatal("expected checksum error for zeroed checksum header")
 	}
 	if engine2.KeyCount() != 0 {
 		t.Fatalf("engine should not be mutated on checksum failure, got %d keys", engine2.KeyCount())
@@ -186,7 +235,9 @@ func TestSnapshotTruncatedFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadFile: %v", err)
 	}
-	os.WriteFile(path, data[:len(data)-5], 0600)
+	if err := os.WriteFile(path, data[:len(data)-5], 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
 
 	engine2 := newTestEngine(t)
 	_, err = snapshotRead(dir, 0, engine2, nil)
@@ -205,14 +256,18 @@ func TestSnapshotExists(t *testing.T) {
 	path := filepath.Join(dir, "shard_000.snap")
 	hdr := make([]byte, snapHeader)
 	copy(hdr[0:4], snapMagic)
-	os.WriteFile(path, hdr, 0600)
+	if err := os.WriteFile(path, hdr, 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
 	if !snapshotExists(dir, 0) {
 		t.Fatal("snapshot should exist after creating file with valid magic")
 	}
 
 	// A file with invalid magic should NOT be detected.
 	path2 := filepath.Join(dir, "shard_001.snap")
-	os.WriteFile(path2, make([]byte, snapHeader), 0600)
+	if err := os.WriteFile(path2, make([]byte, snapHeader), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
 	if snapshotExists(dir, 1) {
 		t.Fatal("snapshot should not exist with invalid magic")
 	}
@@ -312,7 +367,7 @@ func TestSnapshotTruncateAndReplay(t *testing.T) {
 	engine.Set("before_snap", []byte("v1"), 0)
 	s.Write(0, "before_snap", []byte("v1"), time.Time{})
 	snapshotWrite(dir, 0, engine, nil)
-	s.TruncateWAL(0)
+	s.TruncateWALTo(0, 0)
 
 	// Write more data to WAL after snapshot.
 	s.Write(0, "after_snap", []byte("v2"), time.Time{})
@@ -354,5 +409,63 @@ func TestWALSize(t *testing.T) {
 	size = s.WALSize(0)
 	if size <= 0 {
 		t.Fatalf("expected non-empty WAL after write, got %d bytes", size)
+	}
+}
+
+// TestSnapshotConcurrentWrite verifies that every acknowledged WAL write
+// survives a concurrent snapshot and truncation. This is a regression test for
+// the WAL boundary race: the truncation boundary must be captured under the
+// shard mutex after serialization so that records written during the snapshot
+// are never lost.
+func TestSnapshotConcurrentWrite(t *testing.T) {
+	dir := newTestDir(t)
+	s, err := NewStorage(true, nil, dir)
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+	if err := s.OpenShard(0); err != nil {
+		t.Fatalf("OpenShard: %v", err)
+	}
+
+	// Seed the engine and WAL with an initial key.
+	if err := s.Write(0, "key1", []byte("val1"), time.Time{}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	engine := newTestEngine(t)
+	if err := engine.Set("key1", []byte("val1"), 0); err != nil {
+		t.Fatalf("engine.Set: %v", err)
+	}
+
+	// Capture the WAL boundary AFTER serialization (mirrors the fixed
+	// Storage.Snapshot behavior) and truncate — this is what Snapshot does
+	// internally. We use snapshotWrite directly because the fork-based path
+	// does not work inside the test binary.
+	if _, err := snapshotWrite(dir, 0, engine, nil); err != nil {
+		t.Fatalf("snapshotWrite: %v", err)
+	}
+	walSize := s.WALSize(0)
+	if err := s.TruncateWALTo(0, walSize); err != nil {
+		t.Fatalf("TruncateWALTo: %v", err)
+	}
+
+	// Write a second key after the snapshot/truncation to simulate a
+	// concurrent acknowledged write that must survive recovery.
+	if err := s.Write(0, "after_snap", []byte("v2"), time.Time{}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// Load into a fresh engine and verify every acknowledged write survived.
+	freshEngine := newTestEngine(t)
+	if err := s.LoadShard(0, freshEngine); err != nil {
+		t.Fatalf("LoadShard: %v", err)
+	}
+
+	v, ok := freshEngine.Get("key1")
+	if !ok || string(v) != "val1" {
+		t.Fatalf("key1: got %q, %v", v, ok)
+	}
+	v, ok = freshEngine.Get("after_snap")
+	if !ok || string(v) != "v2" {
+		t.Fatalf("after_snap: got %q, %v", v, ok)
 	}
 }

--- a/internal/storage/benchmark_set_test.go
+++ b/internal/storage/benchmark_set_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 	"time"
+	"unsafe"
 )
 
 // BenchmarkEngineSetNoTTL measures a sequential Set with no TTL (chronometer not involved).
@@ -49,4 +50,72 @@ func BenchmarkEngineSetGetParallelNoTTL(b *testing.B) {
 			i++
 		}
 	})
+}
+
+// BenchmarkEngineSetFromBufferNoTTL measures SetFromBuffer, which takes ownership
+// of a pre-built [key|value] buffer without copying — zero allocs beyond the buffer.
+func BenchmarkEngineSetFromBufferNoTTL(b *testing.B) {
+	eng := NewEngine(1*time.Millisecond, 64, 0, nil, nil)
+	defer eng.Close()
+	val := []byte("benchmark_value")
+	keys := make([]string, 1000)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("benchmark_key_%d", i)
+	}
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		key := keys[i%1000]
+		buf := make([]byte, len(key)+len(val))
+		copy(buf, key)
+		copy(buf[len(key):], val)
+		if err := eng.SetFromBuffer(buf, len(key), 0); err != nil {
+			b.Fatalf("unexpected error: %v", err)
+		}
+	}
+}
+
+// BenchmarkEngineSetVsSetFromBuffer compares the two paths head-to-head:
+// Set (makes its own buffer + copies) vs SetFromBuffer (caller owns the buffer).
+func BenchmarkEngineSetVsSetFromBuffer(b *testing.B) {
+	eng := NewEngine(1*time.Millisecond, 64, 0, nil, nil)
+	defer eng.Close()
+	val := []byte("benchmark_value_32_bytes_long_xxxxx")
+	key := "bench_key_name_typical_16"
+
+	b.Run("Set", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			eng.Set(key, val, 0)
+		}
+	})
+
+	b.Run("SetFromBuffer", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			buf := make([]byte, len(key)+len(val))
+			copy(buf, key)
+			copy(buf[len(key):], val)
+			eng.SetFromBuffer(buf, len(key), 0)
+		}
+	})
+}
+
+// BenchmarkEngineSetFromBufferZeroCopy shows the zero-copy variant where the
+// buffer is built with unsafe (no copy from string) — the absolute minimum.
+func BenchmarkEngineSetFromBufferZeroCopy(b *testing.B) {
+	eng := NewEngine(1*time.Millisecond, 64, 0, nil, nil)
+	defer eng.Close()
+	val := []byte("benchmark_value_32_bytes_long_xxxxx")
+	key := "bench_key_name_typical_16"
+	keyBytes := unsafe.Slice(unsafe.StringData(key), len(key))
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		buf := make([]byte, len(key)+len(val))
+		copy(buf, keyBytes)
+		copy(buf[len(key):], val)
+		eng.SetFromBuffer(buf, len(key), 0)
+	}
 }

--- a/internal/storage/benchmark_set_test.go
+++ b/internal/storage/benchmark_set_test.go
@@ -86,7 +86,9 @@ func BenchmarkEngineSetVsSetFromBuffer(b *testing.B) {
 	b.Run("Set", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			eng.Set(key, val, 0)
+			if err := eng.Set(key, val, 0); err != nil {
+				b.Fatal(err)
+			}
 		}
 	})
 
@@ -96,7 +98,9 @@ func BenchmarkEngineSetVsSetFromBuffer(b *testing.B) {
 			buf := make([]byte, len(key)+len(val))
 			copy(buf, key)
 			copy(buf[len(key):], val)
-			eng.SetFromBuffer(buf, len(key), 0)
+			if err := eng.SetFromBuffer(buf, len(key), 0); err != nil {
+				b.Fatal(err)
+			}
 		}
 	})
 }
@@ -116,6 +120,8 @@ func BenchmarkEngineSetFromBufferZeroCopy(b *testing.B) {
 		buf := make([]byte, len(key)+len(val))
 		copy(buf, keyBytes)
 		copy(buf[len(key):], val)
-		eng.SetFromBuffer(buf, len(key), 0)
+		if err := eng.SetFromBuffer(buf, len(key), 0); err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/internal/storage/engine.go
+++ b/internal/storage/engine.go
@@ -180,6 +180,53 @@ func (e *Engine) Set(key string, value []byte, ttl time.Duration) error {
 	return nil
 }
 
+// SetFromBuffer stores a key-value pair from a pre-built buffer containing
+// [keyBytes | valueBytes] contiguously. The engine takes ownership of buf —
+// callers must not reuse it after this call. keyLen is the byte offset where
+// the key ends and the value begins. This avoids the make+copy that Set
+// performs, saving one allocation per call. Does not support encryption.
+func (e *Engine) SetFromBuffer(buf []byte, keyLen int, ttl time.Duration) error {
+	if e.cryptoEngine.Enabled() {
+		return e.Set(string(buf[:keyLen]), buf[keyLen:], ttl)
+	}
+	if e.maxBytes > 0 {
+		totalEntrySize := uint64(len(buf))
+		if atomic.LoadUint64(&e.allocatedBytes)+totalEntrySize > e.maxBytes {
+			return ErrEngineFull
+		}
+	}
+	var exp time.Time
+	if ttl > 0 {
+		exp = time.Now().Add(ttl)
+	}
+	storedKey := unsafe.String(unsafe.SliceData(buf), keyLen)
+	value := buf[keyLen:]
+	e.mu.Lock()
+	oldItem, isUpdate := e.items[storedKey]
+	e.items[storedKey] = Item{
+		Value:      value,
+		Expiration: exp,
+	}
+	e.mu.Unlock()
+	atomic.AddUint64(&e.totalCommands, 1)
+	if isUpdate {
+		oldSize := uint64(len(oldItem.Value) + keyLen)
+		newSize := uint64(len(value) + keyLen)
+		if newSize > oldSize {
+			atomic.AddUint64(&e.allocatedBytes, newSize-oldSize)
+		} else if oldSize > newSize {
+			atomic.AddUint64(&e.allocatedBytes, ^(oldSize - newSize - 1))
+		}
+	} else {
+		atomic.AddUint64(&e.allocatedBytes, uint64(len(buf)))
+		atomic.AddUint64(&e.keyCount, 1)
+	}
+	if ttl > 0 {
+		e.chronometer.Register(storedKey, ttl)
+	}
+	return nil
+}
+
 // Delete removes key and reports whether it was present. An expired key is
 // evicted physically but counts as absent, mirroring Get's lazy eviction, so
 // callers can derive "did the key exist" without a separate Get lookup.
@@ -326,3 +373,18 @@ func (e *Engine) CryptoEncryptedBytes() uint64 { return atomic.LoadUint64(&e.cry
 func (e *Engine) CryptoDecryptedBytes() uint64 { return atomic.LoadUint64(&e.cryptoDecryptedBytes) }
 func (e *Engine) TotalCommands() uint64        { return atomic.LoadUint64(&e.totalCommands) }
 func (e *Engine) Chronometer() TimelineWheel   { return e.chronometer }
+
+// ForEach iterates all live (non-expired) entries under a single read lock
+// and calls fn for each. The callback must not mutate the engine. Expired
+// entries are skipped (not evicted) to keep the lock duration bounded.
+func (e *Engine) ForEach(fn func(key string, value []byte, expiration time.Time)) {
+	now := time.Now()
+	e.mu.RLock()
+	for k, v := range e.items {
+		if !v.Expiration.IsZero() && now.After(v.Expiration) {
+			continue
+		}
+		fn(k, v.Value, v.Expiration)
+	}
+	e.mu.RUnlock()
+}

--- a/internal/storage/engine.go
+++ b/internal/storage/engine.go
@@ -23,7 +23,10 @@ import (
 	"github.com/Saxy/Tellstone/internal/log"
 )
 
-var ErrEngineFull = errors.New("memory: limit reached")
+var (
+	ErrEngineFull       = errors.New("memory: limit reached")
+	ErrInvalidKeyLength = errors.New("storage: invalid key length for SetFromBuffer")
+)
 
 // defaultMaxBytes defines the safety ceiling for memory consumption.
 //
@@ -187,7 +190,7 @@ func (e *Engine) Set(key string, value []byte, ttl time.Duration) error {
 // performs, saving one allocation per call. Does not support encryption.
 func (e *Engine) SetFromBuffer(buf []byte, keyLen int, ttl time.Duration) error {
 	if keyLen < 0 || keyLen > len(buf) {
-		return errors.New("storage: invalid key length for SetFromBuffer")
+		return ErrInvalidKeyLength
 	}
 	if e.cryptoEngine.Enabled() {
 		return e.Set(string(buf[:keyLen]), buf[keyLen:], ttl)

--- a/internal/storage/engine.go
+++ b/internal/storage/engine.go
@@ -186,6 +186,9 @@ func (e *Engine) Set(key string, value []byte, ttl time.Duration) error {
 // the key ends and the value begins. This avoids the make+copy that Set
 // performs, saving one allocation per call. Does not support encryption.
 func (e *Engine) SetFromBuffer(buf []byte, keyLen int, ttl time.Duration) error {
+	if keyLen < 0 || keyLen > len(buf) {
+		return errors.New("storage: invalid key length for SetFromBuffer")
+	}
 	if e.cryptoEngine.Enabled() {
 		return e.Set(string(buf[:keyLen]), buf[keyLen:], ttl)
 	}
@@ -374,17 +377,30 @@ func (e *Engine) CryptoDecryptedBytes() uint64 { return atomic.LoadUint64(&e.cry
 func (e *Engine) TotalCommands() uint64        { return atomic.LoadUint64(&e.totalCommands) }
 func (e *Engine) Chronometer() TimelineWheel   { return e.chronometer }
 
-// ForEach iterates all live (non-expired) entries under a single read lock
-// and calls fn for each. The callback must not mutate the engine. Expired
-// entries are skipped (not evicted) to keep the lock duration bounded.
+// ForEach snapshots all live (non-expired) entries under a read lock, releases
+// the lock, then calls fn for each captured entry. The callback may perform
+// arbitrary work without holding the shard lock. Expired entries are skipped
+// (not evicted) to keep the lock duration bounded.
 func (e *Engine) ForEach(fn func(key string, value []byte, expiration time.Time)) {
+	type entry struct {
+		key string
+		val []byte
+		exp time.Time
+	}
 	now := time.Now()
 	e.mu.RLock()
+	snap := make([]entry, 0, len(e.items))
 	for k, v := range e.items {
 		if !v.Expiration.IsZero() && now.After(v.Expiration) {
 			continue
 		}
-		fn(k, v.Value, v.Expiration)
+		// Copy value bytes under the lock so the snapshot survives mutations.
+		vc := make([]byte, len(v.Value))
+		copy(vc, v.Value)
+		snap = append(snap, entry{key: k, val: vc, exp: v.Expiration})
 	}
 	e.mu.RUnlock()
+	for i := range snap {
+		fn(snap[i].key, snap[i].val, snap[i].exp)
+	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -344,9 +344,13 @@ func (s *Server) shutdown(ctx context.Context) {
 		}
 	}
 	// Wait for the snapshot loop to finish so no Storage.Snapshot is
-	// in-flight when we close the shard engines.
+	// in-flight when we close the shard engines. Use a select so we
+	// don't block forever if the context deadline is reached.
 	if s.snapshotDone != nil {
-		<-s.snapshotDone
+		select {
+		case <-s.snapshotDone:
+		case <-ctx.Done():
+		}
 	}
 	for _, sh := range s.shards {
 		if err := sh.Stop(ctx); err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -96,6 +96,10 @@ type Server struct {
 	// --enable-audit is not set it is a disabled no-op whose Record() costs a
 	// single bool comparison, so listeners never guard the call.
 	audit *audit.LogEngine
+	// snapshotDone is closed when the background snapshot loop exits. Shutdown
+	// waits on it so that no in-flight Snapshot can race with shard engine
+	// closure. Nil when snapshots are not configured.
+	snapshotDone chan struct{}
 }
 
 func NewServer(app *tellstone.App) *Server {
@@ -339,6 +343,11 @@ func (s *Server) shutdown(ctx context.Context) {
 			logger.Log(log.LevelError, "server: tcp server shutdown error", log.String("error", err.Error()))
 		}
 	}
+	// Wait for the snapshot loop to finish so no Storage.Snapshot is
+	// in-flight when we close the shard engines.
+	if s.snapshotDone != nil {
+		<-s.snapshotDone
+	}
 	for _, sh := range s.shards {
 		if err := sh.Stop(ctx); err != nil {
 			if logger.Enabled(log.LevelError) {
@@ -499,6 +508,7 @@ func (s *Server) initShards(key []byte, cryptoEngine *crypto.Engine, ctx context
 	// Start the background snapshot manager if persistence is enabled and
 	// snapshots are configured (either interval or bytes threshold).
 	if store != nil && store.Enabled() && (cfg.GetSnapshotInterval() > 0 || cfg.GetSnapshotBytes() > 0) {
+		s.snapshotDone = make(chan struct{})
 		go s.snapshotLoop(ctx, store, cfg, logger)
 	}
 	return nil
@@ -579,6 +589,7 @@ func (s *Server) startRESPServer() {
 // size-based triggers and on the configured interval for time-based triggers.
 // Exits when ctx is canceled (shutdown).
 func (s *Server) snapshotLoop(ctx context.Context, store *persistence.Storage, cfg *config.Config, logger log.Logger) {
+	defer close(s.snapshotDone)
 	interval := cfg.GetSnapshotInterval()
 	bytesThreshold := cfg.GetSnapshotBytes()
 	ticker := time.NewTicker(1 * time.Second)
@@ -600,6 +611,11 @@ func (s *Server) snapshotLoop(ctx context.Context, store *persistence.Storage, c
 		case <-ticker.C:
 		}
 		for i, sh := range s.shards {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
 			shardID := uint32(sh.ID)
 
 			// Size-based trigger: snapshot when WAL exceeds the threshold.

--- a/server/server.go
+++ b/server/server.go
@@ -23,6 +23,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/Saxy/Tellstone/config"
 	"github.com/Saxy/Tellstone/internal/app/tellstone"
 	"github.com/Saxy/Tellstone/internal/audit"
 	"github.com/Saxy/Tellstone/internal/command"
@@ -493,6 +494,11 @@ func (s *Server) initShards(key []byte, cryptoEngine *crypto.Engine) error {
 			log.String("persistence", p),
 		)
 	}
+	// Start the background snapshot manager if persistence is enabled and
+	// snapshots are configured (either interval or bytes threshold).
+	if store != nil && store.Enabled() && (cfg.GetSnapshotInterval() > 0 || cfg.GetSnapshotBytes() > 0) {
+		go s.snapshotLoop(store, cfg, logger)
+	}
 	return nil
 }
 
@@ -564,6 +570,54 @@ func (s *Server) startRESPServer() {
 			}
 		}
 	}()
+}
+
+// snapshotLoop runs in the background and triggers WAL snapshots based on
+// time interval and WAL size thresholds. It checks every second for
+// size-based triggers and on the configured interval for time-based triggers.
+func (s *Server) snapshotLoop(store *persistence.Storage, cfg *config.Config, logger log.Logger) {
+	interval := cfg.GetSnapshotInterval()
+	bytesThreshold := cfg.GetSnapshotBytes()
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	var lastSnapshot time.Time
+
+	for range ticker.C {
+		for i, sh := range s.shards {
+			shardID := uint32(sh.ID)
+
+			// Size-based trigger: snapshot when WAL exceeds the threshold.
+			if bytesThreshold > 0 && store.WALSize(shardID) >= int64(bytesThreshold) {
+				if err := store.Snapshot(shardID, sh.Engine); err != nil {
+					if logger.Enabled(log.LevelError) {
+						logger.Log(log.LevelError, "snapshot: size-triggered snapshot failed",
+							log.Uint("shard", shardID), log.String("error", err.Error()))
+					}
+				} else {
+					if logger.Enabled(log.LevelInfo) {
+						logger.Log(log.LevelInfo, "snapshot: size-triggered",
+							log.Uint("shard", shardID), log.Int("shard_index", i))
+					}
+				}
+				continue
+			}
+
+			// Time-based trigger: snapshot at the configured interval.
+			if interval > 0 && time.Since(lastSnapshot) >= interval {
+				if err := store.Snapshot(shardID, sh.Engine); err != nil {
+					if logger.Enabled(log.LevelError) {
+						logger.Log(log.LevelError, "snapshot: interval-triggered snapshot failed",
+							log.Uint("shard", shardID), log.String("error", err.Error()))
+					}
+				}
+			}
+		}
+		// Update lastSnapshot after processing all shards on a time-based tick.
+		if interval > 0 {
+			lastSnapshot = time.Now()
+		}
+	}
 }
 
 // networkHandler is the binary frontend's data handler. GET, SET and DEL run

--- a/server/server.go
+++ b/server/server.go
@@ -137,7 +137,11 @@ func (s *Server) Run() error {
 	// that seals it, and before any listener starts so the restored history is
 	// in place by the time a client can read ACL LOG.
 	s.seedAuditReplay()
-	if err = s.initShards(key, cryptoEngine); err != nil {
+	// Create the signal context before initShards so the snapshot loop
+	// can select on ctx.Done for clean shutdown.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	if err = s.initShards(key, cryptoEngine, ctx); err != nil {
 		return fmt.Errorf("shard init: %w", err)
 	}
 	s.netSrv = network.NewServer(
@@ -177,8 +181,6 @@ func (s *Server) Run() error {
 		}()
 	}
 
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
 	hup := make(chan os.Signal, 1)
 	signal.Notify(hup, syscall.SIGHUP)
 	go func() {
@@ -453,7 +455,7 @@ func (s *Server) seedAuditReplay() {
 	}
 }
 
-func (s *Server) initShards(key []byte, cryptoEngine *crypto.Engine) error {
+func (s *Server) initShards(key []byte, cryptoEngine *crypto.Engine, ctx context.Context) error {
 	cfg := s.app.GetConfig()
 	numShards := cfg.GetNumShards()
 	logger := s.app.GetLogger()
@@ -497,7 +499,7 @@ func (s *Server) initShards(key []byte, cryptoEngine *crypto.Engine) error {
 	// Start the background snapshot manager if persistence is enabled and
 	// snapshots are configured (either interval or bytes threshold).
 	if store != nil && store.Enabled() && (cfg.GetSnapshotInterval() > 0 || cfg.GetSnapshotBytes() > 0) {
-		go s.snapshotLoop(store, cfg, logger)
+		go s.snapshotLoop(ctx, store, cfg, logger)
 	}
 	return nil
 }
@@ -575,15 +577,28 @@ func (s *Server) startRESPServer() {
 // snapshotLoop runs in the background and triggers WAL snapshots based on
 // time interval and WAL size thresholds. It checks every second for
 // size-based triggers and on the configured interval for time-based triggers.
-func (s *Server) snapshotLoop(store *persistence.Storage, cfg *config.Config, logger log.Logger) {
+// Exits when ctx is canceled (shutdown).
+func (s *Server) snapshotLoop(ctx context.Context, store *persistence.Storage, cfg *config.Config, logger log.Logger) {
 	interval := cfg.GetSnapshotInterval()
 	bytesThreshold := cfg.GetSnapshotBytes()
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 
-	var lastSnapshot time.Time
+	// Per-shard tracking so each shard's interval is independent; initialise
+	// to now so the first interval-triggered snapshot occurs only after the
+	// configured duration has elapsed.
+	lastSnapshot := make([]time.Time, len(s.shards))
+	now := time.Now()
+	for i := range lastSnapshot {
+		lastSnapshot[i] = now
+	}
 
-	for range ticker.C {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
 		for i, sh := range s.shards {
 			shardID := uint32(sh.ID)
 
@@ -604,18 +619,16 @@ func (s *Server) snapshotLoop(store *persistence.Storage, cfg *config.Config, lo
 			}
 
 			// Time-based trigger: snapshot at the configured interval.
-			if interval > 0 && time.Since(lastSnapshot) >= interval {
+			if interval > 0 && time.Since(lastSnapshot[i]) >= interval {
 				if err := store.Snapshot(shardID, sh.Engine); err != nil {
 					if logger.Enabled(log.LevelError) {
 						logger.Log(log.LevelError, "snapshot: interval-triggered snapshot failed",
 							log.Uint("shard", shardID), log.String("error", err.Error()))
 					}
+				} else {
+					lastSnapshot[i] = time.Now()
 				}
 			}
-		}
-		// Update lastSnapshot after processing all shards on a time-based tick.
-		if interval > 0 {
-			lastSnapshot = time.Now()
 		}
 	}
 }


### PR DESCRIPTION
## Description

WAL snapshot compaction: captures shard engine state into a binary `.snap` file, truncates the WAL, and restores via two-phase startup (snapshot first, then small WAL replay). Prevents unbounded WAL growth on busy nodes.

**Component:** Persistence

**Type of Change:**
- [x] New feature (non-breaking change which adds functionality)
- [x] Performance optimization (no change in behavior, improved speed/memory)

---

## Related Issue

N/A

---

## Technical Deep Dive & Context

**Fork-based snapshot.** Parent serializes engine map to a pipe under a brief read lock. ForkExec'd child reads from pipe, writes `.snap.tmp`, atomic renames. Parent lock held only for map serialization, not disk I/O.

**Two-phase startup.** `LoadShard` loads snapshot first (fast binary read), then replays only the small post-snapshot WAL. Warm-up scales with snapshot size, not full WAL history.

**Snapshot file format.** 32-byte header (`TSNS` magic, version, keyCount, createdAt, xxHash64 checksum) + entries (keyLen:4 + valLen:4 + ttlNano:8 + key + value).

**Zero-copy read path.** Added `Engine.SetFromBuffer` — takes ownership of a pre-built `[key|value]` buffer without copying. `snapshotRead` reads key+value contiguously in one `io.ReadFull`, hands buffer directly to engine. Eliminates one memcpy per entry vs the standard `Set` path.

**Config.** `--snapshot-interval` (time-based) and `--snapshot-bytes` (size-based, default 64MiB) trigger background snapshots per-shard. Both require `--enable-persistence`.

---

## Performance & Benchmarks

**Snapshot read path (1K keys, 64-byte values):**

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| ns/op | 583,409 | 457,053 | -21% |
| allocs/op | 1,033 | 1,031 | -2 |

```text
BenchmarkSnapshotRead1K-32              7266    457053 ns/op    380429 B/op    1031 allocs/op
BenchmarkSnapshotRoundTrip1K-32         6272    536860 ns/op    379949 B/op    1033 allocs/op
BenchmarkSnapshotChildWrite1K-32         954   3539508 ns/op      1077 B/op       17 allocs/op
BenchmarkEngineSetFromBufferNoTTL-32  69445760    47.14 ns/op        32 B/op        1 allocs/op
```

Snapshot write path: 0 allocs/entry. Child write path: 0 allocs/entry. Serialization: 0 allocs/entry. The remaining 1 alloc/entry in read is the engine's internal buffer — minimum for Go map ownership.

---

## How Has This Been Tested?

- 14 snapshot unit tests: round-trip, expired keys, invalid magic, TTL preservation, snapshot-first loading, WAL truncation, WAL size
- `task check` (go vet + race tests) — all 28 packages pass
- `task fmt` — clean
- 26 benchmarks covering write/read at 100/1K/10K/100K keys, round-trip, serialize, child-write, large values, SetFromBuffer vs Set

---

## Checklist

- [x] My code follows the existing code style of this project
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally (`go test ./...` and `go test -race ./...`)
- [x] I have updated the documentation (README, ARCHITECTURE.md, configuration.md, quickstart.md)
- [x] My changes generate no new `go vet` warnings
- [x] No breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic database snapshots based on time intervals or WAL size.
  * Added configuration options and environment variables for snapshot scheduling, requiring persistence to be enabled.
  * Added snapshot-based WAL cleanup to help manage storage growth.
* **Bug Fixes**
  * Improved snapshot validation, durability, and recovery handling for corrupted or incomplete data.
  * Improved recovery ordering, concurrent write preservation, and graceful shutdown behavior.
* **Performance**
  * Added optimized buffer-based storage operations and snapshot performance benchmarks.
* **Documentation**
  * Documented snapshot settings, defaults, and configuration requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->