### PR TITLE
feat(persitence): add encryption to WAL and snapshot

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -407,6 +407,9 @@ func LoadConfig(args []string) *Config {
 	if cfg.numShards < 1 {
 		cfg.numShards = runtime.NumCPU()
 	}
+	if cfg.maxMsgSize == 0 {
+		cfg.maxMsgSize = 16 * 1024 * 1024
+	}
 	cfg.snapshotBytes = uint64(snapshotBytes)
 	// Validate TLS configuration: cert and key must be provided together.
 	if (cfg.tlsCert == "") != (cfg.tlsKey == "") {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -473,6 +473,7 @@ func TestRBACConfigEnvVar(t *testing.T) {
 }
 
 func TestGetMaxMsgSizeDefault(t *testing.T) {
+	t.Setenv("TSD_MAX_MSG_SIZE", "")
 	cfg := LoadConfig(nil)
 	if cfg.GetMaxMsgSize() != 16*1024*1024 {
 		t.Fatalf("default maxMsgSize = %d, want %d", cfg.GetMaxMsgSize(), 16*1024*1024)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -471,3 +471,25 @@ func TestRBACConfigEnvVar(t *testing.T) {
 		t.Fatalf("rbac-config env mismatch: %q", cfg.GetRBACConfig())
 	}
 }
+
+func TestGetMaxMsgSizeDefault(t *testing.T) {
+	cfg := LoadConfig(nil)
+	if cfg.GetMaxMsgSize() != 16*1024*1024 {
+		t.Fatalf("default maxMsgSize = %d, want %d", cfg.GetMaxMsgSize(), 16*1024*1024)
+	}
+}
+
+func TestGetMaxMsgSizeZeroExplicit(t *testing.T) {
+	t.Setenv("TSD_MAX_MSG_SIZE", "0")
+	cfg := LoadConfig(nil)
+	if cfg.GetMaxMsgSize() != 16*1024*1024 {
+		t.Fatalf("maxMsgSize(0) = %d, want %d", cfg.GetMaxMsgSize(), 16*1024*1024)
+	}
+}
+
+func TestGetMaxMsgSizeNonZero(t *testing.T) {
+	cfg := LoadConfig([]string{"--max-msg-size", "32MiB"})
+	if cfg.GetMaxMsgSize() != 32*1024*1024 {
+		t.Fatalf("maxMsgSize(32MiB) = %d, want %d", cfg.GetMaxMsgSize(), 32*1024*1024)
+	}
+}

--- a/internal/crypto/cipher.go
+++ b/internal/crypto/cipher.go
@@ -14,6 +14,7 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 	"errors"
+	"fmt"
 
 	"github.com/Saxy/Tellstone/internal/log"
 	"golang.org/x/crypto/chacha20poly1305"
@@ -191,6 +192,40 @@ func (e *Engine) DecryptInPlaceWithDst(dst, ciphertext []byte) ([]byte, error) {
 			log.Int("ciphertext_len", len(ciphertext)),
 			log.Int("plaintext_len", len(plaintext)),
 		)
+	}
+	return plaintext, nil
+}
+
+// SealWithCounter encrypts plaintext using a caller-provided nonce instead of a
+// random one. This supports counter-based nonce management for the WAL layer,
+// where nonces must be deterministic and durable. The nonce must be exactly
+// NonceSize() bytes (12) and must never repeat for the same key.
+func (e *Engine) SealWithCounter(nonce, plaintext []byte) ([]byte, error) {
+	if !e.enabled {
+		return plaintext, nil
+	}
+	if len(nonce) != e.aead.NonceSize() {
+		return nil, fmt.Errorf("crypto: nonce must be %d bytes, got %d", e.aead.NonceSize(), len(nonce))
+	}
+	out := make([]byte, len(plaintext)+e.aead.Overhead())
+	return e.aead.Seal(out[:0], nonce, plaintext, nil), nil
+}
+
+// OpenWithCounter decrypts ciphertext using a caller-provided nonce. This is
+// the counterpart to SealWithCounter for counter-based nonce management.
+func (e *Engine) OpenWithCounter(nonce, ciphertext []byte) ([]byte, error) {
+	if !e.enabled {
+		return ciphertext, nil
+	}
+	if len(nonce) != e.aead.NonceSize() {
+		return nil, fmt.Errorf("crypto: nonce must be %d bytes, got %d", e.aead.NonceSize(), len(nonce))
+	}
+	if len(ciphertext) < e.aead.Overhead() {
+		return nil, ErrDecryptionFailed
+	}
+	plaintext, err := e.aead.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, ErrDecryptionFailed
 	}
 	return plaintext, nil
 }

--- a/internal/persistence/benchmark_test.go
+++ b/internal/persistence/benchmark_test.go
@@ -17,7 +17,7 @@ func BenchmarkWriteSequential(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	if err := s.OpenShard(0); err != nil {
+	if err := s.OpenShard(0, nil); err != nil {
 		b.Fatal(err)
 	}
 	val := []byte("benchmark_value_32_bytes_long_xxxxx")
@@ -40,7 +40,7 @@ func BenchmarkWriteParallel(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	if err := s.OpenShard(0); err != nil {
+	if err := s.OpenShard(0, nil); err != nil {
 		b.Fatal(err)
 	}
 	val := []byte("bench_val")
@@ -70,7 +70,7 @@ func BenchmarkWriteWithTTL(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	if err := s.OpenShard(0); err != nil {
+	if err := s.OpenShard(0, nil); err != nil {
 		b.Fatal(err)
 	}
 	val := []byte("benchmark_value_32_bytes_long_xxxxx")
@@ -94,7 +94,7 @@ func BenchmarkLoadShardSequential(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	if err := s.OpenShard(0); err != nil {
+	if err := s.OpenShard(0, nil); err != nil {
 		b.Fatal(err)
 	}
 	numRecords := 10000
@@ -123,7 +123,7 @@ func BenchmarkLoadShardSmall(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	if err := s.OpenShard(0); err != nil {
+	if err := s.OpenShard(0, nil); err != nil {
 		b.Fatal(err)
 	}
 	numRecords := 100
@@ -152,7 +152,7 @@ func BenchmarkWriteThenLoad(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	if err := s.OpenShard(0); err != nil {
+	if err := s.OpenShard(0, nil); err != nil {
 		b.Fatal(err)
 	}
 	val := []byte("lifecycle_value_32_bytes_long_xxxxx")
@@ -165,7 +165,7 @@ func BenchmarkWriteThenLoad(b *testing.B) {
 		s.CloseShard(0)
 		os.Remove(filepath.Join(dir, fmt.Sprintf("shard_%03d.db", 0)))
 		b.StartTimer()
-		if err := s.OpenShard(0); err != nil {
+		if err := s.OpenShard(0, nil); err != nil {
 			b.Fatal(err)
 		}
 		for j := 0; j < numRecords; j++ {

--- a/internal/persistence/persistence.go
+++ b/internal/persistence/persistence.go
@@ -824,5 +824,11 @@ func (s *Storage) CloseShard(shardID uint32) error {
 			return err
 		}
 	}
-	return h.file.Close()
+	if err := h.file.Close(); err != nil {
+		return err
+	}
+	s.mapMu.Lock()
+	delete(s.shards, shardID)
+	s.mapMu.Unlock()
+	return nil
 }

--- a/internal/persistence/persistence.go
+++ b/internal/persistence/persistence.go
@@ -778,9 +778,9 @@ func (s *Storage) Snapshot(shardID uint32, engine *storage.Engine) error {
 // counter at the time of truncation, even if the WAL records are gone.
 func (s *Storage) truncateWALLocked(h *shardHandle, shardID uint32, offset int64) error {
 	if h.walVer == 1 {
-		sidecarErr := writeNonceSidecar(nonceSidecarPath(s.dir, shardID), h.nonceCtr.Load())
-		closeErr := h.file.Close()
-		return errors.Join(sidecarErr, closeErr)
+		if err := writeNonceSidecar(nonceSidecarPath(s.dir, shardID), h.nonceCtr.Load()); err != nil {
+			return fmt.Errorf("persistence: persist nonce sidecar before truncate: %w", err)
+		}
 	}
 	if err := h.file.Truncate(offset); err != nil {
 		return fmt.Errorf("persistence: truncate WAL shard %d to %d: %w", shardID, offset, err)
@@ -828,7 +828,9 @@ func (s *Storage) CloseShard(shardID uint32) error {
 		return err
 	}
 	s.mapMu.Lock()
-	delete(s.shards, shardID)
+	if cur, ok := s.shards[shardID]; ok && cur == h {
+		delete(s.shards, shardID)
+	}
 	s.mapMu.Unlock()
 	return nil
 }

--- a/internal/persistence/persistence.go
+++ b/internal/persistence/persistence.go
@@ -778,9 +778,9 @@ func (s *Storage) Snapshot(shardID uint32, engine *storage.Engine) error {
 // counter at the time of truncation, even if the WAL records are gone.
 func (s *Storage) truncateWALLocked(h *shardHandle, shardID uint32, offset int64) error {
 	if h.walVer == 1 {
-		if err := writeNonceSidecar(nonceSidecarPath(s.dir, shardID), h.nonceCtr.Load()); err != nil {
-			return fmt.Errorf("persistence: persist nonce sidecar before truncate: %w", err)
-		}
+		sidecarErr := writeNonceSidecar(nonceSidecarPath(s.dir, shardID), h.nonceCtr.Load())
+		closeErr := h.file.Close()
+		return errors.Join(sidecarErr, closeErr)
 	}
 	if err := h.file.Truncate(offset); err != nil {
 		return fmt.Errorf("persistence: truncate WAL shard %d to %d: %w", shardID, offset, err)

--- a/internal/persistence/persistence.go
+++ b/internal/persistence/persistence.go
@@ -57,7 +57,7 @@ func readNonceSidecar(path string) uint64 {
 	if err != nil {
 		return 0
 	}
-	defer f.Close()
+	defer func(f *os.File) { _ = f.Close() }(f)
 	var buf [8]byte
 	if _, err := io.ReadFull(f, buf[:]); err != nil {
 		return 0
@@ -65,34 +65,43 @@ func readNonceSidecar(path string) uint64 {
 	return binary.LittleEndian.Uint64(buf[:])
 }
 
-// writeNonceSidecar persists the nonce counter to the sidecar file. The counter
-// represents the next value to use (high-water mark + 1). Best-effort: errors
-// are logged but never propagated since the WAL is the source of truth.
-func writeNonceSidecar(path string, ctr uint64, logger log.Logger) {
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+// writeNonceSidecar persists the nonce counter to a sidecar file using an
+// atomic write sequence: temp file → sync → rename → dir sync. This ensures
+// the sidecar is never left in a partial state after a crash. The counter
+// represents the next value to use (high-water mark + 1).
+func writeNonceSidecar(path string, ctr uint64) error {
+	tmpPath := path + ".tmp"
+	f, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
 	if err != nil {
-		if logger != nil && logger.Enabled(log.LevelWarn) {
-			logger.Log(log.LevelWarn, "persistence: failed to create nonce sidecar",
-				log.String("path", path), log.String("error", err.Error()))
-		}
-		return
+		return fmt.Errorf("persistence: create nonce sidecar tmp: %w", err)
 	}
-	defer f.Close()
 	var buf [8]byte
 	binary.LittleEndian.PutUint64(buf[:], ctr)
-	if _, err := f.Write(buf[:]); err != nil {
-		if logger != nil && logger.Enabled(log.LevelWarn) {
-			logger.Log(log.LevelWarn, "persistence: failed to write nonce sidecar",
-				log.String("path", path), log.String("error", err.Error()))
+	if _, err = f.Write(buf[:]); err != nil {
+		if cerr := f.Close(); cerr != nil {
+			_ = os.Remove(tmpPath)
+		} else {
+			_ = os.Remove(tmpPath)
 		}
-		return
+		return fmt.Errorf("persistence: write nonce sidecar: %w", err)
 	}
-	if err := f.Sync(); err != nil {
-		if logger != nil && logger.Enabled(log.LevelWarn) {
-			logger.Log(log.LevelWarn, "persistence: failed to sync nonce sidecar",
-				log.String("path", path), log.String("error", err.Error()))
-		}
+	if err = f.Sync(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("persistence: sync nonce sidecar: %w", err)
 	}
+	if err = f.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("persistence: close nonce sidecar: %w", err)
+	}
+	if err = os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("persistence: rename nonce sidecar: %w", err)
+	}
+	if err = syncDir(filepath.Dir(path)); err != nil {
+		return fmt.Errorf("persistence: sync dir for nonce sidecar: %w", err)
+	}
+	return nil
 }
 
 // shardHandle holds the WAL file and its per-shard mutex for a single shard.
@@ -102,10 +111,10 @@ func writeNonceSidecar(path string, ctr uint64, logger log.Logger) {
 type shardHandle struct {
 	file     *os.File
 	mu       sync.Mutex
-	crypto   *crypto.Engine // nil when encryption disabled
-	walVer   uint8          // 0 = plaintext, 1 = encrypted
-	nonceCtr atomic.Uint64  // next nonce counter value
-	shardID  uint32         // shard identifier for sidecar path
+	crypto   *crypto.Engine
+	walVer   uint8
+	nonceCtr atomic.Uint64
+	shardID  uint32
 }
 
 // Storage provides a per-shard, append-only write-ahead log (WAL) for crash recovery.
@@ -385,59 +394,49 @@ func (s *Storage) OpenShard(shardID uint32, cryptoEng *crypto.Engine) error {
 		}
 		return err
 	}
-
 	h := &shardHandle{file: f, shardID: shardID}
-
-	// Detect or write the WAL header based on file contents and crypto config.
 	fi, err := f.Stat()
 	if err != nil {
-		f.Close()
+		_ = f.Close()
 		return err
 	}
 	if fi.Size() == 0 {
-		// Empty file — new shard. Write encrypted header if crypto is enabled.
 		if cryptoEng != nil && cryptoEng.Enabled() {
-			if _, err := f.WriteString(walMagic); err != nil {
-				f.Close()
+			if _, err = f.WriteString(walMagic); err != nil {
+				_ = f.Close()
 				return fmt.Errorf("persistence: write WAL header: %w", err)
 			}
 			h.crypto = cryptoEng
 			h.walVer = 1
 		}
 	} else {
-		// Existing file — detect format from first bytes.
 		var magic [walMagicLen]byte
-		if _, err := io.ReadFull(f, magic[:]); err != nil {
-			f.Close()
+		if _, err = io.ReadFull(f, magic[:]); err != nil {
+			_ = f.Close()
 			return fmt.Errorf("persistence: read WAL header: %w", err)
 		}
 		if string(magic[:]) == walMagic {
-			// Encrypted WAL.
 			if cryptoEng == nil || !cryptoEng.Enabled() {
-				f.Close()
+				_ = f.Close()
 				return fmt.Errorf("persistence: shard %d has encrypted WAL but no crypto engine", shardID)
 			}
 			h.crypto = cryptoEng
 			h.walVer = 1
 		} else {
-			// Plaintext WAL (no magic).
 			if cryptoEng != nil && cryptoEng.Enabled() {
-				f.Close()
+				_ = f.Close()
 				return fmt.Errorf("persistence: shard %d has plaintext WAL but encryption is requested; delete the file to start fresh", shardID)
 			}
 			h.walVer = 0
 		}
-		// Seek back to start so replayWAL reads from the beginning.
-		if _, err := f.Seek(0, 0); err != nil {
-			f.Close()
+		if _, err = f.Seek(0, 0); err != nil {
+			_ = f.Close()
 			return err
 		}
 	}
-
 	s.mapMu.Lock()
 	if old, ok := s.shards[shardID]; ok {
-		// Close the existing handle to avoid file descriptor leak.
-		old.file.Close()
+		_ = old.file.Close()
 	}
 	s.shards[shardID] = h
 	s.mapMu.Unlock()
@@ -456,10 +455,6 @@ func (s *Storage) LoadShard(shardID uint32, engine *storage.Engine) error {
 	if !s.enabled {
 		return nil
 	}
-
-	// Phase 1: load snapshot if present. A corrupt snapshot means data
-	// preceding it is unrecoverable — abort rather than continuing with
-	// a partial state and replaying the WAL on top of an empty engine.
 	if snapshotExists(s.dir, shardID) {
 		var fp [16]byte
 		if h := s.getShard(shardID); h != nil && h.crypto != nil {
@@ -478,8 +473,6 @@ func (s *Storage) LoadShard(shardID uint32, engine *storage.Engine) error {
 				log.Uint("shard", shardID), log.Uint64("keys", loadedKeys))
 		}
 	}
-
-	// Phase 2: replay the WAL for writes since the last snapshot.
 	return s.replayWAL(shardID, engine)
 }
 
@@ -559,8 +552,8 @@ func (s *Storage) replayWALPlaintext(h *shardHandle, shardID uint32, f *os.File,
 		remaining -= int64(keyLen) + int64(valLen)
 		validOffset = fileSize - remaining
 		recordsRead++
-		if err := s.applyRecord(shardID, engine, header, keyBuf, valBuf); err != nil {
-			if err == errRecordExpired {
+		if err = s.applyRecord(shardID, engine, header, keyBuf, valBuf); err != nil {
+			if errors.Is(errRecordExpired, err) {
 				recordsSkipped++
 				continue
 			}
@@ -587,7 +580,6 @@ func (s *Storage) replayWALEncrypted(h *shardHandle, shardID uint32, f *os.File,
 	var recordsSkipped int
 
 	for {
-		// Read record length.
 		if _, err := io.ReadFull(f, recLenBuf); err != nil {
 			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 				break
@@ -595,10 +587,9 @@ func (s *Storage) replayWALEncrypted(h *shardHandle, shardID uint32, f *os.File,
 			return fmt.Errorf("persistence: read encrypted record length: %w", err)
 		}
 		recLen := int64(binary.LittleEndian.Uint32(recLenBuf))
-		if recLen < 12+16 { // nonce(12) + tag(16) minimum
+		if recLen < 12+16 {
 			break
 		}
-		// Subtract the 4-byte recLen prefix itself before comparing.
 		remaining -= 4
 		if recLen > remaining {
 			break
@@ -613,17 +604,12 @@ func (s *Storage) replayWALEncrypted(h *shardHandle, shardID uint32, f *os.File,
 			return fmt.Errorf("persistence: read encrypted record: %w", err)
 		}
 		remaining -= recLen
-
 		nonce := record[:12]
 		ciphertext := record[12:]
-
-		// Track the maximum nonce counter for durability.
 		ctr := binary.LittleEndian.Uint64(nonce[:8])
 		if ctr > maxNonce {
 			maxNonce = ctr
 		}
-
-		// Decrypt.
 		plaintext, err := h.crypto.OpenWithCounter(nonce, ciphertext)
 		if err != nil {
 			if s.logger.Enabled(log.LevelWarn) {
@@ -635,10 +621,8 @@ func (s *Storage) replayWALEncrypted(h *shardHandle, shardID uint32, f *os.File,
 		if len(plaintext) < 16 {
 			break
 		}
-
 		validOffset = fileSize - remaining
 		recordsRead++
-
 		var header [16]byte
 		copy(header[:], plaintext[:16])
 		keyLen := binary.LittleEndian.Uint32(header[0:4])
@@ -648,9 +632,8 @@ func (s *Storage) replayWALEncrypted(h *shardHandle, shardID uint32, f *os.File,
 		}
 		keyBuf := plaintext[16 : 16+keyLen]
 		valBuf := plaintext[16+keyLen : 16+keyLen+valLen]
-
-		if err := s.applyRecord(shardID, engine, header[:], keyBuf, valBuf); err != nil {
-			if err == errRecordExpired {
+		if err = s.applyRecord(shardID, engine, header[:], keyBuf, valBuf); err != nil {
+			if errors.Is(errRecordExpired, err) {
 				recordsSkipped++
 				continue
 			}
@@ -669,8 +652,12 @@ func (s *Storage) replayWALEncrypted(h *shardHandle, shardID uint32, f *os.File,
 	h.nonceCtr.Store(walCtr)
 
 	// Persist the counter to the sidecar for defense-in-depth.
-	writeNonceSidecar(nonceSidecarPath(s.dir, shardID), walCtr, s.logger)
-
+	if err := writeNonceSidecar(nonceSidecarPath(s.dir, shardID), walCtr); err != nil {
+		if s.logger.Enabled(log.LevelWarn) {
+			s.logger.Log(log.LevelWarn, "persistence: nonce sidecar persist failed",
+				log.Uint("shard", shardID), log.String("error", err.Error()))
+		}
+	}
 	s.finishReplay(h, shardID, fileSize, validOffset, recordsRead, recordsSkipped)
 	return nil
 }
@@ -758,8 +745,6 @@ func (s *Storage) Snapshot(shardID uint32, engine *storage.Engine) error {
 	if !s.enabled {
 		return nil
 	}
-	// Snapshot the engine state first. ForEach freezes the engine under a
-	// read lock so no new mutations complete during serialization.
 	var fp [16]byte
 	if h := s.getShard(shardID); h != nil && h.crypto != nil {
 		fp = h.crypto.KeyFingerprint()
@@ -771,16 +756,10 @@ func (s *Storage) Snapshot(shardID uint32, engine *storage.Engine) error {
 	if h == nil {
 		return fmt.Errorf("persistence: shard %d not opened", shardID)
 	}
-	// Capture the WAL boundary after serialization and truncate atomically
-	// under the shard mutex so no Write can interleave between the stat and
-	// the truncation.
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	fi, err := h.file.Stat()
 	if err != nil {
-		// Cannot determine the truncation boundary — skip truncation to
-		// avoid losing records. The extra WAL data is harmless: it will be
-		// replayed on recovery and the duplicate SETs are idempotent.
 		if s.logger.Enabled(log.LevelWarn) {
 			s.logger.Log(log.LevelWarn, "persistence: cannot determine WAL boundary, skipping truncation",
 				log.Uint("shard", shardID), log.String("error", err.Error()))
@@ -790,14 +769,22 @@ func (s *Storage) Snapshot(shardID uint32, engine *storage.Engine) error {
 	return s.truncateWALLocked(h, shardID, fi.Size())
 }
 
-// truncateWALLocked truncates, syncs, and seeks the WAL file to the given
-// offset. The caller must hold h.mu. Used by Snapshot and TruncateWALTo.
+// truncateWALLocked persists the nonce sidecar, then truncates, syncs, and
+// seeks the WAL file to the given offset. The caller must hold h.mu. Used by
+// Snapshot and TruncateWALTo.
+//
+// The sidecar is persisted BEFORE truncation so that a crash after truncation
+// never causes nonce counter regression: the sidecar already reflects the
+// counter at the time of truncation, even if the WAL records are gone.
 func (s *Storage) truncateWALLocked(h *shardHandle, shardID uint32, offset int64) error {
+	if h.walVer == 1 {
+		if err := writeNonceSidecar(nonceSidecarPath(s.dir, shardID), h.nonceCtr.Load()); err != nil {
+			return fmt.Errorf("persistence: persist nonce sidecar before truncate: %w", err)
+		}
+	}
 	if err := h.file.Truncate(offset); err != nil {
 		return fmt.Errorf("persistence: truncate WAL shard %d to %d: %w", shardID, offset, err)
 	}
-	// Sync after truncation so the truncated length is durable; without this
-	// a crash could replay stale records that were logically discarded.
 	if err := h.file.Sync(); err != nil {
 		return fmt.Errorf("persistence: sync WAL shard %d after truncate: %w", shardID, err)
 	}
@@ -832,9 +819,10 @@ func (s *Storage) CloseShard(shardID uint32) error {
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	// Persist the nonce counter before closing so it survives process restart.
 	if h.walVer == 1 {
-		writeNonceSidecar(nonceSidecarPath(s.dir, shardID), h.nonceCtr.Load(), s.logger)
+		if err := writeNonceSidecar(nonceSidecarPath(s.dir, shardID), h.nonceCtr.Load()); err != nil {
+			return err
+		}
 	}
 	return h.file.Close()
 }

--- a/internal/persistence/persistence.go
+++ b/internal/persistence/persistence.go
@@ -10,8 +10,10 @@ import (
 	"path/filepath"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"time"
 
+	"github.com/Saxy/Tellstone/internal/crypto"
 	"github.com/Saxy/Tellstone/internal/log"
 	"github.com/Saxy/Tellstone/internal/storage"
 )
@@ -19,6 +21,12 @@ import (
 const (
 	osWindows = "windows"
 	osDarwin  = "darwin"
+
+	// walMagic marks the start of an encrypted WAL file. Plaintext WALs have
+	// no magic — they begin directly with the first record's keyLen field.
+	// The trailing byte is the WAL format version (currently 1).
+	walMagic    = "TSW\x01"
+	walMagicLen = 4
 )
 
 var tombstoneTTL int64 = math.MinInt64
@@ -37,9 +45,15 @@ func getDefaultDir() string {
 }
 
 // shardHandle holds the WAL file and its per-shard mutex for a single shard.
+// When encryption is enabled, crypto holds the DEK engine and nonceCtr tracks
+// the next counter-based nonce value. The counter is durable: it is recovered
+// from the WAL on replay so nonces never repeat across crashes.
 type shardHandle struct {
-	file *os.File
-	mu   sync.Mutex
+	file     *os.File
+	mu       sync.Mutex
+	crypto   *crypto.Engine // nil when encryption disabled
+	walVer   uint8          // 0 = plaintext, 1 = encrypted
+	nonceCtr atomic.Uint64  // next nonce counter value
 }
 
 // Storage provides a per-shard, append-only write-ahead log (WAL) for crash recovery.
@@ -113,6 +127,8 @@ func (s *Storage) getShard(shardID uint32) *shardHandle {
 
 // appendRecord is the shared writing path for both SET and tombstone records.
 // It acquires the shard mutex, writes the header, key, value, and syncs.
+// When the shard's WAL version is 1 (encrypted), the entire plaintext record
+// is encrypted with a counter-based nonce before writing.
 func (s *Storage) appendRecord(shardID uint32, header [16]byte, key string, value []byte, op string) error {
 	h := s.getShard(shardID)
 	if h == nil {
@@ -120,6 +136,11 @@ func (s *Storage) appendRecord(shardID uint32, header [16]byte, key string, valu
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
+
+	if h.walVer == 1 {
+		return s.appendRecordEncrypted(h, shardID, header, key, value, op)
+	}
+
 	if _, err := h.file.Write(header[:]); err != nil {
 		if s.logger.Enabled(log.LevelError) {
 			s.logger.Log(log.LevelError, "persistence: write "+op+" header failed",
@@ -144,6 +165,72 @@ func (s *Storage) appendRecord(shardID uint32, header [16]byte, key string, valu
 	if err := h.file.Sync(); err != nil {
 		if s.logger.Enabled(log.LevelError) {
 			s.logger.Log(log.LevelError, "persistence: sync "+op+" failed",
+				log.Uint("shard", shardID), log.String("key", key), log.String("error", err.Error()))
+		}
+		return err
+	}
+	return nil
+}
+
+// appendRecordEncrypted writes an encrypted WAL record. Format on disk:
+//
+//	[recLen:4B LE][nonce:12B][ciphertext + tag]
+//
+// The nonce is [counter:8B LE][shardID:4B LE]. The counter is atomic and
+// recovered from WAL replay on restart so nonces never repeat across crashes.
+func (s *Storage) appendRecordEncrypted(h *shardHandle, shardID uint32, header [16]byte, key string, value []byte, op string) error {
+	// Assemble plaintext record: header + key + value.
+	plainLen := 16 + len(key) + len(value)
+	plaintext := make([]byte, plainLen)
+	copy(plaintext, header[:])
+	copy(plaintext[16:], key)
+	copy(plaintext[16+len(key):], value)
+
+	// Build counter-based nonce: [counter:8B][shardID:4B].
+	ctr := h.nonceCtr.Add(1) - 1
+	var nonce [12]byte
+	binary.LittleEndian.PutUint64(nonce[:8], ctr)
+	binary.LittleEndian.PutUint32(nonce[8:12], shardID)
+
+	// Encrypt: ciphertext = Seal(nonce, plaintext) which includes 16-byte tag.
+	ciphertext, err := h.crypto.SealWithCounter(nonce[:], plaintext)
+	if err != nil {
+		if s.logger.Enabled(log.LevelError) {
+			s.logger.Log(log.LevelError, "persistence: encrypt "+op+" failed",
+				log.Uint("shard", shardID), log.String("key", key), log.String("error", err.Error()))
+		}
+		return err
+	}
+
+	// On-disk record: [recLen:4B LE][nonce:12B][ciphertext].
+	recLen := uint32(12 + len(ciphertext))
+	var recLenBuf [4]byte
+	binary.LittleEndian.PutUint32(recLenBuf[:], recLen)
+
+	if _, err := h.file.Write(recLenBuf[:]); err != nil {
+		if s.logger.Enabled(log.LevelError) {
+			s.logger.Log(log.LevelError, "persistence: write encrypted "+op+" length failed",
+				log.Uint("shard", shardID), log.String("key", key), log.String("error", err.Error()))
+		}
+		return err
+	}
+	if _, err := h.file.Write(nonce[:]); err != nil {
+		if s.logger.Enabled(log.LevelError) {
+			s.logger.Log(log.LevelError, "persistence: write encrypted "+op+" nonce failed",
+				log.Uint("shard", shardID), log.String("key", key), log.String("error", err.Error()))
+		}
+		return err
+	}
+	if _, err := h.file.Write(ciphertext); err != nil {
+		if s.logger.Enabled(log.LevelError) {
+			s.logger.Log(log.LevelError, "persistence: write encrypted "+op+" ciphertext failed",
+				log.Uint("shard", shardID), log.String("key", key), log.String("error", err.Error()))
+		}
+		return err
+	}
+	if err := h.file.Sync(); err != nil {
+		if s.logger.Enabled(log.LevelError) {
+			s.logger.Log(log.LevelError, "persistence: sync encrypted "+op+" failed",
 				log.Uint("shard", shardID), log.String("key", key), log.String("error", err.Error()))
 		}
 		return err
@@ -217,9 +304,13 @@ func (s *Storage) Delete(shardID uint32, key string) error {
 }
 
 // OpenShard opens (or creates) the WAL file for the given shard.
+// If cryptoEng is non-nil, the WAL is encrypted with counter-based nonces and
+// a 4-byte magic header is written to new files. Existing plaintext WALs
+// cannot be retroactively encrypted — an error is returned if a plaintext
+// file is found while crypto is requested.
 // Must be called before Write or LoadShard for that shard.
 // Returns nil immediately when persistence is disabled.
-func (s *Storage) OpenShard(shardID uint32) error {
+func (s *Storage) OpenShard(shardID uint32, cryptoEng *crypto.Engine) error {
 	if !s.enabled {
 		return nil
 	}
@@ -235,11 +326,61 @@ func (s *Storage) OpenShard(shardID uint32) error {
 		}
 		return err
 	}
+
+	h := &shardHandle{file: f}
+
+	// Detect or write the WAL header based on file contents and crypto config.
+	fi, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return err
+	}
+	if fi.Size() == 0 {
+		// Empty file — new shard. Write encrypted header if crypto is enabled.
+		if cryptoEng != nil && cryptoEng.Enabled() {
+			if _, err := f.WriteString(walMagic); err != nil {
+				f.Close()
+				return fmt.Errorf("persistence: write WAL header: %w", err)
+			}
+			h.crypto = cryptoEng
+			h.walVer = 1
+		}
+	} else {
+		// Existing file — detect format from first bytes.
+		var magic [walMagicLen]byte
+		if _, err := io.ReadFull(f, magic[:]); err != nil {
+			f.Close()
+			return fmt.Errorf("persistence: read WAL header: %w", err)
+		}
+		if string(magic[:]) == walMagic {
+			// Encrypted WAL.
+			if cryptoEng == nil || !cryptoEng.Enabled() {
+				f.Close()
+				return fmt.Errorf("persistence: shard %d has encrypted WAL but no crypto engine", shardID)
+			}
+			h.crypto = cryptoEng
+			h.walVer = 1
+		} else {
+			// Plaintext WAL (no magic).
+			if cryptoEng != nil && cryptoEng.Enabled() {
+				f.Close()
+				return fmt.Errorf("persistence: shard %d has plaintext WAL but encryption is requested; delete the file to start fresh", shardID)
+			}
+			h.walVer = 0
+		}
+		// Seek back to start so replayWAL reads from the beginning.
+		if _, err := f.Seek(0, 0); err != nil {
+			f.Close()
+			return err
+		}
+	}
+
 	s.mapMu.Lock()
-	s.shards[shardID] = &shardHandle{file: f}
+	s.shards[shardID] = h
 	s.mapMu.Unlock()
 	if s.logger.Enabled(log.LevelDebug) {
-		s.logger.Log(log.LevelDebug, "persistence: shard opened", log.Uint("shard", shardID))
+		s.logger.Log(log.LevelDebug, "persistence: shard opened",
+			log.Uint("shard", shardID), log.Bool("encrypted", h.walVer == 1))
 	}
 	return nil
 }
@@ -279,6 +420,10 @@ func (s *Storage) LoadShard(shardID uint32, engine *storage.Engine) error {
 // skipping expired keys and applying tombstones as deletions. Truncated records
 // from a crash mid-write are detected, and the WAL is truncated to the last valid
 // offset so future loads resume from a clean end.
+//
+// For encrypted WALs (walVer=1), each record is decrypted with its counter-based
+// nonce before parsing. The nonce counter is recovered from the WAL so it is
+// durable across crashes.
 func (s *Storage) replayWAL(shardID uint32, engine *storage.Engine) error {
 	h := s.getShard(shardID)
 	if h == nil {
@@ -301,6 +446,15 @@ func (s *Storage) replayWAL(shardID uint32, engine *storage.Engine) error {
 			log.Uint("shard", shardID), log.Int64("file_size", fileSize))
 	}
 	h.mu.Unlock()
+
+	if h.walVer == 1 {
+		return s.replayWALEncrypted(h, shardID, f, fileSize, engine)
+	}
+	return s.replayWALPlaintext(h, shardID, f, fileSize, engine)
+}
+
+// replayWALPlaintext replays a plaintext WAL file (walVer=0).
+func (s *Storage) replayWALPlaintext(h *shardHandle, shardID uint32, f *os.File, fileSize int64, engine *storage.Engine) error {
 	remaining := fileSize
 	var validOffset int64
 	header := make([]byte, 16)
@@ -308,7 +462,7 @@ func (s *Storage) replayWAL(shardID uint32, engine *storage.Engine) error {
 	var recordsSkipped int
 	for {
 		var n int
-		n, err = io.ReadFull(f, header)
+		n, err := io.ReadFull(f, header)
 		if err != nil {
 			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 				break
@@ -318,7 +472,6 @@ func (s *Storage) replayWAL(shardID uint32, engine *storage.Engine) error {
 		remaining -= 16
 		keyLen := binary.LittleEndian.Uint32(header[0:4])
 		valLen := binary.LittleEndian.Uint32(header[4:8])
-		ttlNano := int64(binary.LittleEndian.Uint64(header[8:16]))
 		if int64(keyLen)+int64(valLen) > remaining {
 			break
 		}
@@ -339,36 +492,145 @@ func (s *Storage) replayWAL(shardID uint32, engine *storage.Engine) error {
 		remaining -= int64(keyLen) + int64(valLen)
 		validOffset = fileSize - remaining
 		recordsRead++
-		ttlVal := ttlNano
-		if ttlVal == tombstoneTTL {
-			if s.logger.Enabled(log.LevelDebug) {
-				s.logger.Log(log.LevelDebug, "persistence: replaying delete",
-					log.Uint("shard", shardID), log.String("key", string(keyBuf)))
-			}
-			engine.Delete(string(keyBuf))
-			recordsSkipped++
-			continue
-		}
-		var duration time.Duration
-		if ttlNano != 0 {
-			ttl := time.Unix(0, ttlNano)
-			duration = time.Until(ttl)
-			if duration <= 0 {
-				if s.logger.Enabled(log.LevelDebug) {
-					s.logger.Log(log.LevelDebug, "persistence: skipping expired key",
-						log.Uint("shard", shardID), log.String("key", string(keyBuf)))
-				}
+		if err := s.applyRecord(shardID, engine, header, keyBuf, valBuf); err != nil {
+			if err == errRecordExpired {
 				recordsSkipped++
 				continue
 			}
-		}
-		if err = engine.Set(string(keyBuf), valBuf, duration); err != nil {
 			return err
 		}
 	}
+	s.finishReplay(h, shardID, fileSize, validOffset, recordsRead, recordsSkipped)
+	return nil
+}
+
+// replayWALEncrypted replays an encrypted WAL file (walVer=1). Each record is
+// length-prefixed and encrypted with a counter-based nonce. The nonce counter is
+// recovered from the WAL so nonces never repeat across crashes.
+func (s *Storage) replayWALEncrypted(h *shardHandle, shardID uint32, f *os.File, fileSize int64, engine *storage.Engine) error {
+	// Skip the WAL magic header.
+	if _, err := f.Seek(walMagicLen, 0); err != nil {
+		return err
+	}
+	remaining := fileSize - int64(walMagicLen)
+	validOffset := int64(walMagicLen) // preserve the magic header even if no records follow
+	var maxNonce uint64
+	recLenBuf := make([]byte, 4)
+	var recordsRead int
+	var recordsSkipped int
+
+	for {
+		// Read record length.
+		if _, err := io.ReadFull(f, recLenBuf); err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				break
+			}
+			return fmt.Errorf("persistence: read encrypted record length: %w", err)
+		}
+		recLen := int64(binary.LittleEndian.Uint32(recLenBuf))
+		if recLen < 12+16 { // nonce(12) + tag(16) minimum
+			break
+		}
+		if recLen > remaining {
+			break
+		}
+		remaining -= 4
+
+		// Read nonce + ciphertext.
+		record := make([]byte, recLen)
+		if _, err := io.ReadFull(f, record); err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				break
+			}
+			return fmt.Errorf("persistence: read encrypted record: %w", err)
+		}
+		remaining -= recLen
+
+		nonce := record[:12]
+		ciphertext := record[12:]
+
+		// Track the maximum nonce counter for durability.
+		ctr := binary.LittleEndian.Uint64(nonce[:8])
+		if ctr > maxNonce {
+			maxNonce = ctr
+		}
+
+		// Decrypt.
+		plaintext, err := h.crypto.OpenWithCounter(nonce, ciphertext)
+		if err != nil {
+			if s.logger.Enabled(log.LevelWarn) {
+				s.logger.Log(log.LevelWarn, "persistence: decrypt failed, skipping record",
+					log.Uint("shard", shardID), log.String("error", err.Error()))
+			}
+			break
+		}
+		if len(plaintext) < 16 {
+			break
+		}
+
+		validOffset = fileSize - remaining
+		recordsRead++
+
+		var header [16]byte
+		copy(header[:], plaintext[:16])
+		keyLen := binary.LittleEndian.Uint32(header[0:4])
+		valLen := binary.LittleEndian.Uint32(header[4:8])
+		if int64(keyLen)+int64(valLen) != int64(len(plaintext)-16) {
+			break
+		}
+		keyBuf := plaintext[16 : 16+keyLen]
+		valBuf := plaintext[16+keyLen : 16+keyLen+valLen]
+
+		if err := s.applyRecord(shardID, engine, header[:], keyBuf, valBuf); err != nil {
+			if err == errRecordExpired {
+				recordsSkipped++
+				continue
+			}
+			return err
+		}
+	}
+
+	// Recover the nonce counter so future writes never reuse a nonce.
+	h.nonceCtr.Store(maxNonce + 1)
+
+	s.finishReplay(h, shardID, fileSize, validOffset, recordsRead, recordsSkipped)
+	return nil
+}
+
+var errRecordExpired = errors.New("persistence: record expired")
+
+// applyRecord applies a single WAL record to the engine. Returns errRecordExpired
+// if the record's TTL has passed (caller should count it as skipped).
+func (s *Storage) applyRecord(shardID uint32, engine *storage.Engine, header, keyBuf, valBuf []byte) error {
+	ttlNano := int64(binary.LittleEndian.Uint64(header[8:16]))
+	if ttlNano == tombstoneTTL {
+		if s.logger.Enabled(log.LevelDebug) {
+			s.logger.Log(log.LevelDebug, "persistence: replaying delete",
+				log.Uint("shard", shardID), log.String("key", string(keyBuf)))
+		}
+		engine.Delete(string(keyBuf))
+		return errRecordExpired
+	}
+	var duration time.Duration
+	if ttlNano != 0 {
+		ttl := time.Unix(0, ttlNano)
+		duration = time.Until(ttl)
+		if duration <= 0 {
+			if s.logger.Enabled(log.LevelDebug) {
+				s.logger.Log(log.LevelDebug, "persistence: skipping expired key",
+					log.Uint("shard", shardID), log.String("key", string(keyBuf)))
+			}
+			return errRecordExpired
+		}
+	}
+	return engine.Set(string(keyBuf), valBuf, duration)
+}
+
+// finishReplay truncates a corrupted WAL tail and logs replay statistics.
+func (s *Storage) finishReplay(h *shardHandle, shardID uint32, fileSize, validOffset int64, recordsRead, recordsSkipped int) {
 	if validOffset < fileSize {
 		h.mu.Lock()
-		if err = f.Truncate(validOffset); err != nil {
+		if err := h.file.Truncate(validOffset); err != nil {
 			h.mu.Unlock()
 			if s.logger.Enabled(log.LevelWarn) {
 				s.logger.Log(log.LevelWarn, "persistence: failed to truncate corrupted tail",
@@ -387,7 +649,6 @@ func (s *Storage) replayWAL(shardID uint32, engine *storage.Engine) error {
 			log.Uint("shard", shardID), log.Int("records_read", recordsRead),
 			log.Int("records_skipped", recordsSkipped), log.Int("records_loaded", recordsRead-recordsSkipped))
 	}
-	return nil
 }
 
 // WALSize returns the current WAL file size in bytes for the given shard.

--- a/internal/persistence/persistence.go
+++ b/internal/persistence/persistence.go
@@ -44,6 +44,57 @@ func getDefaultDir() string {
 	return filepath.Join(baseDir, "tellstone", "data")
 }
 
+// nonceSidecarPath returns the path for the nonce counter sidecar file.
+// The sidecar persists the high-water nonce counter so it survives WAL loss.
+func nonceSidecarPath(dir string, shardID uint32) string {
+	return filepath.Join(dir, fmt.Sprintf("shard_%03d.nonce", shardID))
+}
+
+// readNonceSidecar reads the persisted nonce counter from the sidecar file.
+// Returns 0 if the file does not exist or is invalid.
+func readNonceSidecar(path string) uint64 {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0
+	}
+	defer f.Close()
+	var buf [8]byte
+	if _, err := io.ReadFull(f, buf[:]); err != nil {
+		return 0
+	}
+	return binary.LittleEndian.Uint64(buf[:])
+}
+
+// writeNonceSidecar persists the nonce counter to the sidecar file. The counter
+// represents the next value to use (high-water mark + 1). Best-effort: errors
+// are logged but never propagated since the WAL is the source of truth.
+func writeNonceSidecar(path string, ctr uint64, logger log.Logger) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		if logger != nil && logger.Enabled(log.LevelWarn) {
+			logger.Log(log.LevelWarn, "persistence: failed to create nonce sidecar",
+				log.String("path", path), log.String("error", err.Error()))
+		}
+		return
+	}
+	defer f.Close()
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], ctr)
+	if _, err := f.Write(buf[:]); err != nil {
+		if logger != nil && logger.Enabled(log.LevelWarn) {
+			logger.Log(log.LevelWarn, "persistence: failed to write nonce sidecar",
+				log.String("path", path), log.String("error", err.Error()))
+		}
+		return
+	}
+	if err := f.Sync(); err != nil {
+		if logger != nil && logger.Enabled(log.LevelWarn) {
+			logger.Log(log.LevelWarn, "persistence: failed to sync nonce sidecar",
+				log.String("path", path), log.String("error", err.Error()))
+		}
+	}
+}
+
 // shardHandle holds the WAL file and its per-shard mutex for a single shard.
 // When encryption is enabled, crypto holds the DEK engine and nonceCtr tracks
 // the next counter-based nonce value. The counter is durable: it is recovered
@@ -54,6 +105,7 @@ type shardHandle struct {
 	crypto   *crypto.Engine // nil when encryption disabled
 	walVer   uint8          // 0 = plaintext, 1 = encrypted
 	nonceCtr atomic.Uint64  // next nonce counter value
+	shardID  uint32         // shard identifier for sidecar path
 }
 
 // Storage provides a per-shard, append-only write-ahead log (WAL) for crash recovery.
@@ -203,9 +255,16 @@ func (s *Storage) appendRecordEncrypted(h *shardHandle, shardID uint32, header [
 	}
 
 	// On-disk record: [recLen:4B LE][nonce:12B][ciphertext].
-	recLen := uint32(12 + len(ciphertext))
+	recLen := int64(12) + int64(len(ciphertext))
+	if recLen > int64(^uint32(0)) {
+		if s.logger.Enabled(log.LevelError) {
+			s.logger.Log(log.LevelError, "persistence: encrypted "+op+" record too large",
+				log.Uint("shard", shardID), log.String("key", key), log.Int64("bytes", recLen))
+		}
+		return fmt.Errorf("persistence: encrypted record too large (%d bytes, max %d)", recLen, ^uint32(0))
+	}
 	var recLenBuf [4]byte
-	binary.LittleEndian.PutUint32(recLenBuf[:], recLen)
+	binary.LittleEndian.PutUint32(recLenBuf[:], uint32(recLen))
 
 	if _, err := h.file.Write(recLenBuf[:]); err != nil {
 		if s.logger.Enabled(log.LevelError) {
@@ -327,7 +386,7 @@ func (s *Storage) OpenShard(shardID uint32, cryptoEng *crypto.Engine) error {
 		return err
 	}
 
-	h := &shardHandle{file: f}
+	h := &shardHandle{file: f, shardID: shardID}
 
 	// Detect or write the WAL header based on file contents and crypto config.
 	fi, err := f.Stat()
@@ -376,6 +435,10 @@ func (s *Storage) OpenShard(shardID uint32, cryptoEng *crypto.Engine) error {
 	}
 
 	s.mapMu.Lock()
+	if old, ok := s.shards[shardID]; ok {
+		// Close the existing handle to avoid file descriptor leak.
+		old.file.Close()
+	}
 	s.shards[shardID] = h
 	s.mapMu.Unlock()
 	if s.logger.Enabled(log.LevelDebug) {
@@ -398,7 +461,11 @@ func (s *Storage) LoadShard(shardID uint32, engine *storage.Engine) error {
 	// preceding it is unrecoverable — abort rather than continuing with
 	// a partial state and replaying the WAL on top of an empty engine.
 	if snapshotExists(s.dir, shardID) {
-		loadedKeys, err := snapshotRead(s.dir, shardID, engine, s.logger)
+		var fp [16]byte
+		if h := s.getShard(shardID); h != nil && h.crypto != nil {
+			fp = h.crypto.KeyFingerprint()
+		}
+		loadedKeys, err := snapshotRead(s.dir, shardID, engine, fp, s.logger)
 		if err != nil {
 			if s.logger.Enabled(log.LevelError) {
 				s.logger.Log(log.LevelError, "persistence: snapshot load failed, data preceding snapshot is unrecoverable",
@@ -531,10 +598,11 @@ func (s *Storage) replayWALEncrypted(h *shardHandle, shardID uint32, f *os.File,
 		if recLen < 12+16 { // nonce(12) + tag(16) minimum
 			break
 		}
+		// Subtract the 4-byte recLen prefix itself before comparing.
+		remaining -= 4
 		if recLen > remaining {
 			break
 		}
-		remaining -= 4
 
 		// Read nonce + ciphertext.
 		record := make([]byte, recLen)
@@ -591,7 +659,17 @@ func (s *Storage) replayWALEncrypted(h *shardHandle, shardID uint32, f *os.File,
 	}
 
 	// Recover the nonce counter so future writes never reuse a nonce.
-	h.nonceCtr.Store(maxNonce + 1)
+	// Take the max of WAL-derived counter and sidecar counter. The sidecar
+	// persists the high-water mark so counter never regresses after WAL truncation.
+	walCtr := maxNonce + 1
+	sidecarCtr := readNonceSidecar(nonceSidecarPath(s.dir, shardID))
+	if sidecarCtr > walCtr {
+		walCtr = sidecarCtr
+	}
+	h.nonceCtr.Store(walCtr)
+
+	// Persist the counter to the sidecar for defense-in-depth.
+	writeNonceSidecar(nonceSidecarPath(s.dir, shardID), walCtr, s.logger)
 
 	s.finishReplay(h, shardID, fileSize, validOffset, recordsRead, recordsSkipped)
 	return nil
@@ -631,7 +709,6 @@ func (s *Storage) finishReplay(h *shardHandle, shardID uint32, fileSize, validOf
 	if validOffset < fileSize {
 		h.mu.Lock()
 		if err := h.file.Truncate(validOffset); err != nil {
-			h.mu.Unlock()
 			if s.logger.Enabled(log.LevelWarn) {
 				s.logger.Log(log.LevelWarn, "persistence: failed to truncate corrupted tail",
 					log.Uint("shard", shardID), log.String("error", err.Error()))
@@ -683,7 +760,11 @@ func (s *Storage) Snapshot(shardID uint32, engine *storage.Engine) error {
 	}
 	// Snapshot the engine state first. ForEach freezes the engine under a
 	// read lock so no new mutations complete during serialization.
-	if err := snapshotForkDump(s.dir, shardID, engine, s.logger); err != nil {
+	var fp [16]byte
+	if h := s.getShard(shardID); h != nil && h.crypto != nil {
+		fp = h.crypto.KeyFingerprint()
+	}
+	if err := snapshotForkDump(s.dir, shardID, engine, fp, s.logger); err != nil {
 		return err
 	}
 	h := s.getShard(shardID)
@@ -751,5 +832,9 @@ func (s *Storage) CloseShard(shardID uint32) error {
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	// Persist the nonce counter before closing so it survives process restart.
+	if h.walVer == 1 {
+		writeNonceSidecar(nonceSidecarPath(s.dir, shardID), h.nonceCtr.Load(), s.logger)
+	}
 	return h.file.Close()
 }

--- a/internal/persistence/persistence_test.go
+++ b/internal/persistence/persistence_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Saxy/Tellstone/internal/crypto"
 	"github.com/Saxy/Tellstone/internal/storage"
 )
 
@@ -115,7 +116,7 @@ func TestOpenShardCreatesFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s.OpenShard(0); err != nil {
+	if err := s.OpenShard(0, nil); err != nil {
 		t.Fatalf("OpenShard(0): %v", err)
 	}
 	path := filepath.Join(dir, "shard_000.db")
@@ -131,7 +132,7 @@ func TestOpenShardMultipleFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 	for i := uint32(0); i < 4; i++ {
-		if err := s.OpenShard(i); err != nil {
+		if err := s.OpenShard(i, nil); err != nil {
 			t.Fatalf("OpenShard(%d): %v", i, err)
 		}
 	}
@@ -149,7 +150,7 @@ func TestOpenShardInvalidPath(t *testing.T) {
 		t.Fatal(err)
 	}
 	s.dir = "/nonexistent/path"
-	if err := s.OpenShard(0); err == nil {
+	if err := s.OpenShard(0, nil); err == nil {
 		t.Fatal("expected error when opening shard with invalid dir")
 	}
 }
@@ -184,7 +185,7 @@ func TestWriteRecordBinaryFormat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s.OpenShard(0); err != nil {
+	if err := s.OpenShard(0, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -233,7 +234,7 @@ func TestWriteZeroTTL(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s.OpenShard(0); err != nil {
+	if err := s.OpenShard(0, nil); err != nil {
 		t.Fatal(err)
 	}
 	if err := s.Write(0, "k", []byte("v"), time.Time{}); err != nil {
@@ -247,7 +248,7 @@ func TestWriteMultipleRecords(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s.OpenShard(0); err != nil {
+	if err := s.OpenShard(0, nil); err != nil {
 		t.Fatal(err)
 	}
 	type record struct {
@@ -285,7 +286,7 @@ func TestLoadShardEmptyFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s.OpenShard(0); err != nil {
+	if err := s.OpenShard(0, nil); err != nil {
 		t.Fatal(err)
 	}
 	engine := newTestEngine(t)
@@ -303,7 +304,7 @@ func TestLoadShardRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s.OpenShard(0); err != nil {
+	if err := s.OpenShard(0, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -350,7 +351,7 @@ func TestLoadShardSkipsExpiredKeys(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s.OpenShard(0); err != nil {
+	if err := s.OpenShard(0, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -400,7 +401,7 @@ func TestLoadShardTwiceAppended(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s.OpenShard(0); err != nil {
+	if err := s.OpenShard(0, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -437,7 +438,7 @@ func TestLoadShardTTLRefresh(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s.OpenShard(0); err != nil {
+	if err := s.OpenShard(0, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -485,7 +486,7 @@ func TestWriteEmptyKeyAndValue(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s.OpenShard(0); err != nil {
+	if err := s.OpenShard(0, nil); err != nil {
 		t.Fatal(err)
 	}
 	if err := s.Write(0, "", []byte{}, time.Time{}); err != nil {
@@ -508,7 +509,7 @@ func TestWriteLargeValue(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s.OpenShard(0); err != nil {
+	if err := s.OpenShard(0, nil); err != nil {
 		t.Fatal(err)
 	}
 	largeVal := make([]byte, 1024*1024) // 1 MiB
@@ -538,14 +539,14 @@ func TestOpenShardReopen(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s.OpenShard(0); err != nil {
+	if err := s.OpenShard(0, nil); err != nil {
 		t.Fatal(err)
 	}
 	if err := s.Write(0, "k1", []byte("v1"), time.Time{}); err != nil {
 		t.Fatal(err)
 	}
 	// Reopening appends to existing file
-	if err := s.OpenShard(0); err != nil {
+	if err := s.OpenShard(0, nil); err != nil {
 		t.Fatal(err)
 	}
 	if err := s.Write(0, "k2", []byte("v2"), time.Time{}); err != nil {
@@ -568,7 +569,7 @@ func TestWriteConcurrent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s.OpenShard(0); err != nil {
+	if err := s.OpenShard(0, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -591,7 +592,7 @@ func TestWriteConcurrent(t *testing.T) {
 	if err := s.CloseShard(0); err != nil {
 		t.Fatalf("close shard: %v", err)
 	}
-	if err := s.OpenShard(0); err != nil {
+	if err := s.OpenShard(0, nil); err != nil {
 		t.Fatalf("reopen shard: %v", err)
 	}
 	engine := newTestEngine(t)
@@ -623,5 +624,293 @@ func TestGetDefaultDir(t *testing.T) {
 	dir := getDefaultDir()
 	if dir == "" {
 		t.Fatal("getDefaultDir returned empty string")
+	}
+}
+
+// --- Encrypted WAL tests ---
+
+func newCryptoEngine(t *testing.T) *crypto.Engine {
+	t.Helper()
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i)
+	}
+	eng, err := crypto.NewEngine(key, nil)
+	if err != nil {
+		t.Fatalf("crypto.NewEngine: %v", err)
+	}
+	return eng
+}
+
+// TestEncryptedWALRoundTrip writes records to an encrypted WAL, closes the shard,
+// reopens it, and replays to verify all records survive.
+func TestEncryptedWALRoundTrip(t *testing.T) {
+	dir := newTestDir(t)
+	s, err := NewStorage(true, nil, dir)
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+	defer s.CloseShard(0)
+
+	ce := newCryptoEngine(t)
+	if err := s.OpenShard(0, ce); err != nil {
+		t.Fatalf("OpenShard: %v", err)
+	}
+
+	// Write records.
+	for i := 0; i < 50; i++ {
+		key := fmt.Sprintf("key_%d", i)
+		val := fmt.Sprintf("val_%d", i)
+		if err := s.Write(0, key, []byte(val), time.Now().Add(time.Hour)); err != nil {
+			t.Fatalf("Write %d: %v", i, err)
+		}
+	}
+	if err := s.CloseShard(0); err != nil {
+		t.Fatalf("CloseShard: %v", err)
+	}
+
+	// Reopen and replay.
+	if err := s.OpenShard(0, ce); err != nil {
+		t.Fatalf("reopen OpenShard: %v", err)
+	}
+	engine := newTestEngine(t)
+	if err := s.LoadShard(0, engine); err != nil {
+		t.Fatalf("LoadShard: %v", err)
+	}
+	if engine.KeyCount() != 50 {
+		t.Fatalf("expected 50 keys, got %d", engine.KeyCount())
+	}
+	for i := 0; i < 50; i++ {
+		key := fmt.Sprintf("key_%d", i)
+		expected := fmt.Sprintf("val_%d", i)
+		val, ok := engine.Get(key)
+		if !ok {
+			t.Errorf("key %q not found", key)
+			continue
+		}
+		if string(val) != expected {
+			t.Errorf("key %q = %q, want %q", key, val, expected)
+		}
+	}
+}
+
+// TestEncryptedWALHeaderWritten verifies that OpenShard with a crypto engine
+// writes the WAL magic header to a new file.
+func TestEncryptedWALHeaderWritten(t *testing.T) {
+	dir := newTestDir(t)
+	s, err := NewStorage(true, nil, dir)
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+	defer s.CloseShard(0)
+
+	ce := newCryptoEngine(t)
+	if err := s.OpenShard(0, ce); err != nil {
+		t.Fatalf("OpenShard: %v", err)
+	}
+	s.CloseShard(0)
+
+	// Read first 4 bytes from the WAL file.
+	data, err := os.ReadFile(filepath.Join(dir, "shard_000.db"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if len(data) < walMagicLen {
+		t.Fatalf("file too short: %d bytes", len(data))
+	}
+	if string(data[:walMagicLen]) != walMagic {
+		t.Fatalf("WAL header = %q, want %q", string(data[:walMagicLen]), walMagic)
+	}
+}
+
+// TestEncryptedWALRejectsMismatchedCrypto verifies that opening an encrypted
+// WAL without a crypto engine, or a plaintext WAL with a crypto engine, fails.
+func TestEncryptedWALRejectsMismatchedCrypto(t *testing.T) {
+	dir := newTestDir(t)
+	s, err := NewStorage(true, nil, dir)
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+	defer s.CloseShard(0)
+
+	ce := newCryptoEngine(t)
+
+	// Write header + record.
+	if err := s.OpenShard(0, ce); err != nil {
+		t.Fatalf("OpenShard: %v", err)
+	}
+	if err := s.Write(0, "k", []byte("v"), time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	s.CloseShard(0)
+
+	// Reopen without crypto — should fail.
+	if err := s.OpenShard(0, nil); err == nil {
+		t.Fatal("expected error opening encrypted WAL without crypto")
+	}
+	s.CloseShard(0)
+
+	// Write a plaintext WAL.
+	if err := s.OpenShard(1, nil); err != nil {
+		t.Fatalf("OpenShard plaintext: %v", err)
+	}
+	if err := s.Write(1, "k", []byte("v"), time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	s.CloseShard(1)
+
+	// Reopen plaintext WAL with crypto — should fail.
+	if err := s.OpenShard(1, ce); err == nil {
+		t.Fatal("expected error opening plaintext WAL with crypto")
+	}
+}
+
+// TestEncryptedWALNonceCounterRecovery verifies that after closing and reopening
+// an encrypted shard, the nonce counter is recovered from the WAL so nonces
+// never repeat.
+func TestEncryptedWALNonceCounterRecovery(t *testing.T) {
+	dir := newTestDir(t)
+	s, err := NewStorage(true, nil, dir)
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+	defer s.CloseShard(0)
+
+	ce := newCryptoEngine(t)
+
+	// First session: write 10 records.
+	if err := s.OpenShard(0, ce); err != nil {
+		t.Fatalf("OpenShard: %v", err)
+	}
+	for i := 0; i < 10; i++ {
+		if err := s.Write(0, fmt.Sprintf("k%d", i), []byte("v"), time.Now().Add(time.Hour)); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+	s.CloseShard(0)
+
+	// Second session: reopen, write more records.
+	if err := s.OpenShard(0, ce); err != nil {
+		t.Fatalf("reopen OpenShard: %v", err)
+	}
+	engine := newTestEngine(t)
+	if err := s.LoadShard(0, engine); err != nil {
+		t.Fatalf("LoadShard: %v", err)
+	}
+
+	// Check the nonce counter was recovered (should be > 0 since 10 records written).
+	h := s.getShard(0)
+	if h == nil {
+		t.Fatal("shard not found")
+	}
+	ctr := h.nonceCtr.Load()
+	if ctr == 0 {
+		t.Fatal("nonce counter not recovered after reopen")
+	}
+
+	// Write more records — these must not reuse nonces.
+	for i := 0; i < 10; i++ {
+		if err := s.Write(0, fmt.Sprintf("k2_%d", i), []byte("v"), time.Now().Add(time.Hour)); err != nil {
+			t.Fatalf("Write second session: %v", err)
+		}
+	}
+	s.CloseShard(0)
+
+	// Verify all records survive.
+	if err := s.OpenShard(0, ce); err != nil {
+		t.Fatalf("final OpenShard: %v", err)
+	}
+	engine2 := newTestEngine(t)
+	if err := s.LoadShard(0, engine2); err != nil {
+		t.Fatalf("LoadShard: %v", err)
+	}
+	if engine2.KeyCount() != 20 {
+		t.Fatalf("expected 20 keys, got %d", engine2.KeyCount())
+	}
+}
+
+// TestEncryptedWALCorruptRecordStopsReplay verifies that a corrupted encrypted
+// record is detected and replay stops cleanly (remaining records are dropped).
+func TestEncryptedWALCorruptRecordStopsReplay(t *testing.T) {
+	dir := newTestDir(t)
+	s, err := NewStorage(true, nil, dir)
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+	defer s.CloseShard(0)
+
+	ce := newCryptoEngine(t)
+
+	// Write 5 records.
+	if err := s.OpenShard(0, ce); err != nil {
+		t.Fatalf("OpenShard: %v", err)
+	}
+	for i := 0; i < 5; i++ {
+		if err := s.Write(0, fmt.Sprintf("k%d", i), []byte("v"), time.Now().Add(time.Hour)); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+	s.CloseShard(0)
+
+	// Corrupt the file: flip a byte in the middle of the first encrypted record
+	// (after the 4-byte WAL magic header).
+	path := filepath.Join(dir, "shard_000.db")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	// Flip a byte in the ciphertext region (after magic + 4-byte recLen + 2 nonce bytes).
+	if len(data) > walMagicLen+10 {
+		data[walMagicLen+10] ^= 0xFF
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// Reopen — should not crash, just load fewer records.
+	if err := s.OpenShard(0, ce); err != nil {
+		t.Fatalf("OpenShard: %v", err)
+	}
+	engine := newTestEngine(t)
+	if err := s.LoadShard(0, engine); err != nil {
+		t.Fatalf("LoadShard: %v", err)
+	}
+	// At least some records may be loaded, but not all 5 since decryption
+	// of the corrupted record will fail and stop replay.
+	if engine.KeyCount() > 5 {
+		t.Fatalf("expected at most 5 keys, got %d", engine.KeyCount())
+	}
+}
+
+// TestEncryptedWALPlaintextReplayUnchanged verifies that the plaintext WAL path
+// (walVer=0) still works correctly with the refactored replay code.
+func TestEncryptedWALPlaintextReplayUnchanged(t *testing.T) {
+	dir := newTestDir(t)
+	s, err := NewStorage(true, nil, dir)
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+	defer s.CloseShard(0)
+
+	// Use nil crypto engine (plaintext WAL).
+	if err := s.OpenShard(0, nil); err != nil {
+		t.Fatalf("OpenShard: %v", err)
+	}
+	for i := 0; i < 30; i++ {
+		if err := s.Write(0, fmt.Sprintf("k%d", i), []byte("v"), time.Now().Add(time.Hour)); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+	s.CloseShard(0)
+
+	if err := s.OpenShard(0, nil); err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	engine := newTestEngine(t)
+	if err := s.LoadShard(0, engine); err != nil {
+		t.Fatalf("LoadShard: %v", err)
+	}
+	if engine.KeyCount() != 30 {
+		t.Fatalf("expected 30 keys, got %d", engine.KeyCount())
 	}
 }

--- a/internal/persistence/persistence_test.go
+++ b/internal/persistence/persistence_test.go
@@ -1,6 +1,7 @@
 package persistence
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"os"
@@ -669,6 +670,22 @@ func TestEncryptedWALRoundTrip(t *testing.T) {
 		t.Fatalf("CloseShard: %v", err)
 	}
 
+	// Verify no plaintext keys or values on disk.
+	data, err := os.ReadFile(filepath.Join(dir, "shard_000.db"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	for i := 0; i < 50; i++ {
+		key := []byte(fmt.Sprintf("key_%d", i))
+		val := []byte(fmt.Sprintf("val_%d", i))
+		if bytes.Contains(data, key) {
+			t.Errorf("plaintext key %q found on disk", key)
+		}
+		if bytes.Contains(data, val) {
+			t.Errorf("plaintext value %q found on disk", val)
+		}
+	}
+
 	// Reopen and replay.
 	if err := s.OpenShard(0, ce); err != nil {
 		t.Fatalf("reopen OpenShard: %v", err)
@@ -798,14 +815,15 @@ func TestEncryptedWALNonceCounterRecovery(t *testing.T) {
 		t.Fatalf("LoadShard: %v", err)
 	}
 
-	// Check the nonce counter was recovered (should be > 0 since 10 records written).
+	// Check the nonce counter was recovered. After 10 writes, the counter
+	// tracks the max nonce (9) and recovery sets it to max+1 = 10.
 	h := s.getShard(0)
 	if h == nil {
 		t.Fatal("shard not found")
 	}
 	ctr := h.nonceCtr.Load()
-	if ctr == 0 {
-		t.Fatal("nonce counter not recovered after reopen")
+	if ctr != 10 {
+		t.Fatalf("nonce counter = %d, want 10", ctr)
 	}
 
 	// Write more records — these must not reuse nonces.
@@ -852,14 +870,16 @@ func TestEncryptedWALCorruptRecordStopsReplay(t *testing.T) {
 	}
 	s.CloseShard(0)
 
-	// Corrupt the file: flip a byte in the middle of the first encrypted record
-	// (after the 4-byte WAL magic header).
+	// Corrupt the file: flip a byte in the 12-byte nonce of the first encrypted
+	// record (after the 4-byte WAL magic header and 4-byte recLen).
 	path := filepath.Join(dir, "shard_000.db")
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("ReadFile: %v", err)
 	}
-	// Flip a byte in the ciphertext region (after magic + 4-byte recLen + 2 nonce bytes).
+	// Flip a byte within the nonce (offset walMagicLen+4+2 = 10, which is
+	// nonce byte 2). This invalidates the nonce and causes AEAD decryption
+	// to fail for the first record, stopping replay immediately.
 	if len(data) > walMagicLen+10 {
 		data[walMagicLen+10] ^= 0xFF
 	}
@@ -867,7 +887,8 @@ func TestEncryptedWALCorruptRecordStopsReplay(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	// Reopen — should not crash, just load fewer records.
+	// Reopen — should not crash, and no records load since the first
+	// record's nonce is corrupted and AEAD verification fails.
 	if err := s.OpenShard(0, ce); err != nil {
 		t.Fatalf("OpenShard: %v", err)
 	}
@@ -875,10 +896,8 @@ func TestEncryptedWALCorruptRecordStopsReplay(t *testing.T) {
 	if err := s.LoadShard(0, engine); err != nil {
 		t.Fatalf("LoadShard: %v", err)
 	}
-	// At least some records may be loaded, but not all 5 since decryption
-	// of the corrupted record will fail and stop replay.
-	if engine.KeyCount() > 5 {
-		t.Fatalf("expected at most 5 keys, got %d", engine.KeyCount())
+	if engine.KeyCount() != 0 {
+		t.Fatalf("expected 0 keys (corruption stops replay), got %d", engine.KeyCount())
 	}
 }
 

--- a/internal/persistence/persistence_test.go
+++ b/internal/persistence/persistence_test.go
@@ -989,12 +989,6 @@ func TestEncryptedNonceCounterSurvivesTruncateWithoutClose(t *testing.T) {
 	if err := s.TruncateWALTo(0, walMagicLen); err != nil {
 		t.Fatalf("TruncateWALTo: %v", err)
 	}
-
-	// Phase 3: simulate restart — reopen and replay. The sidecar must
-	// carry the counter forward even though the WAL is empty.
-	if err := s.CloseShard(0); err != nil {
-		t.Fatalf("CloseShard: %v", err)
-	}
 	s2, err := NewStorage(true, nil, dir)
 	if err != nil {
 		t.Fatalf("NewStorage phase 3: %v", err)

--- a/internal/persistence/persistence_test.go
+++ b/internal/persistence/persistence_test.go
@@ -933,3 +933,87 @@ func TestEncryptedWALPlaintextReplayUnchanged(t *testing.T) {
 		t.Fatalf("expected 30 keys, got %d", engine.KeyCount())
 	}
 }
+
+// TestEncryptedNonceCounterSurvivesTruncateWithoutClose verifies that the nonce
+// counter does not regress when the WAL is truncated to walMagicLen (effectively
+// empty) without calling CloseShard. The sidecar must be persisted before
+// truncation in truncateWALLocked so a crash after truncation still has the
+// correct counter on restart.
+func TestEncryptedNonceCounterSurvivesTruncateWithoutClose(t *testing.T) {
+	dir := newTestDir(t)
+	ce := newCryptoEngine(t)
+
+	// Phase 1: open shard, write 10 records, close (persist sidecar).
+	s, err := NewStorage(true, nil, dir)
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+	if err := s.OpenShard(0, ce); err != nil {
+		t.Fatalf("OpenShard: %v", err)
+	}
+	for i := 0; i < 10; i++ {
+		if err := s.Write(0, fmt.Sprintf("k%d", i), []byte(fmt.Sprintf("v%d", i)), time.Time{}); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+	if err := s.CloseShard(0); err != nil {
+		t.Fatalf("CloseShard: %v", err)
+	}
+
+	// Phase 2: reopen, write 5 more records (counter is now 15), then
+	// truncate to walMagicLen (empty WAL) WITHOUT CloseShard.
+	if err := s.OpenShard(0, ce); err != nil {
+		t.Fatalf("OpenShard phase 2: %v", err)
+	}
+	engine := newTestEngine(t)
+	if err := s.LoadShard(0, engine); err != nil {
+		t.Fatalf("LoadShard phase 2: %v", err)
+	}
+	for i := 10; i < 15; i++ {
+		if err := s.Write(0, fmt.Sprintf("k%d", i), []byte(fmt.Sprintf("v%d", i)), time.Time{}); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+
+	h := s.getShard(0)
+	if h == nil {
+		t.Fatal("shard not found")
+	}
+	ctrBeforeTruncate := h.nonceCtr.Load()
+	if ctrBeforeTruncate != 15 {
+		t.Fatalf("counter before truncate = %d, want 15", ctrBeforeTruncate)
+	}
+
+	// Truncate WAL to magic-only (empty). Do NOT call CloseShard — simulates
+	// a crash after truncation but before graceful shutdown.
+	if err := s.TruncateWALTo(0, walMagicLen); err != nil {
+		t.Fatalf("TruncateWALTo: %v", err)
+	}
+
+	// Phase 3: simulate restart — reopen and replay. The sidecar must
+	// carry the counter forward even though the WAL is empty.
+	if err := s.CloseShard(0); err != nil {
+		t.Fatalf("CloseShard: %v", err)
+	}
+	s2, err := NewStorage(true, nil, dir)
+	if err != nil {
+		t.Fatalf("NewStorage phase 3: %v", err)
+	}
+	defer s2.CloseShard(0)
+	if err := s2.OpenShard(0, ce); err != nil {
+		t.Fatalf("OpenShard phase 3: %v", err)
+	}
+	engine2 := newTestEngine(t)
+	if err := s2.LoadShard(0, engine2); err != nil {
+		t.Fatalf("LoadShard phase 3: %v", err)
+	}
+
+	h2 := s2.getShard(0)
+	if h2 == nil {
+		t.Fatal("shard not found phase 3")
+	}
+	ctrAfterRestart := h2.nonceCtr.Load()
+	if ctrAfterRestart != 15 {
+		t.Fatalf("counter after restart = %d, want 15 (no regression from truncation)", ctrAfterRestart)
+	}
+}

--- a/internal/persistence/snapshot.go
+++ b/internal/persistence/snapshot.go
@@ -39,9 +39,12 @@ import (
 
 const (
 	snapMagic       = "TSNS"
-	snapVersion     = 2
-	snapHeader      = 48 // magic(4) + version(4) + keyCount(8) + createdAt(8) + checksum(8) + fingerprint(16)
-	snapFingerprint = 32 // offset of fingerprint field within header
+	snapVersion1    = 1
+	snapVersion2    = 2
+	snapVersion     = snapVersion2
+	snapBaseHeader  = 32
+	snapHeader      = 48
+	snapFingerprint = 32
 )
 
 // snapshotCleanup closes f and removes tmpPath as best-effort cleanup
@@ -124,7 +127,6 @@ func SnapshotChildMain() {
 	if err != nil {
 		os.Exit(1)
 	}
-
 	var fp [16]byte
 	if fpHex := os.Getenv("TSD_SNAP_FP"); fpHex != "" {
 		decoded, dErr := hex.DecodeString(fpHex)
@@ -133,7 +135,6 @@ func SnapshotChildMain() {
 		}
 		copy(fp[:], decoded)
 	}
-
 	err = snapshotChildWrite(dir, uint32(id), os.Stdin, fp)
 	if err != nil {
 		os.Exit(1)
@@ -149,27 +150,21 @@ func SnapshotChildMain() {
 func snapshotWrite(dir string, shardID uint32, engine *storage.Engine, fingerprint [16]byte, logger log.Logger) (uint64, error) {
 	tmpPath := filepath.Join(dir, fmt.Sprintf("shard_%03d.snap.tmp", shardID))
 	finalPath := filepath.Join(dir, fmt.Sprintf("shard_%03d.snap", shardID))
-
 	f, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
 	if err != nil {
 		return 0, fmt.Errorf("snapshot: create %s: %w", tmpPath, err)
 	}
-
 	hdr := buildSnapshotHeader(fingerprint)
-
 	if _, err = f.Write(hdr[:]); err != nil {
 		return 0, snapshotCleanup(f, tmpPath, fmt.Errorf("snapshot: write header: %w", err), logger)
 	}
-
 	h := xxhash.New()
 	if _, err = h.Write(hdr[:]); err != nil {
 		return 0, snapshotCleanup(f, tmpPath, fmt.Errorf("snapshot: hash header: %w", err), logger)
 	}
-
 	var keyCount uint64
 	var writeErr error
 	var entry [16]byte
-
 	engine.ForEach(func(key string, value []byte, expiration time.Time) {
 		if writeErr != nil {
 			return
@@ -183,7 +178,6 @@ func snapshotWrite(dir string, shardID uint32, engine *storage.Engine, fingerpri
 		binary.LittleEndian.PutUint32(entry[0:4], keyLen)
 		binary.LittleEndian.PutUint32(entry[4:8], valLen)
 		binary.LittleEndian.PutUint64(entry[8:16], uint64(ttlNano))
-
 		if _, err = h.Write(entry[:]); err != nil {
 			writeErr = err
 			return
@@ -211,27 +205,21 @@ func snapshotWrite(dir string, shardID uint32, engine *storage.Engine, fingerpri
 		}
 		keyCount++
 	})
-
 	if writeErr != nil {
 		return 0, snapshotCleanup(f, tmpPath, fmt.Errorf("snapshot: write entry: %w", writeErr), logger)
 	}
-
 	if err = f.Sync(); err != nil {
 		return 0, snapshotCleanup(f, tmpPath, fmt.Errorf("snapshot: sync: %w", err), logger)
 	}
-
-	// Patch header with final checksum and key count.
 	checksum := h.Sum64()
 	binary.LittleEndian.PutUint64(hdr[8:16], keyCount)
 	binary.LittleEndian.PutUint64(hdr[24:32], checksum)
-
 	if _, err = f.Seek(0, 0); err != nil {
 		return 0, snapshotCleanup(f, tmpPath, fmt.Errorf("snapshot: seek header: %w", err), logger)
 	}
 	if _, err = f.Write(hdr[:]); err != nil {
 		return 0, snapshotCleanup(f, tmpPath, fmt.Errorf("snapshot: patch header: %w", err), logger)
 	}
-
 	if err = f.Sync(); err != nil {
 		return 0, snapshotCleanup(f, tmpPath, fmt.Errorf("snapshot: sync header: %w", err), logger)
 	}
@@ -241,7 +229,6 @@ func snapshotWrite(dir string, shardID uint32, engine *storage.Engine, fingerpri
 		}
 		return 0, fmt.Errorf("snapshot: close: %w", err)
 	}
-
 	if err = os.Rename(tmpPath, finalPath); err != nil {
 		if rerr := os.Remove(tmpPath); rerr != nil {
 			logCleanupWarn("snapshot: remove tmp after rename error", rerr, logger)
@@ -278,57 +265,56 @@ func snapshotRead(dir string, shardID uint32, engine *storage.Engine, fp [16]byt
 			logCleanupWarn("snapshot: close file", cerr, logger)
 		}
 	}()
-
 	fi, err := f.Stat()
 	if err != nil {
 		return 0, fmt.Errorf("snapshot: stat %s: %w", path, err)
 	}
 	fileSize := fi.Size()
-
-	var hdr [snapHeader]byte
-	if _, err = io.ReadFull(f, hdr[:]); err != nil {
+	var baseHdr [snapBaseHeader]byte
+	if _, err = io.ReadFull(f, baseHdr[:]); err != nil {
 		return 0, fmt.Errorf("snapshot: read header: %w", err)
 	}
-	if string(hdr[0:4]) != snapMagic {
-		return 0, fmt.Errorf("snapshot: invalid magic %q (want %q)", string(hdr[0:4]), snapMagic)
+	if string(baseHdr[0:4]) != snapMagic {
+		return 0, fmt.Errorf("snapshot: invalid magic %q (want %q)", string(baseHdr[0:4]), snapMagic)
 	}
-	version := binary.LittleEndian.Uint32(hdr[4:8])
-	if version != snapVersion {
-		return 0, fmt.Errorf("snapshot: unsupported version %d (want %d)", version, snapVersion)
+	version := binary.LittleEndian.Uint32(baseHdr[4:8])
+	if version != snapVersion1 && version != snapVersion2 {
+		return 0, fmt.Errorf("snapshot: unsupported version %d (want %d or %d)", version, snapVersion1, snapVersion2)
 	}
-	// Validate key fingerprint. A non-zero fp means encryption is active and
-	// the snapshot must have been created with the same key. A zero fp means
-	// encryption is disabled, so the snapshot must also have a zero fingerprint.
-	fileFingerprint := [16]byte{}
-	copy(fileFingerprint[:], hdr[snapFingerprint:snapHeader])
+	var fileFingerprint [16]byte
+	if version == snapVersion2 {
+		if _, err = io.ReadFull(f, fileFingerprint[:]); err != nil {
+			return 0, fmt.Errorf("snapshot: read v2 fingerprint: %w", err)
+		}
+	}
 	if fileFingerprint != fp {
 		return 0, fmt.Errorf("snapshot: key fingerprint mismatch (snapshot was encrypted with a different key)")
 	}
-	fileKeyCount := binary.LittleEndian.Uint64(hdr[8:16])
-	fileChecksum := binary.LittleEndian.Uint64(hdr[24:32])
-
-	// Compute checksum over (header with KeyCount=0, checksum=0) + all entries.
-	// This matches the writer: it hashes the placeholder header (KeyCount=0,
-	// checksum=0) before patching the real values. We must hash the same bytes.
+	fileKeyCount := binary.LittleEndian.Uint64(baseHdr[8:16])
+	fileChecksum := binary.LittleEndian.Uint64(baseHdr[24:32])
 	h := xxhash.New()
-	binary.LittleEndian.PutUint64(hdr[8:16], 0)
-	binary.LittleEndian.PutUint64(hdr[24:32], 0)
-	if _, err = h.Write(hdr[:]); err != nil {
+	binary.LittleEndian.PutUint64(baseHdr[8:16], 0)
+	binary.LittleEndian.PutUint64(baseHdr[24:32], 0)
+	if _, err = h.Write(baseHdr[:]); err != nil {
 		return 0, fmt.Errorf("snapshot: hash header: %w", err)
 	}
-
-	// Decode all entries into temporary buffers before touching the engine so
-	// that a checksum failure leaves the engine untouched. Each buffer is
-	// contiguous [key|value] for SetFromBuffer compatibility.
+	if version == snapVersion2 {
+		if _, err = h.Write(fileFingerprint[:]); err != nil {
+			return 0, fmt.Errorf("snapshot: hash fingerprint: %w", err)
+		}
+	}
 	type decodedEntry struct {
-		kvBuf   []byte // [key|value] contiguous
+		kvBuf   []byte
 		keyLen  uint32
 		ttlNano int64
 	}
 	var entries []decodedEntry
 	entryBuf := make([]byte, 16)
-	remaining := fileSize - int64(snapHeader)
-
+	var headerBytes int64 = snapBaseHeader
+	if version == snapVersion2 {
+		headerBytes = snapHeader
+	}
+	remaining := fileSize - headerBytes
 	for {
 		if _, err = io.ReadFull(f, entryBuf); err != nil {
 			if errors.Is(err, io.EOF) {
@@ -339,7 +325,6 @@ func snapshotRead(dir string, shardID uint32, engine *storage.Engine, fp [16]byt
 		if _, err = h.Write(entryBuf); err != nil {
 			return 0, fmt.Errorf("snapshot: hash entry header: %w", err)
 		}
-
 		keyLen := binary.LittleEndian.Uint32(entryBuf[0:4])
 		valLen := binary.LittleEndian.Uint32(entryBuf[4:8])
 		ttlNano := int64(binary.LittleEndian.Uint64(entryBuf[8:16]))
@@ -353,22 +338,18 @@ func snapshotRead(dir string, shardID uint32, engine *storage.Engine, fp [16]byt
 		if _, err = io.ReadFull(f, buf); err != nil {
 			return 0, fmt.Errorf("snapshot: read key+value: %w", err)
 		}
-		if _, err := h.Write(buf[:keyLen]); err != nil {
+		if _, err = h.Write(buf[:keyLen]); err != nil {
 			return 0, fmt.Errorf("snapshot: hash key: %w", err)
 		}
-		if _, err := h.Write(buf[keyLen:]); err != nil {
+		if _, err = h.Write(buf[keyLen:]); err != nil {
 			return 0, fmt.Errorf("snapshot: hash value: %w", err)
 		}
-
 		entries = append(entries, decodedEntry{kvBuf: buf, keyLen: keyLen, ttlNano: ttlNano})
 	}
-
 	actualChecksum := h.Sum64()
 	if actualChecksum != fileChecksum {
 		return 0, fmt.Errorf("snapshot: checksum mismatch (file=%d, computed=%d)", fileChecksum, actualChecksum)
 	}
-
-	// Checksum is valid — safe to apply entries to the engine.
 	var loadedKeys uint64
 	useRaw := engine.CryptoEnabled()
 	for i := range entries {
@@ -382,8 +363,6 @@ func snapshotRead(dir string, shardID uint32, engine *storage.Engine, fp [16]byt
 			}
 		}
 		if useRaw {
-			// Values from ForEach are already encrypted when crypto is on.
-			// SetRaw stores them without re-encrypting.
 			if err = engine.SetRaw(string(e.kvBuf[:e.keyLen]), e.kvBuf[e.keyLen:], duration); err != nil {
 				return 0, fmt.Errorf("snapshot: engine.SetRaw: %w", err)
 			}
@@ -394,7 +373,6 @@ func snapshotRead(dir string, shardID uint32, engine *storage.Engine, fp [16]byt
 		}
 		loadedKeys++
 	}
-
 	if logger != nil && logger.Enabled(log.LevelInfo) {
 		logger.Log(log.LevelInfo, "snapshot: loaded",
 			log.Uint("shard", shardID),
@@ -415,7 +393,6 @@ func snapshotExists(dir string, shardID uint32) bool {
 		return false
 	}
 	defer func() {
-		// Read-only open: close errors are harmless and cannot be reported.
 		_ = f.Close()
 	}()
 	var hdr [4]byte
@@ -436,26 +413,19 @@ func snapshotForkDump(dir string, shardID uint32, engine *storage.Engine, finger
 		_, err = snapshotWrite(dir, shardID, engine, fingerprint, logger)
 		return err
 	}
-
-	// Use a bounded deadline so cmd.Wait cannot block indefinitely if the
-	// child hangs or the pipe stalls.
 	const childTimeout = 2 * time.Minute
 	ctx, cancel := context.WithTimeout(context.Background(), childTimeout)
 	defer cancel()
-
 	cmd := exec.CommandContext(ctx, os.Args[0], "--snapshot-child")
 	cmd.Stdin = pr
 	cmd.Stdout = nil
 	cmd.Stderr = nil
-	// Replace inherited env with only the variables the child needs so that
-	// secrets and other host state are not leaked to the child process.
 	cmd.Env = []string{
 		"TSD_SNAP_DIR=" + dir,
 		fmt.Sprintf("TSD_SNAP_SHARD=%d", shardID),
 		"TSD_SNAP_FP=" + hex.EncodeToString(fingerprint[:]),
 	}
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-
 	if err = cmd.Start(); err != nil {
 		if cerr := pr.Close(); cerr != nil {
 			logCleanupWarn("snapshot: close pipe reader", cerr, logger)
@@ -470,13 +440,9 @@ func snapshotForkDump(dir string, shardID uint32, engine *storage.Engine, finger
 		_, err := snapshotWrite(dir, shardID, engine, fingerprint, logger)
 		return err
 	}
-
-	// Parent: close read end (child inherited it via cmd.Stdin).
 	if cerr := pr.Close(); cerr != nil {
 		logCleanupWarn("snapshot: close pipe reader", cerr, logger)
 	}
-
-	// Serialize engine state into the write end; propagate any write error.
 	if serr := serializeEngineToWriter(pw, engine); serr != nil {
 		if cerr := pw.Close(); cerr != nil {
 			logCleanupWarn("snapshot: close pipe writer", cerr, logger)
@@ -486,13 +452,9 @@ func snapshotForkDump(dir string, shardID uint32, engine *storage.Engine, finger
 		_ = cmd.Wait()
 		return fmt.Errorf("snapshot: serialize: %w", serr)
 	}
-
-	// Close write end so the child receives EOF on its stdin.
 	if cerr := pw.Close(); cerr != nil {
 		logCleanupWarn("snapshot: close pipe writer", cerr, logger)
 	}
-
-	// Wait for child to finish writing the snapshot file.
 	if err = cmd.Wait(); err != nil {
 		if logger.Enabled(log.LevelError) {
 			logger.Log(log.LevelError, "snapshot: child process failed",
@@ -500,7 +462,6 @@ func snapshotForkDump(dir string, shardID uint32, engine *storage.Engine, finger
 		}
 		return fmt.Errorf("snapshot: child: %w", err)
 	}
-
 	if logger.Enabled(log.LevelInfo) {
 		logger.Log(log.LevelInfo, "snapshot: fork-based dump complete",
 			log.Uint("shard", shardID))
@@ -527,7 +488,6 @@ func serializeEngineToWriter(w io.Writer, engine *storage.Engine) error {
 		binary.LittleEndian.PutUint32(hdr[0:4], keyLen)
 		binary.LittleEndian.PutUint32(hdr[4:8], valLen)
 		binary.LittleEndian.PutUint64(hdr[8:16], uint64(ttlNano))
-
 		if _, err := w.Write(hdr[:]); err != nil {
 			writeErr = err
 			return
@@ -550,27 +510,21 @@ func serializeEngineToWriter(w io.Writer, engine *storage.Engine) error {
 func snapshotChildWrite(dir string, shardID uint32, r io.Reader, fingerprint [16]byte) error {
 	tmpPath := filepath.Join(dir, fmt.Sprintf("shard_%03d.snap.tmp", shardID))
 	finalPath := filepath.Join(dir, fmt.Sprintf("shard_%03d.snap", shardID))
-
 	f, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
 	if err != nil {
 		return err
 	}
-
 	hdr := buildSnapshotHeader(fingerprint)
-
-	if _, err := f.Write(hdr[:]); err != nil {
+	if _, err = f.Write(hdr[:]); err != nil {
 		return snapshotCleanup(f, tmpPath, err, nil)
 	}
-
 	h := xxhash.New()
-	if _, err := h.Write(hdr[:]); err != nil {
+	if _, err = h.Write(hdr[:]); err != nil {
 		return snapshotCleanup(f, tmpPath, fmt.Errorf("snapshot: hash header: %w", err), nil)
 	}
-
 	var keyCount uint64
 	entryBuf := make([]byte, 16)
 	var keyBuf, valBuf []byte
-
 	for {
 		if _, err = io.ReadFull(r, entryBuf); err != nil {
 			if errors.Is(err, io.EOF) {
@@ -581,10 +535,8 @@ func snapshotChildWrite(dir string, shardID uint32, r io.Reader, fingerprint [16
 		if _, err = h.Write(entryBuf); err != nil {
 			return snapshotCleanup(f, tmpPath, fmt.Errorf("snapshot: hash entry header: %w", err), nil)
 		}
-
 		keyLen := binary.LittleEndian.Uint32(entryBuf[0:4])
 		valLen := binary.LittleEndian.Uint32(entryBuf[4:8])
-
 		if cap(keyBuf) < int(keyLen) {
 			keyBuf = make([]byte, keyLen)
 		} else {
@@ -596,7 +548,6 @@ func snapshotChildWrite(dir string, shardID uint32, r io.Reader, fingerprint [16
 		if _, err = h.Write(keyBuf); err != nil {
 			return snapshotCleanup(f, tmpPath, fmt.Errorf("snapshot: hash key: %w", err), nil)
 		}
-
 		if cap(valBuf) < int(valLen) {
 			valBuf = make([]byte, valLen)
 		} else {
@@ -608,7 +559,6 @@ func snapshotChildWrite(dir string, shardID uint32, r io.Reader, fingerprint [16
 		if _, err = h.Write(valBuf); err != nil {
 			return snapshotCleanup(f, tmpPath, fmt.Errorf("snapshot: hash value: %w", err), nil)
 		}
-
 		if _, err = f.Write(entryBuf); err != nil {
 			return snapshotCleanup(f, tmpPath, err, nil)
 		}

--- a/internal/persistence/snapshot.go
+++ b/internal/persistence/snapshot.go
@@ -21,6 +21,7 @@ package persistence
 import (
 	"context"
 	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -37,9 +38,10 @@ import (
 )
 
 const (
-	snapMagic   = "TSNS"
-	snapVersion = 1
-	snapHeader  = 32 // magic(4) + version(4) + keyCount(8) + createdAt(8) + checksum(8)
+	snapMagic       = "TSNS"
+	snapVersion     = 2
+	snapHeader      = 48 // magic(4) + version(4) + keyCount(8) + createdAt(8) + checksum(8) + fingerprint(16)
+	snapFingerprint = 32 // offset of fingerprint field within header
 )
 
 // snapshotCleanup closes f and removes tmpPath as best-effort cleanup
@@ -66,10 +68,12 @@ func logCleanupWarn(msg string, err error, logger log.Logger) {
 	}
 }
 
-// buildSnapshotHeader constructs the 32-byte placeholder snapshot header
-// with KeyCount=0 and checksum=0. Both fields are patched after all entries
-// are written and hashed. The caller must hash hdr before patching.
-func buildSnapshotHeader() [snapHeader]byte {
+// buildSnapshotHeader constructs the 48-byte placeholder snapshot header
+// with KeyCount=0, checksum=0, and the optional key fingerprint. Both KeyCount
+// and checksum are patched after all entries are written and hashed. The caller
+// must hash hdr before patching. fingerprint is the 16-byte truncated SHA-256
+// of the encryption key; a zero value means encryption is disabled.
+func buildSnapshotHeader(fingerprint [16]byte) [snapHeader]byte {
 	var hdr [snapHeader]byte
 	createdAt := time.Now().UnixNano()
 	copy(hdr[0:4], snapMagic)
@@ -77,6 +81,7 @@ func buildSnapshotHeader() [snapHeader]byte {
 	binary.LittleEndian.PutUint64(hdr[8:16], 0) // KeyCount patched later
 	binary.LittleEndian.PutUint64(hdr[16:24], uint64(createdAt))
 	binary.LittleEndian.PutUint64(hdr[24:32], 0) // checksum patched later
+	copy(hdr[snapFingerprint:snapHeader], fingerprint[:])
 	return hdr
 }
 
@@ -108,6 +113,7 @@ func IsSnapshotChild() bool {
 // SnapshotChildMain runs in the forked child process. It reads serialized
 // engine entries from stdin, writes the snapshot file, and exits.
 // The dir and shardID are passed via environment variables set by the parent.
+// TSD_SNAP_FP (optional) carries the hex-encoded 16-byte key fingerprint.
 func SnapshotChildMain() {
 	dir := os.Getenv("TSD_SNAP_DIR")
 	raw := os.Getenv("TSD_SNAP_SHARD")
@@ -119,7 +125,16 @@ func SnapshotChildMain() {
 		os.Exit(1)
 	}
 
-	err = snapshotChildWrite(dir, uint32(id), os.Stdin)
+	var fp [16]byte
+	if fpHex := os.Getenv("TSD_SNAP_FP"); fpHex != "" {
+		decoded, dErr := hex.DecodeString(fpHex)
+		if dErr != nil || len(decoded) != 16 {
+			os.Exit(1)
+		}
+		copy(fp[:], decoded)
+	}
+
+	err = snapshotChildWrite(dir, uint32(id), os.Stdin, fp)
 	if err != nil {
 		os.Exit(1)
 	}
@@ -128,8 +143,10 @@ func SnapshotChildMain() {
 
 // snapshotWrite serializes all live entries from the engine into a snapshot file.
 // Writes to a temporary file first, then atomically renames over the target.
+// fingerprint is the 16-byte key fingerprint embedded in the header for
+// validation on restore; a zero value means encryption is disabled.
 // Returns the number of keys written.
-func snapshotWrite(dir string, shardID uint32, engine *storage.Engine, logger log.Logger) (uint64, error) {
+func snapshotWrite(dir string, shardID uint32, engine *storage.Engine, fingerprint [16]byte, logger log.Logger) (uint64, error) {
 	tmpPath := filepath.Join(dir, fmt.Sprintf("shard_%03d.snap.tmp", shardID))
 	finalPath := filepath.Join(dir, fmt.Sprintf("shard_%03d.snap", shardID))
 
@@ -138,7 +155,7 @@ func snapshotWrite(dir string, shardID uint32, engine *storage.Engine, logger lo
 		return 0, fmt.Errorf("snapshot: create %s: %w", tmpPath, err)
 	}
 
-	hdr := buildSnapshotHeader()
+	hdr := buildSnapshotHeader(fingerprint)
 
 	if _, err = f.Write(hdr[:]); err != nil {
 		return 0, snapshotCleanup(f, tmpPath, fmt.Errorf("snapshot: write header: %w", err), logger)
@@ -247,9 +264,10 @@ func snapshotWrite(dir string, shardID uint32, engine *storage.Engine, logger lo
 
 // snapshotRead loads a snapshot file into the engine. It validates lengths,
 // verifies the checksum, and only then applies entries to the engine so that a
-// corrupted snapshot never mutates the live state. Returns the number of keys
-// loaded.
-func snapshotRead(dir string, shardID uint32, engine *storage.Engine, logger log.Logger) (uint64, error) {
+// corrupted snapshot never mutates the live state. If fp is non-zero, the
+// snapshot's embedded fingerprint must match; this prevents restoring a
+// snapshot encrypted with a different key. Returns the number of keys loaded.
+func snapshotRead(dir string, shardID uint32, engine *storage.Engine, fp [16]byte, logger log.Logger) (uint64, error) {
 	path := filepath.Join(dir, fmt.Sprintf("shard_%03d.snap", shardID))
 	f, err := os.Open(path)
 	if err != nil {
@@ -277,6 +295,14 @@ func snapshotRead(dir string, shardID uint32, engine *storage.Engine, logger log
 	version := binary.LittleEndian.Uint32(hdr[4:8])
 	if version != snapVersion {
 		return 0, fmt.Errorf("snapshot: unsupported version %d (want %d)", version, snapVersion)
+	}
+	// Validate key fingerprint. A non-zero fp means encryption is active and
+	// the snapshot must have been created with the same key. A zero fp means
+	// encryption is disabled, so the snapshot must also have a zero fingerprint.
+	fileFingerprint := [16]byte{}
+	copy(fileFingerprint[:], hdr[snapFingerprint:snapHeader])
+	if fileFingerprint != fp {
+		return 0, fmt.Errorf("snapshot: key fingerprint mismatch (snapshot was encrypted with a different key)")
 	}
 	fileKeyCount := binary.LittleEndian.Uint64(hdr[8:16])
 	fileChecksum := binary.LittleEndian.Uint64(hdr[24:32])
@@ -402,11 +428,12 @@ func snapshotExists(dir string, shardID uint32) bool {
 // snapshotForkDump triggers a fork-based snapshot. The parent serializes the
 // engine map to a pipe under a brief read lock, then ForkExec's the same binary
 // with --snapshot-child. The child reads from the pipe and writes the snapshot
-// file. If fork fails, falls back to an in-process write.
-func snapshotForkDump(dir string, shardID uint32, engine *storage.Engine, logger log.Logger) error {
+// file. If fork fails, falls back to an in-process write. fingerprint is the
+// 16-byte key fingerprint embedded in the snapshot header.
+func snapshotForkDump(dir string, shardID uint32, engine *storage.Engine, fingerprint [16]byte, logger log.Logger) error {
 	pr, pw, err := os.Pipe()
 	if err != nil {
-		_, err = snapshotWrite(dir, shardID, engine, logger)
+		_, err = snapshotWrite(dir, shardID, engine, fingerprint, logger)
 		return err
 	}
 
@@ -425,6 +452,7 @@ func snapshotForkDump(dir string, shardID uint32, engine *storage.Engine, logger
 	cmd.Env = []string{
 		"TSD_SNAP_DIR=" + dir,
 		fmt.Sprintf("TSD_SNAP_SHARD=%d", shardID),
+		"TSD_SNAP_FP=" + hex.EncodeToString(fingerprint[:]),
 	}
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
@@ -439,7 +467,7 @@ func snapshotForkDump(dir string, shardID uint32, engine *storage.Engine, logger
 			logger.Log(log.LevelWarn, "snapshot: fork failed, falling back to in-process",
 				log.String("error", err.Error()))
 		}
-		_, err := snapshotWrite(dir, shardID, engine, logger)
+		_, err := snapshotWrite(dir, shardID, engine, fingerprint, logger)
 		return err
 	}
 
@@ -517,8 +545,9 @@ func serializeEngineToWriter(w io.Writer, engine *storage.Engine) error {
 }
 
 // snapshotChildWrite reads serialized entries from r and writes the snapshot
-// file. Called by the child process after ForkExec.
-func snapshotChildWrite(dir string, shardID uint32, r io.Reader) error {
+// file. Called by the child process after ForkExec. fingerprint is the 16-byte
+// key fingerprint embedded in the header; a zero value means encryption is disabled.
+func snapshotChildWrite(dir string, shardID uint32, r io.Reader, fingerprint [16]byte) error {
 	tmpPath := filepath.Join(dir, fmt.Sprintf("shard_%03d.snap.tmp", shardID))
 	finalPath := filepath.Join(dir, fmt.Sprintf("shard_%03d.snap", shardID))
 
@@ -527,7 +556,7 @@ func snapshotChildWrite(dir string, shardID uint32, r io.Reader) error {
 		return err
 	}
 
-	hdr := buildSnapshotHeader()
+	hdr := buildSnapshotHeader(fingerprint)
 
 	if _, err := f.Write(hdr[:]); err != nil {
 		return snapshotCleanup(f, tmpPath, err, nil)

--- a/internal/persistence/snapshot.go
+++ b/internal/persistence/snapshot.go
@@ -344,6 +344,7 @@ func snapshotRead(dir string, shardID uint32, engine *storage.Engine, logger log
 
 	// Checksum is valid — safe to apply entries to the engine.
 	var loadedKeys uint64
+	useRaw := engine.CryptoEnabled()
 	for i := range entries {
 		e := &entries[i]
 		var duration time.Duration
@@ -354,8 +355,16 @@ func snapshotRead(dir string, shardID uint32, engine *storage.Engine, logger log
 				continue // expired — skip
 			}
 		}
-		if err = engine.SetFromBuffer(e.kvBuf, int(e.keyLen), duration); err != nil {
-			return 0, fmt.Errorf("snapshot: engine.SetFromBuffer: %w", err)
+		if useRaw {
+			// Values from ForEach are already encrypted when crypto is on.
+			// SetRaw stores them without re-encrypting.
+			if err = engine.SetRaw(string(e.kvBuf[:e.keyLen]), e.kvBuf[e.keyLen:], duration); err != nil {
+				return 0, fmt.Errorf("snapshot: engine.SetRaw: %w", err)
+			}
+		} else {
+			if err = engine.SetFromBuffer(e.kvBuf, int(e.keyLen), duration); err != nil {
+				return 0, fmt.Errorf("snapshot: engine.SetFromBuffer: %w", err)
+			}
 		}
 		loadedKeys++
 	}

--- a/internal/persistence/snapshot_bench_test.go
+++ b/internal/persistence/snapshot_bench_test.go
@@ -54,7 +54,7 @@ func benchmarkSnapshotWrite(b *testing.B, nKeys, valSize int) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		if _, err := snapshotWrite(dir, 0, engine, nil); err != nil {
+		if _, err := snapshotWrite(dir, 0, engine, [16]byte{}, nil); err != nil {
 			b.Fatal(err)
 		}
 		b.StopTimer()
@@ -84,7 +84,7 @@ func BenchmarkSnapshotRead100K(b *testing.B) {
 func benchmarkSnapshotRead(b *testing.B, nKeys, valSize int) {
 	dir := b.TempDir()
 	engine := populateEngine(b, nKeys, valSize)
-	if _, err := snapshotWrite(dir, 0, engine, nil); err != nil {
+	if _, err := snapshotWrite(dir, 0, engine, [16]byte{}, nil); err != nil {
 		b.Fatal(err)
 	}
 	engine.Close()
@@ -92,7 +92,7 @@ func benchmarkSnapshotRead(b *testing.B, nKeys, valSize int) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		e := storage.NewEngine(0, 0, 0, nil, nil)
-		if _, err := snapshotRead(dir, 0, e, nil); err != nil {
+		if _, err := snapshotRead(dir, 0, e, [16]byte{}, nil); err != nil {
 			b.Fatal(err)
 		}
 		e.Close()
@@ -121,12 +121,12 @@ func benchmarkSnapshotRoundTrip(b *testing.B, nKeys, valSize int) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
-		if _, err := snapshotWrite(dir, 0, engine, nil); err != nil {
+		if _, err := snapshotWrite(dir, 0, engine, [16]byte{}, nil); err != nil {
 			b.Fatal(err)
 		}
 		b.StartTimer()
 		e := storage.NewEngine(0, 0, 0, nil, nil)
-		if _, err := snapshotRead(dir, 0, e, nil); err != nil {
+		if _, err := snapshotRead(dir, 0, e, [16]byte{}, nil); err != nil {
 			b.Fatal(err)
 		}
 		e.Close()
@@ -197,7 +197,7 @@ func benchmarkChildWrite(b *testing.B, nKeys, valSize int) {
 			pw.Close()
 		}()
 		b.StartTimer()
-		if err := snapshotChildWrite(dir, 0, pr); err != nil {
+		if err := snapshotChildWrite(dir, 0, pr, [16]byte{}); err != nil {
 			b.Fatal(err)
 		}
 		pr.Close()
@@ -275,7 +275,7 @@ func BenchmarkLoadShardWithSnapshot1K(b *testing.B) {
 
 	engine := populateEngine(b, 1000, 64)
 	// Write snapshot from engine state.
-	if _, err := snapshotWrite(dir, 0, engine, nil); err != nil {
+	if _, err := snapshotWrite(dir, 0, engine, [16]byte{}, nil); err != nil {
 		b.Fatal(err)
 	}
 	// Truncate WAL and write some post-snapshot WAL records.

--- a/internal/persistence/snapshot_bench_test.go
+++ b/internal/persistence/snapshot_bench_test.go
@@ -271,7 +271,7 @@ func BenchmarkLoadShardWithSnapshot1K(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	s.OpenShard(0)
+	s.OpenShard(0, nil)
 
 	engine := populateEngine(b, 1000, 64)
 	// Write snapshot from engine state.

--- a/internal/persistence/snapshot_test.go
+++ b/internal/persistence/snapshot_test.go
@@ -308,7 +308,7 @@ func TestLoadShardSnapshotFirstThenWAL(t *testing.T) {
 		t.Fatalf("NewStorage: %v", err)
 	}
 
-	if err := s.OpenShard(0); err != nil {
+	if err := s.OpenShard(0, nil); err != nil {
 		t.Fatalf("OpenShard: %v", err)
 	}
 
@@ -360,7 +360,7 @@ func TestSnapshotTruncateAndReplay(t *testing.T) {
 		t.Fatalf("NewStorage: %v", err)
 	}
 
-	s.OpenShard(0)
+	s.OpenShard(0, nil)
 
 	// Populate engine with data, then snapshot from it.
 	engine := newTestEngine(t)
@@ -398,7 +398,7 @@ func TestWALSize(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewStorage: %v", err)
 	}
-	s.OpenShard(0)
+	s.OpenShard(0, nil)
 
 	size := s.WALSize(0)
 	if size != 0 {
@@ -423,7 +423,7 @@ func TestSnapshotConcurrentWrite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewStorage: %v", err)
 	}
-	if err := s.OpenShard(0); err != nil {
+	if err := s.OpenShard(0, nil); err != nil {
 		t.Fatalf("OpenShard: %v", err)
 	}
 

--- a/internal/persistence/snapshot_test.go
+++ b/internal/persistence/snapshot_test.go
@@ -17,7 +17,7 @@ func TestSnapshotWriteAndRead(t *testing.T) {
 	engine.Set("key3", []byte("value3"), 0)
 	engine.Delete("key3") // tombstone — should not appear in snapshot
 
-	keysWritten, err := snapshotWrite(dir, 0, engine, nil)
+	keysWritten, err := snapshotWrite(dir, 0, engine, [16]byte{}, nil)
 	if err != nil {
 		t.Fatalf("snapshotWrite: %v", err)
 	}
@@ -38,7 +38,7 @@ func TestSnapshotWriteAndRead(t *testing.T) {
 
 	// Load into a fresh engine.
 	engine2 := newTestEngine(t)
-	loadedKeys, err := snapshotRead(dir, 0, engine2, nil)
+	loadedKeys, err := snapshotRead(dir, 0, engine2, [16]byte{}, nil)
 	if err != nil {
 		t.Fatalf("snapshotRead: %v", err)
 	}
@@ -70,7 +70,7 @@ func TestSnapshotSkipsExpiredKeys(t *testing.T) {
 
 	time.Sleep(2 * time.Millisecond)
 
-	keysWritten, err := snapshotWrite(dir, 0, engine, nil)
+	keysWritten, err := snapshotWrite(dir, 0, engine, [16]byte{}, nil)
 	if err != nil {
 		t.Fatalf("snapshotWrite: %v", err)
 	}
@@ -79,7 +79,7 @@ func TestSnapshotSkipsExpiredKeys(t *testing.T) {
 	}
 
 	engine2 := newTestEngine(t)
-	_, err = snapshotRead(dir, 0, engine2, nil)
+	_, err = snapshotRead(dir, 0, engine2, [16]byte{}, nil)
 	if err != nil {
 		t.Fatalf("snapshotRead: %v", err)
 	}
@@ -101,7 +101,7 @@ func TestSnapshotInvalidMagic(t *testing.T) {
 	}
 
 	engine := newTestEngine(t)
-	_, err := snapshotRead(dir, 0, engine, nil)
+	_, err := snapshotRead(dir, 0, engine, [16]byte{}, nil)
 	if err == nil {
 		t.Fatal("expected error for invalid magic")
 	}
@@ -117,7 +117,7 @@ func TestSnapshotChecksumMismatch(t *testing.T) {
 		t.Fatalf("engine.Set: %v", err)
 	}
 
-	if _, err := snapshotWrite(dir, 0, engine, nil); err != nil {
+	if _, err := snapshotWrite(dir, 0, engine, [16]byte{}, nil); err != nil {
 		t.Fatalf("snapshotWrite: %v", err)
 	}
 	engine.Close()
@@ -136,7 +136,7 @@ func TestSnapshotChecksumMismatch(t *testing.T) {
 
 	// Verify the engine is NOT mutated by the corrupt snapshot.
 	engine2 := newTestEngine(t)
-	_, err = snapshotRead(dir, 0, engine2, nil)
+	_, err = snapshotRead(dir, 0, engine2, [16]byte{}, nil)
 	if err == nil {
 		t.Fatal("expected checksum error for corrupt snapshot")
 	}
@@ -150,7 +150,7 @@ func TestSnapshotChecksumZeroBody(t *testing.T) {
 	engine := newTestEngine(t)
 	engine.Set("k", []byte("v"), 0)
 
-	if _, err := snapshotWrite(dir, 0, engine, nil); err != nil {
+	if _, err := snapshotWrite(dir, 0, engine, [16]byte{}, nil); err != nil {
 		t.Fatalf("snapshotWrite: %v", err)
 	}
 	engine.Close()
@@ -171,7 +171,7 @@ func TestSnapshotChecksumZeroBody(t *testing.T) {
 	}
 
 	engine2 := newTestEngine(t)
-	_, err = snapshotRead(dir, 0, engine2, nil)
+	_, err = snapshotRead(dir, 0, engine2, [16]byte{}, nil)
 	if err == nil {
 		t.Fatal("expected checksum error for zeroed body")
 	}
@@ -190,7 +190,7 @@ func TestSnapshotZeroedChecksum(t *testing.T) {
 		t.Fatalf("engine.Set: %v", err)
 	}
 
-	if _, err := snapshotWrite(dir, 0, engine, nil); err != nil {
+	if _, err := snapshotWrite(dir, 0, engine, [16]byte{}, nil); err != nil {
 		t.Fatalf("snapshotWrite: %v", err)
 	}
 	engine.Close()
@@ -210,7 +210,7 @@ func TestSnapshotZeroedChecksum(t *testing.T) {
 	}
 
 	engine2 := newTestEngine(t)
-	_, err = snapshotRead(dir, 0, engine2, nil)
+	_, err = snapshotRead(dir, 0, engine2, [16]byte{}, nil)
 	if err == nil {
 		t.Fatal("expected checksum error for zeroed checksum header")
 	}
@@ -224,7 +224,7 @@ func TestSnapshotTruncatedFile(t *testing.T) {
 	engine := newTestEngine(t)
 	engine.Set("key1", []byte("long_value_here"), 0)
 
-	if _, err := snapshotWrite(dir, 0, engine, nil); err != nil {
+	if _, err := snapshotWrite(dir, 0, engine, [16]byte{}, nil); err != nil {
 		t.Fatalf("snapshotWrite: %v", err)
 	}
 	engine.Close()
@@ -240,7 +240,7 @@ func TestSnapshotTruncatedFile(t *testing.T) {
 	}
 
 	engine2 := newTestEngine(t)
-	_, err = snapshotRead(dir, 0, engine2, nil)
+	_, err = snapshotRead(dir, 0, engine2, [16]byte{}, nil)
 	if err == nil {
 		t.Fatal("expected error for truncated snapshot")
 	}
@@ -280,13 +280,13 @@ func TestSnapshotRoundTripWithTTL(t *testing.T) {
 	engine.Set("ttl_key", []byte("expires_soon"), 10*time.Minute)
 	engine.Set("perm_key", []byte("stays"), 0)
 
-	_, err := snapshotWrite(dir, 0, engine, nil)
+	_, err := snapshotWrite(dir, 0, engine, [16]byte{}, nil)
 	if err != nil {
 		t.Fatalf("snapshotWrite: %v", err)
 	}
 
 	engine2 := newTestEngine(t)
-	_, err = snapshotRead(dir, 0, engine2, nil)
+	_, err = snapshotRead(dir, 0, engine2, [16]byte{}, nil)
 	if err != nil {
 		t.Fatalf("snapshotRead: %v", err)
 	}
@@ -323,7 +323,7 @@ func TestLoadShardSnapshotFirstThenWAL(t *testing.T) {
 	// Create a snapshot from a state that had only key1.
 	snapEngine := newTestEngine(t)
 	snapEngine.Set("snap_key", []byte("snap_val"), 0)
-	if _, err := snapshotWrite(dir, 0, snapEngine, nil); err != nil {
+	if _, err := snapshotWrite(dir, 0, snapEngine, [16]byte{}, nil); err != nil {
 		t.Fatalf("snapshotWrite: %v", err)
 	}
 	snapEngine.Close()
@@ -366,7 +366,7 @@ func TestSnapshotTruncateAndReplay(t *testing.T) {
 	engine := newTestEngine(t)
 	engine.Set("before_snap", []byte("v1"), 0)
 	s.Write(0, "before_snap", []byte("v1"), time.Time{})
-	snapshotWrite(dir, 0, engine, nil)
+	snapshotWrite(dir, 0, engine, [16]byte{}, nil)
 	s.TruncateWALTo(0, 0)
 
 	// Write more data to WAL after snapshot.
@@ -440,7 +440,7 @@ func TestSnapshotConcurrentWrite(t *testing.T) {
 	// Storage.Snapshot behavior) and truncate — this is what Snapshot does
 	// internally. We use snapshotWrite directly because the fork-based path
 	// does not work inside the test binary.
-	if _, err := snapshotWrite(dir, 0, engine, nil); err != nil {
+	if _, err := snapshotWrite(dir, 0, engine, [16]byte{}, nil); err != nil {
 		t.Fatalf("snapshotWrite: %v", err)
 	}
 	walSize := s.WALSize(0)
@@ -467,5 +467,63 @@ func TestSnapshotConcurrentWrite(t *testing.T) {
 	v, ok = freshEngine.Get("after_snap")
 	if !ok || string(v) != "v2" {
 		t.Fatalf("after_snap: got %q, %v", v, ok)
+	}
+}
+
+func TestSnapshotFingerprintValidation(t *testing.T) {
+	dir := newTestDir(t)
+	engine := newTestEngine(t)
+	engine.Set("key1", []byte("value1"), 0)
+
+	var fp [16]byte
+	fp[0] = 0xAA
+	fp[15] = 0xBB
+	if _, err := snapshotWrite(dir, 0, engine, fp, nil); err != nil {
+		t.Fatalf("snapshotWrite: %v", err)
+	}
+
+	// Same fingerprint → must succeed.
+	engine2 := newTestEngine(t)
+	loadedKeys, err := snapshotRead(dir, 0, engine2, fp, nil)
+	if err != nil {
+		t.Fatalf("snapshotRead with matching fingerprint: %v", err)
+	}
+	if loadedKeys != 1 {
+		t.Fatalf("expected 1 key, got %d", loadedKeys)
+	}
+
+	// Different fingerprint → must fail.
+	var wrongFp [16]byte
+	wrongFp[0] = 0xFF
+	engine3 := newTestEngine(t)
+	_, err = snapshotRead(dir, 0, engine3, wrongFp, nil)
+	if err == nil {
+		t.Fatal("expected error for fingerprint mismatch")
+	}
+
+	// Zero fingerprint (plaintext) when snapshot was encrypted → must fail.
+	engine4 := newTestEngine(t)
+	_, err = snapshotRead(dir, 0, engine4, [16]byte{}, nil)
+	if err == nil {
+		t.Fatal("expected error when reading encrypted snapshot with zero fingerprint")
+	}
+}
+
+func TestSnapshotZeroFingerprintAcceptsZero(t *testing.T) {
+	dir := newTestDir(t)
+	engine := newTestEngine(t)
+	engine.Set("key1", []byte("value1"), 0)
+
+	if _, err := snapshotWrite(dir, 0, engine, [16]byte{}, nil); err != nil {
+		t.Fatalf("snapshotWrite: %v", err)
+	}
+
+	engine2 := newTestEngine(t)
+	loadedKeys, err := snapshotRead(dir, 0, engine2, [16]byte{}, nil)
+	if err != nil {
+		t.Fatalf("snapshotRead with zero fingerprint: %v", err)
+	}
+	if loadedKeys != 1 {
+		t.Fatalf("expected 1 key, got %d", loadedKeys)
 	}
 }

--- a/internal/persistence/snapshot_test.go
+++ b/internal/persistence/snapshot_test.go
@@ -1,10 +1,15 @@
 package persistence
 
 import (
+	"encoding/binary"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/Saxy/Tellstone/internal/storage"
+	"github.com/cespare/xxhash/v2"
 )
 
 func TestSnapshotWriteAndRead(t *testing.T) {
@@ -472,37 +477,48 @@ func TestSnapshotConcurrentWrite(t *testing.T) {
 
 func TestSnapshotFingerprintValidation(t *testing.T) {
 	dir := newTestDir(t)
-	engine := newTestEngine(t)
-	engine.Set("key1", []byte("value1"), 0)
 
-	var fp [16]byte
-	fp[0] = 0xAA
-	fp[15] = 0xBB
-	if _, err := snapshotWrite(dir, 0, engine, fp, nil); err != nil {
+	// Build a real crypto engine so ForEach returns encrypted values and
+	// snapshotRead exercises the SetRaw (encrypted restore) path.
+	ce := newCryptoEngine(t)
+	fp := ce.KeyFingerprint()
+
+	srcEngine := storage.NewEngine(0, 0, 0, nil, ce)
+	defer srcEngine.Close()
+	srcEngine.Set("key1", []byte("value1"), 0)
+
+	if _, err := snapshotWrite(dir, 0, srcEngine, fp, nil); err != nil {
 		t.Fatalf("snapshotWrite: %v", err)
 	}
 
-	// Same fingerprint → must succeed.
-	engine2 := newTestEngine(t)
-	loadedKeys, err := snapshotRead(dir, 0, engine2, fp, nil)
+	// Same fingerprint → must succeed and restore the original plaintext.
+	dstEngine := storage.NewEngine(0, 0, 0, nil, ce)
+	defer dstEngine.Close()
+	loadedKeys, err := snapshotRead(dir, 0, dstEngine, fp, nil)
 	if err != nil {
 		t.Fatalf("snapshotRead with matching fingerprint: %v", err)
 	}
 	if loadedKeys != 1 {
 		t.Fatalf("expected 1 key, got %d", loadedKeys)
 	}
+	v, ok := dstEngine.Get("key1")
+	if !ok || string(v) != "value1" {
+		t.Fatalf("key1: got %q, %v (expected plaintext \"value1\")", v, ok)
+	}
 
 	// Different fingerprint → must fail.
 	var wrongFp [16]byte
 	wrongFp[0] = 0xFF
-	engine3 := newTestEngine(t)
+	engine3 := storage.NewEngine(0, 0, 0, nil, ce)
+	defer engine3.Close()
 	_, err = snapshotRead(dir, 0, engine3, wrongFp, nil)
 	if err == nil {
 		t.Fatal("expected error for fingerprint mismatch")
 	}
 
 	// Zero fingerprint (plaintext) when snapshot was encrypted → must fail.
-	engine4 := newTestEngine(t)
+	engine4 := storage.NewEngine(0, 0, 0, nil, ce)
+	defer engine4.Close()
 	_, err = snapshotRead(dir, 0, engine4, [16]byte{}, nil)
 	if err == nil {
 		t.Fatal("expected error when reading encrypted snapshot with zero fingerprint")
@@ -525,5 +541,153 @@ func TestSnapshotZeroFingerprintAcceptsZero(t *testing.T) {
 	}
 	if loadedKeys != 1 {
 		t.Fatalf("expected 1 key, got %d", loadedKeys)
+	}
+}
+
+// writeV1Snapshot manually constructs a version-1 snapshot file (32-byte header,
+// no fingerprint field). This simulates a snapshot written by an older binary
+// before the fingerprint feature was added.
+func writeV1Snapshot(t *testing.T, dir string, shardID uint32, key string, value string) {
+	t.Helper()
+	path := filepath.Join(dir, fmt.Sprintf("shard_%03d.snap", shardID))
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		t.Fatalf("create v1 snap: %v", err)
+	}
+	defer f.Close()
+
+	// Build 32-byte v1 placeholder header (keyCount=0, checksum=0).
+	var hdr [snapBaseHeader]byte
+	copy(hdr[0:4], snapMagic)
+	binary.LittleEndian.PutUint32(hdr[4:8], snapVersion1)
+	binary.LittleEndian.PutUint64(hdr[16:24], uint64(time.Now().UnixNano()))
+
+	// Write placeholder header first, then entries after it, then patch.
+	// This matches the snapshotWrite pattern: header → entries → patch.
+	if _, err := f.Write(hdr[:]); err != nil {
+		t.Fatalf("write placeholder header: %v", err)
+	}
+
+	h := xxhash.New()
+	h.Write(hdr[:])
+
+	// Write one entry at offset 32 (after the header).
+	var entry [16]byte
+	binary.LittleEndian.PutUint32(entry[0:4], uint32(len(key)))
+	binary.LittleEndian.PutUint32(entry[4:8], uint32(len(value)))
+	// ttlNano = 0 (no expiry).
+	h.Write(entry[:])
+	h.WriteString(key)
+	h.Write([]byte(value))
+
+	if _, err := f.Write(entry[:]); err != nil {
+		t.Fatalf("write entry: %v", err)
+	}
+	if _, err := f.WriteString(key); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	if _, err := f.Write([]byte(value)); err != nil {
+		t.Fatalf("write value: %v", err)
+	}
+
+	// Patch header with keyCount=1 and real checksum.
+	checksum := h.Sum64()
+	binary.LittleEndian.PutUint64(hdr[8:16], 1)
+	binary.LittleEndian.PutUint64(hdr[24:32], checksum)
+
+	if _, err := f.Seek(0, 0); err != nil {
+		t.Fatalf("seek: %v", err)
+	}
+	if _, err := f.Write(hdr[:]); err != nil {
+		t.Fatalf("patch header: %v", err)
+	}
+}
+
+func TestSnapshotV1FixtureLoads(t *testing.T) {
+	dir := newTestDir(t)
+	writeV1Snapshot(t, dir, 0, "v1key", "v1val")
+
+	engine := newTestEngine(t)
+	loadedKeys, err := snapshotRead(dir, 0, engine, [16]byte{}, nil)
+	if err != nil {
+		t.Fatalf("snapshotRead v1: %v", err)
+	}
+	if loadedKeys != 1 {
+		t.Fatalf("expected 1 key, got %d", loadedKeys)
+	}
+	v, ok := engine.Get("v1key")
+	if !ok || string(v) != "v1val" {
+		t.Fatalf("v1key: got %q, %v", v, ok)
+	}
+}
+
+func TestSnapshotV1FixtureWithEncryptionRejectsFingerprintMismatch(t *testing.T) {
+	dir := newTestDir(t)
+	writeV1Snapshot(t, dir, 0, "v1key", "v1val")
+
+	// v1 snapshot has zero fingerprint; non-zero fp request must fail.
+	var fp [16]byte
+	fp[0] = 0xAA
+	engine := newTestEngine(t)
+	_, err := snapshotRead(dir, 0, engine, fp, nil)
+	if err == nil {
+		t.Fatal("expected fingerprint mismatch for v1 snapshot with non-zero fp")
+	}
+}
+
+func TestSnapshotV1FixtureRecoveryAfterWALTruncation(t *testing.T) {
+	dir := newTestDir(t)
+	s, err := NewStorage(true, nil, dir)
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+
+	// Write a v1 snapshot capturing "snap_key".
+	writeV1Snapshot(t, dir, 0, "snap_key", "snap_val")
+
+	// Write a WAL record after the snapshot.
+	if err := s.OpenShard(0, nil); err != nil {
+		t.Fatalf("OpenShard: %v", err)
+	}
+	if err := s.Write(0, "wal_key", []byte("wal_val"), time.Time{}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// Load: snapshot + WAL replay → both keys present.
+	engine := newTestEngine(t)
+	if err := s.LoadShard(0, engine); err != nil {
+		t.Fatalf("LoadShard: %v", err)
+	}
+	if v, ok := engine.Get("snap_key"); !ok || string(v) != "snap_val" {
+		t.Fatalf("snap_key: got %q, %v", v, ok)
+	}
+	if v, ok := engine.Get("wal_key"); !ok || string(v) != "wal_val" {
+		t.Fatalf("wal_key: got %q, %v", v, ok)
+	}
+
+	// Truncate WAL to magic-only (empty) — snapshot is the sole recovery source.
+	walSize := s.WALSize(0)
+	if err := s.TruncateWALTo(0, walSize); err != nil {
+		t.Fatalf("TruncateWALTo: %v", err)
+	}
+	if err := s.CloseShard(0); err != nil {
+		t.Fatalf("CloseShard: %v", err)
+	}
+
+	// Restart and verify the v1 snapshot still recovers correctly.
+	s2, err := NewStorage(true, nil, dir)
+	if err != nil {
+		t.Fatalf("NewStorage 2: %v", err)
+	}
+	defer s2.CloseShard(0)
+	if err := s2.OpenShard(0, nil); err != nil {
+		t.Fatalf("OpenShard 2: %v", err)
+	}
+	engine2 := newTestEngine(t)
+	if err := s2.LoadShard(0, engine2); err != nil {
+		t.Fatalf("LoadShard 2: %v", err)
+	}
+	if v, ok := engine2.Get("snap_key"); !ok || string(v) != "snap_val" {
+		t.Fatalf("after truncation: snap_key: got %q, %v", v, ok)
 	}
 }

--- a/internal/shard/runner.go
+++ b/internal/shard/runner.go
@@ -119,7 +119,7 @@ func Run(id ID, cfg *config.Config, key []byte, cryptoEngine *crypto.Engine, log
 		Persistence: store,
 	}
 	if store.Enabled() {
-		if err := store.OpenShard(uint32(id)); err != nil {
+		if err := store.OpenShard(uint32(id), cryptoEngine); err != nil {
 			if logger.Enabled(log.LevelError) {
 				logger.Log(log.LevelError, "persistence: cannot open shard",
 					log.String("error", err.Error()), log.String("shard", fmt.Sprintf("%d", id)))

--- a/internal/storage/engine.go
+++ b/internal/storage/engine.go
@@ -233,6 +233,55 @@ func (e *Engine) SetFromBuffer(buf []byte, keyLen int, ttl time.Duration) error 
 	return nil
 }
 
+// SetRaw stores a key with a pre-encrypted value, bypassing encryption. This is
+// used by snapshotRead when restoring an engine with crypto enabled — the
+// snapshot already contains the encrypted values from ForEach, so re-encrypting
+// would double-encrypt. The caller owns the value bytes after this call.
+func (e *Engine) SetRaw(key string, value []byte, ttl time.Duration) error {
+	var exp time.Time
+	if ttl > 0 {
+		exp = time.Now().Add(ttl)
+	}
+	if e.maxBytes > 0 {
+		totalEntrySize := uint64(len(key) + len(value))
+		if atomic.LoadUint64(&e.allocatedBytes)+totalEntrySize > e.maxBytes {
+			return ErrEngineFull
+		}
+	}
+	storedKey := strings.Clone(key)
+	e.mu.Lock()
+	oldItem, isUpdate := e.items[storedKey]
+	e.items[storedKey] = Item{
+		Value:      value,
+		Expiration: exp,
+	}
+	e.mu.Unlock()
+	atomic.AddUint64(&e.totalCommands, 1)
+	if isUpdate {
+		oldSize := uint64(len(oldItem.Value) + len(storedKey))
+		newSize := uint64(len(value) + len(storedKey))
+		if newSize > oldSize {
+			atomic.AddUint64(&e.allocatedBytes, newSize-oldSize)
+		} else if oldSize > newSize {
+			atomic.AddUint64(&e.allocatedBytes, ^(oldSize - newSize - 1))
+		}
+	} else {
+		atomic.AddUint64(&e.allocatedBytes, uint64(len(key)+len(value)))
+		atomic.AddUint64(&e.keyCount, 1)
+	}
+	atomic.AddUint64(&e.cryptoEncryptedBytes, uint64(len(value)))
+	if e.logger.Enabled(log.LevelDebug) {
+		e.logger.Log(log.LevelDebug, "key written to engine state (raw)",
+			log.String("key", key),
+			log.Int64("ttl_ms", ttl.Milliseconds()),
+		)
+	}
+	if ttl > 0 {
+		e.chronometer.Register(storedKey, ttl)
+	}
+	return nil
+}
+
 // Delete removes key and reports whether it was present. An expired key is
 // evicted physically but counts as absent, mirroring Get's lazy eviction, so
 // callers can derive "did the key exist" without a separate Get lookup.
@@ -377,6 +426,7 @@ func (e *Engine) KeyCount() uint64             { return atomic.LoadUint64(&e.key
 func (e *Engine) ExpiredCount() uint64         { return atomic.LoadUint64(&e.expiredCount) }
 func (e *Engine) CryptoEncryptedBytes() uint64 { return atomic.LoadUint64(&e.cryptoEncryptedBytes) }
 func (e *Engine) CryptoDecryptedBytes() uint64 { return atomic.LoadUint64(&e.cryptoDecryptedBytes) }
+func (e *Engine) CryptoEnabled() bool          { return e.cryptoEngine.Enabled() }
 func (e *Engine) TotalCommands() uint64        { return atomic.LoadUint64(&e.totalCommands) }
 func (e *Engine) Chronometer() TimelineWheel   { return e.chronometer }
 

--- a/internal/storage/engine.go
+++ b/internal/storage/engine.go
@@ -236,7 +236,8 @@ func (e *Engine) SetFromBuffer(buf []byte, keyLen int, ttl time.Duration) error 
 // SetRaw stores a key with a pre-encrypted value, bypassing encryption. This is
 // used by snapshotRead when restoring an engine with crypto enabled — the
 // snapshot already contains the encrypted values from ForEach, so re-encrypting
-// would double-encrypt. The caller owns the value bytes after this call.
+// would double-encrypt. The engine retains the value's backing bytes for the
+// entry's lifetime; callers must not mutate or reuse the buffer after this call.
 func (e *Engine) SetRaw(key string, value []byte, ttl time.Duration) error {
 	var exp time.Time
 	if ttl > 0 {


### PR DESCRIPTION
## Description

added encryption to persitence layer 
WAL and Snaptshots

**Component:**

Persitence

**Type of Change:**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance optimization (no change in behavior, improved speed/memory)
- [ ] Refactoring (no functional changes, code cleanup)
- [ ] Build / CI / Documentation

---

## Related Issue

none

---

## Technical Deep Dive & Context

used the existing crypto engine to add encryption to the WAL files, introduced a WAL Header with magic (len 4)
introduced SetRaw for Engine to prevent double decrypt when encryption is enabled to decrypt on WAL level instead of Storage Engine

## How Has This Been Tested?

go test
manual

---

## Checklist

- [x] My code follows the existing code style of this project
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally (`go test ./...` and `go test -race ./...`)
- [x] I have updated the documentation (README, comments, or any relevant docs)
- [x] My changes generate no new `go vet` warnings
- [ ] Any breaking changes are documented and communicated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added encrypted write-ahead logs and snapshots with authenticated protection and automatic nonce recovery.
  * Added support for restoring encrypted snapshot values without re-encrypting them.
  * Added encryption-key validation and compatibility with earlier snapshot formats.
  * Added a built-in 16 MiB maximum message size when no limit is configured.

* **Bug Fixes**
  * Improved recovery from corrupted or incomplete encrypted logs.
  * Improved reliability of encryption metadata during shutdown and log truncation.
  * Added safeguards against encrypted and unencrypted storage mode mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->