### PR TITLE
fix(persitence): added the possibility to upgrade from plain wal to e…

### DIFF
--- a/internal/persistence/persistence.go
+++ b/internal/persistence/persistence.go
@@ -109,12 +109,14 @@ func writeNonceSidecar(path string, ctr uint64) error {
 // the next counter-based nonce value. The counter is durable: it is recovered
 // from the WAL on replay so nonces never repeat across crashes.
 type shardHandle struct {
-	file     *os.File
-	mu       sync.Mutex
-	crypto   *crypto.Engine
-	walVer   uint8
-	nonceCtr atomic.Uint64
-	shardID  uint32
+	file          *os.File
+	mu            sync.Mutex
+	crypto        *crypto.Engine
+	walVer        uint8
+	nonceCtr      atomic.Uint64
+	shardID       uint32
+	needsMigrate  bool           // plaintext WAL opened with crypto — migrate after replay
+	pendingCrypto *crypto.Engine // crypto engine waiting for migration
 }
 
 // Storage provides a per-shard, append-only write-ahead log (WAL) for crash recovery.
@@ -374,8 +376,8 @@ func (s *Storage) Delete(shardID uint32, key string) error {
 // OpenShard opens (or creates) the WAL file for the given shard.
 // If cryptoEng is non-nil, the WAL is encrypted with counter-based nonces and
 // a 4-byte magic header is written to new files. Existing plaintext WALs
-// cannot be retroactively encrypted — an error is returned if a plaintext
-// file is found while crypto is requested.
+// (e.g. from v1.2.0) are transparently migrated: records are replayed first,
+// then the file is truncated and re-initialized with the encrypted header.
 // Must be called before Write or LoadShard for that shard.
 // Returns nil immediately when persistence is disabled.
 func (s *Storage) OpenShard(shardID uint32, cryptoEng *crypto.Engine) error {
@@ -423,9 +425,16 @@ func (s *Storage) OpenShard(shardID uint32, cryptoEng *crypto.Engine) error {
 			h.crypto = cryptoEng
 			h.walVer = 1
 		} else {
+			// Plaintext WAL found. If encryption is requested, replay
+			// the existing plaintext records first, then migrate the WAL
+			// to encrypted format in-place after LoadShard completes.
 			if cryptoEng != nil && cryptoEng.Enabled() {
-				_ = f.Close()
-				return fmt.Errorf("persistence: shard %d has plaintext WAL but encryption is requested; delete the file to start fresh", shardID)
+				h.needsMigrate = true
+				h.pendingCrypto = cryptoEng
+				if s.logger.Enabled(log.LevelInfo) {
+					s.logger.Log(log.LevelInfo, "persistence: plaintext WAL will migrate to encrypted",
+						log.Uint("shard", shardID))
+				}
 			}
 			h.walVer = 0
 		}
@@ -473,7 +482,82 @@ func (s *Storage) LoadShard(shardID uint32, engine *storage.Engine) error {
 				log.Uint("shard", shardID), log.Uint64("keys", loadedKeys))
 		}
 	}
-	return s.replayWAL(shardID, engine)
+	if err := s.replayWAL(shardID, engine); err != nil {
+		return err
+	}
+	// After replaying a plaintext WAL with encryption enabled, migrate
+	// the WAL to encrypted format in-place. The plaintext records are
+	// now in memory; truncate the file, write the encrypted magic header,
+	// re-serialize all records as encrypted, and switch the handle to
+	// encrypted mode so new writes are sealed.
+	h := s.getShard(shardID)
+	if h != nil && h.needsMigrate {
+		h.mu.Lock()
+		if err := h.file.Truncate(0); err != nil {
+			h.mu.Unlock()
+			return fmt.Errorf("persistence: truncate WAL for migration: %w", err)
+		}
+		if _, err := h.file.Seek(0, 0); err != nil {
+			h.mu.Unlock()
+			return fmt.Errorf("persistence: seek WAL for migration: %w", err)
+		}
+		if _, err := h.file.WriteString(walMagic); err != nil {
+			h.mu.Unlock()
+			return fmt.Errorf("persistence: write WAL magic for migration: %w", err)
+		}
+		h.crypto = h.pendingCrypto
+		h.pendingCrypto = nil
+		h.walVer = 1
+		h.needsMigrate = false
+		h.mu.Unlock()
+		h.mu.Lock()
+		var recordsWritten int
+		atRestEncrypted := engine.CryptoEnabled()
+		engine.ForEach(func(key string, value []byte, expiration time.Time) {
+			walValue := value
+			if atRestEncrypted {
+				plainValue, decErr := h.crypto.DecryptInPlace(value)
+				if decErr != nil {
+					if s.logger.Enabled(log.LevelError) {
+						s.logger.Log(log.LevelError, "persistence: migration decrypt failed",
+							log.Uint("shard", shardID), log.String("key", key), log.String("error", decErr.Error()))
+					}
+					return
+				}
+				walValue = plainValue
+			}
+			var header [16]byte
+			var ttlNano int64
+			if !expiration.IsZero() {
+				ttlNano = expiration.UnixNano()
+			}
+			binary.LittleEndian.PutUint32(header[0:4], uint32(len(key)))
+			binary.LittleEndian.PutUint32(header[4:8], uint32(len(walValue)))
+			binary.LittleEndian.PutUint64(header[8:16], uint64(ttlNano))
+			if err := s.appendRecordEncrypted(h, shardID, header, key, walValue, "migration"); err != nil {
+				if s.logger.Enabled(log.LevelError) {
+					s.logger.Log(log.LevelError, "persistence: migration write failed",
+						log.Uint("shard", shardID), log.String("key", key), log.String("error", err.Error()))
+				}
+			} else {
+				recordsWritten++
+			}
+		})
+		h.mu.Unlock()
+		noncePath := nonceSidecarPath(s.dir, shardID)
+		nonceVal := h.nonceCtr.Load()
+		if err := writeNonceSidecar(noncePath, nonceVal); err != nil {
+			if s.logger.Enabled(log.LevelError) {
+				s.logger.Log(log.LevelError, "persistence: migration nonce sidecar write failed",
+					log.Uint("shard", shardID), log.String("error", err.Error()))
+			}
+		}
+		if s.logger.Enabled(log.LevelInfo) {
+			s.logger.Log(log.LevelInfo, "persistence: WAL migrated from plaintext to encrypted",
+				log.Uint("shard", shardID), log.Int("records", recordsWritten))
+		}
+	}
+	return nil
 }
 
 // replayWAL replays all records from the shard's WAL file into the given engine,
@@ -573,12 +657,11 @@ func (s *Storage) replayWALEncrypted(h *shardHandle, shardID uint32, f *os.File,
 		return err
 	}
 	remaining := fileSize - int64(walMagicLen)
-	validOffset := int64(walMagicLen) // preserve the magic header even if no records follow
+	validOffset := int64(walMagicLen)
 	var maxNonce uint64
 	recLenBuf := make([]byte, 4)
 	var recordsRead int
 	var recordsSkipped int
-
 	for {
 		if _, err := io.ReadFull(f, recLenBuf); err != nil {
 			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
@@ -594,8 +677,6 @@ func (s *Storage) replayWALEncrypted(h *shardHandle, shardID uint32, f *os.File,
 		if recLen > remaining {
 			break
 		}
-
-		// Read nonce + ciphertext.
 		record := make([]byte, recLen)
 		if _, err := io.ReadFull(f, record); err != nil {
 			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
@@ -640,18 +721,12 @@ func (s *Storage) replayWALEncrypted(h *shardHandle, shardID uint32, f *os.File,
 			return err
 		}
 	}
-
-	// Recover the nonce counter so future writes never reuse a nonce.
-	// Take the max of WAL-derived counter and sidecar counter. The sidecar
-	// persists the high-water mark so counter never regresses after WAL truncation.
 	walCtr := maxNonce + 1
 	sidecarCtr := readNonceSidecar(nonceSidecarPath(s.dir, shardID))
 	if sidecarCtr > walCtr {
 		walCtr = sidecarCtr
 	}
 	h.nonceCtr.Store(walCtr)
-
-	// Persist the counter to the sidecar for defense-in-depth.
 	if err := writeNonceSidecar(nonceSidecarPath(s.dir, shardID), walCtr); err != nil {
 		if s.logger.Enabled(log.LevelWarn) {
 			s.logger.Log(log.LevelWarn, "persistence: nonce sidecar persist failed",

--- a/internal/persistence/persistence.go
+++ b/internal/persistence/persistence.go
@@ -200,6 +200,10 @@ func (s *Storage) appendRecord(shardID uint32, header [16]byte, key string, valu
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
+	if h.needsMigrate {
+		return fmt.Errorf("persistence: shard %d migration in progress, writes blocked", shardID)
+	}
+
 	if h.walVer == 1 {
 		return s.appendRecordEncrypted(h, shardID, header, key, value, op)
 	}
@@ -492,36 +496,67 @@ func (s *Storage) LoadShard(shardID uint32, engine *storage.Engine) error {
 	// encrypted mode so new writes are sealed.
 	h := s.getShard(shardID)
 	if h != nil && h.needsMigrate {
+		// Atomic migration: write all encrypted records to a temp file,
+		// then rename it over the original. If the process crashes during
+		// the rewrite, the original plaintext WAL is intact and migration
+		// will run again on the next startup.
 		h.mu.Lock()
-		if err := h.file.Truncate(0); err != nil {
+
+		// Close the current plaintext file before swapping.
+		if err := h.file.Close(); err != nil {
 			h.mu.Unlock()
-			return fmt.Errorf("persistence: truncate WAL for migration: %w", err)
+			return fmt.Errorf("persistence: close plaintext WAL: %w", err)
 		}
-		if _, err := h.file.Seek(0, 0); err != nil {
+
+		origPath := filepath.Join(s.dir, fmt.Sprintf("shard_%03d.db", shardID))
+		migrPath := origPath + ".migrating"
+
+		mf, err := os.OpenFile(migrPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+		if err != nil {
+			// Re-open original so the handle isn't left with a closed file.
+			of, openErr := os.OpenFile(origPath, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0600)
+			if openErr != nil {
+				h.mu.Unlock()
+				return fmt.Errorf("persistence: migration failed and cannot reopen WAL: %w (original error: %v)", openErr, err)
+			}
+			h.file = of
 			h.mu.Unlock()
-			return fmt.Errorf("persistence: seek WAL for migration: %w", err)
+			return fmt.Errorf("persistence: create migration temp file: %w", err)
 		}
-		if _, err := h.file.WriteString(walMagic); err != nil {
+
+		// Write magic header.
+		if _, err := mf.WriteString(walMagic); err != nil {
+			_ = mf.Close()
+			_ = os.Remove(migrPath)
+			// Re-open original.
+			of, _ := os.OpenFile(origPath, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0600)
+			h.file = of
 			h.mu.Unlock()
 			return fmt.Errorf("persistence: write WAL magic for migration: %w", err)
 		}
-		h.crypto = h.pendingCrypto
-		h.pendingCrypto = nil
-		h.walVer = 1
-		h.needsMigrate = false
-		h.mu.Unlock()
-		h.mu.Lock()
+
+		// Build a temporary handle pointing at the migration file so
+		// appendRecordEncrypted can write to it.
+		tmpH := &shardHandle{
+			file:    mf,
+			crypto:  h.pendingCrypto,
+			walVer:  1,
+			shardID: shardID,
+		}
+
+		// Re-serialize every in-memory record as an encrypted WAL entry.
 		var recordsWritten int
 		atRestEncrypted := engine.CryptoEnabled()
+		var migrateErr error
 		engine.ForEach(func(key string, value []byte, expiration time.Time) {
+			if migrateErr != nil {
+				return
+			}
 			walValue := value
 			if atRestEncrypted {
-				plainValue, decErr := h.crypto.DecryptInPlace(value)
+				plainValue, decErr := tmpH.crypto.DecryptInPlace(value)
 				if decErr != nil {
-					if s.logger.Enabled(log.LevelError) {
-						s.logger.Log(log.LevelError, "persistence: migration decrypt failed",
-							log.Uint("shard", shardID), log.String("key", key), log.String("error", decErr.Error()))
-					}
+					migrateErr = fmt.Errorf("persistence: migration decrypt %q: %w", key, decErr)
 					return
 				}
 				walValue = plainValue
@@ -534,19 +569,78 @@ func (s *Storage) LoadShard(shardID uint32, engine *storage.Engine) error {
 			binary.LittleEndian.PutUint32(header[0:4], uint32(len(key)))
 			binary.LittleEndian.PutUint32(header[4:8], uint32(len(walValue)))
 			binary.LittleEndian.PutUint64(header[8:16], uint64(ttlNano))
-			if err := s.appendRecordEncrypted(h, shardID, header, key, walValue, "migration"); err != nil {
-				if s.logger.Enabled(log.LevelError) {
-					s.logger.Log(log.LevelError, "persistence: migration write failed",
-						log.Uint("shard", shardID), log.String("key", key), log.String("error", err.Error()))
-				}
-			} else {
-				recordsWritten++
+			if err = s.appendRecordEncrypted(tmpH, shardID, header, key, walValue, "migration"); err != nil {
+				migrateErr = fmt.Errorf("persistence: migration write %q: %w", key, err)
+				return
 			}
+			recordsWritten++
 		})
-		h.mu.Unlock()
+
+		if migrateErr != nil {
+			_ = mf.Close()
+			_ = os.Remove(migrPath)
+			// Re-open original so the handle is usable.
+			of, _ := os.OpenFile(origPath, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0600)
+			h.file = of
+			h.mu.Unlock()
+			return migrateErr
+		}
+
+		if err = mf.Sync(); err != nil {
+			_ = mf.Close()
+			_ = os.Remove(migrPath)
+			of, _ := os.OpenFile(origPath, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0600)
+			h.file = of
+			h.mu.Unlock()
+			return fmt.Errorf("persistence: sync migration file: %w", err)
+		}
+		if err = mf.Close(); err != nil {
+			_ = os.Remove(migrPath)
+			of, _ := os.OpenFile(origPath, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0600)
+			h.file = of
+			h.mu.Unlock()
+			return fmt.Errorf("persistence: close migration file: %w", err)
+		}
+
+		// Atomic rename: original plaintext WAL is replaced by the
+		// encrypted version. If the process crashes here, the original
+		// is either the old file or the new file — both are valid.
+		if err = os.Rename(migrPath, origPath); err != nil {
+			_ = os.Remove(migrPath)
+			of, _ := os.OpenFile(origPath, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0600)
+			h.file = of
+			h.mu.Unlock()
+			return fmt.Errorf("persistence: rename migration file: %w", err)
+		}
+		if err := syncDir(s.dir); err != nil {
+			// Best-effort: rename succeeded but dir sync failed. The
+			// data is on disk; a crash+restart may or may not see it.
+			if s.logger.Enabled(log.LevelWarn) {
+				s.logger.Log(log.LevelWarn, "persistence: sync dir after migration failed",
+					log.Uint("shard", shardID), log.String("error", err.Error()))
+			}
+		}
+
+		// Re-open the renamed file as the new WAL handle.
+		nf, err := os.OpenFile(origPath, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0600)
+		if err != nil {
+			h.mu.Unlock()
+			return fmt.Errorf("persistence: reopen migrated WAL: %w", err)
+		}
+		h.file = nf
+		h.crypto = h.pendingCrypto
+		h.pendingCrypto = nil
+		h.walVer = 1
+		h.needsMigrate = false
+
+		// Persist the nonce counter so it survives a crash before the
+		// next clean shutdown writes it during CloseShard.
 		noncePath := nonceSidecarPath(s.dir, shardID)
-		nonceVal := h.nonceCtr.Load()
-		if err := writeNonceSidecar(noncePath, nonceVal); err != nil {
+		nonceVal := tmpH.nonceCtr.Load()
+		h.nonceCtr.Store(nonceVal)
+		h.mu.Unlock()
+
+		if err = writeNonceSidecar(noncePath, nonceVal); err != nil {
 			if s.logger.Enabled(log.LevelError) {
 				s.logger.Log(log.LevelError, "persistence: migration nonce sidecar write failed",
 					log.Uint("shard", shardID), log.String("error", err.Error()))

--- a/internal/persistence/persistence_test.go
+++ b/internal/persistence/persistence_test.go
@@ -781,7 +781,7 @@ func TestEncryptedWALRejectsMismatchedCrypto(t *testing.T) {
 	if err := s.OpenShard(1, ce); err != nil {
 		t.Fatalf("OpenShard plaintext+crypto should migrate: %v", err)
 	}
-	engine := storage.NewEngine(0, 0, 0, nil, nil)
+	engine := newTestEngine(t)
 	if err := s.LoadShard(1, engine); err != nil {
 		t.Fatalf("LoadShard after migration: %v", err)
 	}
@@ -832,8 +832,7 @@ func TestPlaintextToEncryptedMigration(t *testing.T) {
 	if err := s.OpenShard(0, ce); err != nil {
 		t.Fatalf("OpenShard with crypto: %v", err)
 	}
-	engine := storage.NewEngine(0, 0, 0, nil, nil)
-	defer engine.Close()
+	engine := newTestEngine(t)
 	if err := s.LoadShard(0, engine); err != nil {
 		t.Fatalf("LoadShard: %v", err)
 	}
@@ -860,8 +859,7 @@ func TestPlaintextToEncryptedMigration(t *testing.T) {
 	if err := s.OpenShard(0, ce); err != nil {
 		t.Fatalf("OpenShard encrypted: %v", err)
 	}
-	engine2 := storage.NewEngine(0, 0, 0, nil, nil)
-	defer engine2.Close()
+	engine2 := newTestEngine(t)
 	if err := s.LoadShard(0, engine2); err != nil {
 		t.Fatalf("LoadShard: %v", err)
 	}
@@ -920,8 +918,9 @@ func TestDevPlaintextToEncryptedUpgrade(t *testing.T) {
 			t.Fatalf("Write: %v", err)
 		}
 	}
-	s.CloseShard(0)
-	_ = s
+	if err := s.CloseShard(0); err != nil {
+		t.Fatalf("CloseShard: %v", err)
+	}
 
 	// Session 2: crypto enabled — should migrate and recover all keys.
 	s2, err := NewStorage(true, nil, dir)
@@ -931,8 +930,7 @@ func TestDevPlaintextToEncryptedUpgrade(t *testing.T) {
 	if err := s2.OpenShard(0, ce); err != nil {
 		t.Fatalf("OpenShard with crypto: %v", err)
 	}
-	engine := storage.NewEngine(0, 0, 0, nil, nil)
-	defer engine.Close()
+	engine := newTestEngine(t)
 	if err := s2.LoadShard(0, engine); err != nil {
 		t.Fatalf("LoadShard: %v", err)
 	}
@@ -951,8 +949,9 @@ func TestDevPlaintextToEncryptedUpgrade(t *testing.T) {
 	}
 
 	// Session 3: reopen as encrypted — data still survives.
-	s2.CloseShard(0)
-	_ = s2
+	if err := s2.CloseShard(0); err != nil {
+		t.Fatalf("CloseShard: %v", err)
+	}
 	s3, err := NewStorage(true, nil, dir)
 	if err != nil {
 		t.Fatalf("NewStorage: %v", err)
@@ -960,8 +959,7 @@ func TestDevPlaintextToEncryptedUpgrade(t *testing.T) {
 	if err := s3.OpenShard(0, ce); err != nil {
 		t.Fatalf("OpenShard: %v", err)
 	}
-	engine2 := storage.NewEngine(0, 0, 0, nil, nil)
-	defer engine2.Close()
+	engine2 := newTestEngine(t)
 	if err := s3.LoadShard(0, engine2); err != nil {
 		t.Fatalf("LoadShard: %v", err)
 	}

--- a/internal/persistence/persistence_test.go
+++ b/internal/persistence/persistence_test.go
@@ -741,7 +741,8 @@ func TestEncryptedWALHeaderWritten(t *testing.T) {
 }
 
 // TestEncryptedWALRejectsMismatchedCrypto verifies that opening an encrypted
-// WAL without a crypto engine, or a plaintext WAL with a crypto engine, fails.
+// WAL without a crypto engine fails. Opening a plaintext WAL with a crypto
+// engine now succeeds — it migrates the WAL to encrypted format.
 func TestEncryptedWALRejectsMismatchedCrypto(t *testing.T) {
 	dir := newTestDir(t)
 	s, err := NewStorage(true, nil, dir)
@@ -776,9 +777,201 @@ func TestEncryptedWALRejectsMismatchedCrypto(t *testing.T) {
 	}
 	s.CloseShard(1)
 
-	// Reopen plaintext WAL with crypto — should fail.
-	if err := s.OpenShard(1, ce); err == nil {
-		t.Fatal("expected error opening plaintext WAL with crypto")
+	// Reopen plaintext WAL with crypto — should migrate, not fail.
+	if err := s.OpenShard(1, ce); err != nil {
+		t.Fatalf("OpenShard plaintext+crypto should migrate: %v", err)
+	}
+	engine := storage.NewEngine(0, 0, 0, nil, nil)
+	if err := s.LoadShard(1, engine); err != nil {
+		t.Fatalf("LoadShard after migration: %v", err)
+	}
+	val, ok := engine.Get("k")
+	if !ok || string(val) != "v" {
+		t.Fatalf("key 'k' = %q, want 'v'", val)
+	}
+	s.CloseShard(1)
+
+	// Reopen — should now be an encrypted WAL (magic header present).
+	if err := s.OpenShard(1, ce); err != nil {
+		t.Fatalf("OpenShard migrated WAL: %v", err)
+	}
+	if err := s.LoadShard(1, engine); err != nil {
+		t.Fatalf("LoadShard migrated WAL: %v", err)
+	}
+	val, ok = engine.Get("k")
+	if !ok || string(val) != "v" {
+		t.Fatalf("key 'k' after reopen = %q, want 'v'", val)
+	}
+}
+
+// TestPlaintextToEncryptedMigration verifies the full upgrade path:
+// write plaintext WAL (v1.2.0), then open with crypto enabled, replay,
+// migrate, write new encrypted records, close, reopen, verify all data.
+func TestPlaintextToEncryptedMigration(t *testing.T) {
+	dir := newTestDir(t)
+	s, err := NewStorage(true, nil, dir)
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+
+	// Phase 1: write plaintext WAL (simulates v1.2.0).
+	if err := s.OpenShard(0, nil); err != nil {
+		t.Fatalf("OpenShard plaintext: %v", err)
+	}
+	for i := 0; i < 20; i++ {
+		key := fmt.Sprintf("legacy_%02d", i)
+		val := fmt.Sprintf("plain-%02d", i)
+		if err := s.Write(0, key, []byte(val), time.Now().Add(time.Hour)); err != nil {
+			t.Fatalf("Write %s: %v", key, err)
+		}
+	}
+	s.CloseShard(0)
+
+	// Phase 2: open with crypto — triggers migration.
+	ce := newCryptoEngine(t)
+	if err := s.OpenShard(0, ce); err != nil {
+		t.Fatalf("OpenShard with crypto: %v", err)
+	}
+	engine := storage.NewEngine(0, 0, 0, nil, nil)
+	defer engine.Close()
+	if err := s.LoadShard(0, engine); err != nil {
+		t.Fatalf("LoadShard: %v", err)
+	}
+	// All 20 plaintext records should be in memory.
+	for i := 0; i < 20; i++ {
+		key := fmt.Sprintf("legacy_%02d", i)
+		want := fmt.Sprintf("plain-%02d", i)
+		got, ok := engine.Get(key)
+		if !ok || string(got) != want {
+			t.Fatalf("after migration key %q = %q, want %q", key, got, want)
+		}
+	}
+	// New writes should go encrypted.
+	for i := 0; i < 10; i++ {
+		key := fmt.Sprintf("fresh_%02d", i)
+		val := fmt.Sprintf("enc-%02d", i)
+		if err := s.Write(0, key, []byte(val), time.Now().Add(time.Hour)); err != nil {
+			t.Fatalf("Write %s: %v", key, err)
+		}
+	}
+	s.CloseShard(0)
+
+	// Phase 3: reopen as encrypted WAL — all data survives.
+	if err := s.OpenShard(0, ce); err != nil {
+		t.Fatalf("OpenShard encrypted: %v", err)
+	}
+	engine2 := storage.NewEngine(0, 0, 0, nil, nil)
+	defer engine2.Close()
+	if err := s.LoadShard(0, engine2); err != nil {
+		t.Fatalf("LoadShard: %v", err)
+	}
+	for i := 0; i < 20; i++ {
+		key := fmt.Sprintf("legacy_%02d", i)
+		want := fmt.Sprintf("plain-%02d", i)
+		got, ok := engine2.Get(key)
+		if !ok || string(got) != want {
+			t.Fatalf("final legacy key %q = %q, want %q", key, got, want)
+		}
+	}
+	for i := 0; i < 10; i++ {
+		key := fmt.Sprintf("fresh_%02d", i)
+		want := fmt.Sprintf("enc-%02d", i)
+		got, ok := engine2.Get(key)
+		if !ok || string(got) != want {
+			t.Fatalf("final fresh key %q = %q, want %q", key, got, want)
+		}
+	}
+	// WAL file should start with encrypted magic header.
+	h := s.getShard(0)
+	if h == nil {
+		t.Fatal("shard 0 not found")
+	}
+	magic := make([]byte, 4)
+	h.mu.Lock()
+	if _, err := h.file.ReadAt(magic, 0); err != nil {
+		h.mu.Unlock()
+		t.Fatalf("ReadAt: %v", err)
+	}
+	h.mu.Unlock()
+	if string(magic) != walMagic {
+		t.Fatalf("WAL magic = %q, want %q", magic, walMagic)
+	}
+}
+
+// TestDevPlaintextToEncryptedUpgrade verifies the upgrade path where the same
+// dev binary first runs without encryption (plaintext WAL), then restarts
+// with encryption enabled — the WAL migrates transparently.
+func TestDevPlaintextToEncryptedUpgrade(t *testing.T) {
+	dir := newTestDir(t)
+	ce := newCryptoEngine(t)
+
+	// Session 1: no crypto — write plaintext WAL.
+	s, err := NewStorage(true, nil, dir)
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+	if err := s.OpenShard(0, nil); err != nil {
+		t.Fatalf("OpenShard: %v", err)
+	}
+	for i := 0; i < 10; i++ {
+		key := fmt.Sprintf("k%02d", i)
+		val := fmt.Sprintf("v%02d", i)
+		if err := s.Write(0, key, []byte(val), time.Now().Add(time.Hour)); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+	s.CloseShard(0)
+	_ = s
+
+	// Session 2: crypto enabled — should migrate and recover all keys.
+	s2, err := NewStorage(true, nil, dir)
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+	if err := s2.OpenShard(0, ce); err != nil {
+		t.Fatalf("OpenShard with crypto: %v", err)
+	}
+	engine := storage.NewEngine(0, 0, 0, nil, nil)
+	defer engine.Close()
+	if err := s2.LoadShard(0, engine); err != nil {
+		t.Fatalf("LoadShard: %v", err)
+	}
+	for i := 0; i < 10; i++ {
+		key := fmt.Sprintf("k%02d", i)
+		want := fmt.Sprintf("v%02d", i)
+		got, ok := engine.Get(key)
+		if !ok || string(got) != want {
+			t.Fatalf("after migration key %q = %q, want %q", key, got, want)
+		}
+	}
+	// Verify nonce sidecar was written during migration.
+	sidecarPath := nonceSidecarPath(dir, 0)
+	if _, err := os.Stat(sidecarPath); os.IsNotExist(err) {
+		t.Fatal("nonce sidecar not created during migration")
+	}
+
+	// Session 3: reopen as encrypted — data still survives.
+	s2.CloseShard(0)
+	_ = s2
+	s3, err := NewStorage(true, nil, dir)
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+	if err := s3.OpenShard(0, ce); err != nil {
+		t.Fatalf("OpenShard: %v", err)
+	}
+	engine2 := storage.NewEngine(0, 0, 0, nil, nil)
+	defer engine2.Close()
+	if err := s3.LoadShard(0, engine2); err != nil {
+		t.Fatalf("LoadShard: %v", err)
+	}
+	for i := 0; i < 10; i++ {
+		key := fmt.Sprintf("k%02d", i)
+		want := fmt.Sprintf("v%02d", i)
+		got, ok := engine2.Get(key)
+		if !ok || string(got) != want {
+			t.Fatalf("final key %q = %q, want %q", key, got, want)
+		}
 	}
 }
 
@@ -1009,5 +1202,280 @@ func TestEncryptedNonceCounterSurvivesTruncateWithoutClose(t *testing.T) {
 	ctrAfterRestart := h2.nonceCtr.Load()
 	if ctrAfterRestart != 15 {
 		t.Fatalf("counter after restart = %d, want 15 (no regression from truncation)", ctrAfterRestart)
+	}
+}
+
+// writeRawPlaintextWAL writes raw v1.2.0-format WAL records directly to disk.
+// This simulates a data directory left behind by a Tellstone v1.2.0 node
+// (plaintext WAL, no magic header, no snapshots, no encryption).
+func writeRawPlaintextWAL(t *testing.T, path string, records [][]byte) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		t.Fatalf("create WAL file: %v", err)
+	}
+	for _, rec := range records {
+		if _, err := f.Write(rec); err != nil {
+			t.Fatalf("write record: %v", err)
+		}
+	}
+	if err := f.Sync(); err != nil {
+		t.Fatalf("sync WAL: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close WAL: %v", err)
+	}
+}
+
+// buildPlaintextRecord builds a single plaintext WAL record in the v1.2.0 binary
+// format: [keyLen:4B LE][valLen:4B LE][ttlNano:8B LE][key][value].
+func buildPlaintextRecord(key string, value []byte, ttl time.Time) []byte {
+	var header [16]byte
+	binary.LittleEndian.PutUint32(header[0:4], uint32(len(key)))
+	binary.LittleEndian.PutUint32(header[4:8], uint32(len(value)))
+	if !ttl.IsZero() {
+		binary.LittleEndian.PutUint64(header[8:16], uint64(ttl.UnixNano()))
+	}
+	rec := make([]byte, 0, 16+len(key)+len(value))
+	rec = append(rec, header[:]...)
+	rec = append(rec, key...)
+	rec = append(rec, value...)
+	return rec
+}
+
+// TestV120PlaintextWALBackwardCompat verifies that v1.3.0 can open, replay, and
+// read data from a plaintext WAL created by v1.2.0 (no magic header, no snapshot
+// files, no encryption). The WAL bytes are hand-crafted to match the v1.2.0
+// on-disk format exactly.
+func TestV120PlaintextWALBackwardCompat(t *testing.T) {
+	dir := newTestDir(t)
+
+	// Simulate a v1.2.0 data directory: 20 records written directly to disk
+	// in plaintext WAL format. No .snap files, no .nonce files, no magic header.
+	var records [][]byte
+	for i := 0; i < 20; i++ {
+		records = append(records, buildPlaintextRecord(
+			fmt.Sprintf("legacy_%d", i),
+			[]byte(fmt.Sprintf("val_%d", i)),
+			time.Time{},
+		))
+	}
+	walPath := filepath.Join(dir, "shard_000.db")
+	writeRawPlaintextWAL(t, walPath, records)
+
+	// v1.3.0 opens the shard with nil crypto (plaintext mode).
+	s, err := NewStorage(true, nil, dir)
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+	defer s.CloseShard(0)
+
+	if err := s.OpenShard(0, nil); err != nil {
+		t.Fatalf("OpenShard: %v", err)
+	}
+
+	// LoadShard should skip snapshot (none exists) and replay the WAL.
+	engine := newTestEngine(t)
+	if err := s.LoadShard(0, engine); err != nil {
+		t.Fatalf("LoadShard: %v", err)
+	}
+
+	if engine.KeyCount() != 20 {
+		t.Fatalf("expected 20 keys after v1.2.0 WAL replay, got %d", engine.KeyCount())
+	}
+
+	// Spot-check a few records.
+	for i := 0; i < 20; i++ {
+		key := fmt.Sprintf("legacy_%d", i)
+		want := fmt.Sprintf("val_%d", i)
+		v, ok := engine.Get(key)
+		if !ok {
+			t.Fatalf("key %q not found after v1.2.0 WAL replay", key)
+		}
+		if string(v) != want {
+			t.Fatalf("key %q: got %q, want %q", key, v, want)
+		}
+	}
+}
+
+// TestV120PlaintextWALSnapshotMigration verifies the full upgrade path from
+// v1.2.0 to v1.3.0:
+//
+//  1. Hand-craft a v1.2.0 plaintext WAL (no magic, no snapshot).
+//  2. Open with v1.3.0, load, verify all records.
+//  3. Take a snapshot with v1.3.0 (produces a .snap file).
+//  4. Truncate the WAL.
+//  5. Close and reopen — only the snapshot + truncated WAL should exist.
+//  6. Load again, verify all original records survived.
+func TestV120PlaintextWALSnapshotMigration(t *testing.T) {
+	dir := newTestDir(t)
+
+	// Step 1: Create a v1.2.0 plaintext WAL with 30 records.
+	var records [][]byte
+	for i := 0; i < 30; i++ {
+		records = append(records, buildPlaintextRecord(
+			fmt.Sprintf("mig_%d", i),
+			[]byte(fmt.Sprintf("data_%d", i)),
+			time.Time{},
+		))
+	}
+	walPath := filepath.Join(dir, "shard_000.db")
+	writeRawPlaintextWAL(t, walPath, records)
+
+	// Step 2: Open with v1.3.0, load, verify.
+	s, err := NewStorage(true, nil, dir)
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+	if err := s.OpenShard(0, nil); err != nil {
+		t.Fatalf("OpenShard: %v", err)
+	}
+	engine := newTestEngine(t)
+	if err := s.LoadShard(0, engine); err != nil {
+		t.Fatalf("LoadShard: %v", err)
+	}
+	if engine.KeyCount() != 30 {
+		t.Fatalf("expected 30 keys, got %d", engine.KeyCount())
+	}
+
+	// Step 3: Snapshot — serializes the engine to a .snap file, then truncates WAL.
+	// Use snapshotWrite directly (Snapshot() uses ForkExec which needs a built binary).
+	if _, err := snapshotWrite(dir, 0, engine, [16]byte{}, nil); err != nil {
+		t.Fatalf("snapshotWrite: %v", err)
+	}
+
+	// Truncate WAL to snapshot boundary (same as what Snapshot() does after writing).
+	if err := s.TruncateWALTo(0, 0); err != nil {
+		t.Fatalf("TruncateWALTo: %v", err)
+	}
+
+	// Verify snapshot file exists.
+	snapPath := filepath.Join(dir, "shard_000.snap")
+	if _, err := os.Stat(snapPath); err != nil {
+		t.Fatalf("snapshot file not created: %v", err)
+	}
+
+	// Step 4: Close the shard.
+	if err := s.CloseShard(0); err != nil {
+		t.Fatalf("CloseShard: %v", err)
+	}
+
+	// Step 5: Reopen — should load from snapshot + truncated WAL.
+	s2, err := NewStorage(true, nil, dir)
+	if err != nil {
+		t.Fatalf("NewStorage (reopen): %v", err)
+	}
+	defer s2.CloseShard(0)
+	if err := s2.OpenShard(0, nil); err != nil {
+		t.Fatalf("OpenShard (reopen): %v", err)
+	}
+	engine2 := newTestEngine(t)
+	if err := s2.LoadShard(0, engine2); err != nil {
+		t.Fatalf("LoadShard (reopen): %v", err)
+	}
+
+	// Step 6: Verify all 30 records survived the migration.
+	if engine2.KeyCount() != 30 {
+		t.Fatalf("expected 30 keys after migration, got %d", engine2.KeyCount())
+	}
+	for i := 0; i < 30; i++ {
+		key := fmt.Sprintf("mig_%d", i)
+		want := fmt.Sprintf("data_%d", i)
+		v, ok := engine2.Get(key)
+		if !ok {
+			t.Fatalf("key %q not found after migration", key)
+		}
+		if string(v) != want {
+			t.Fatalf("key %q: got %q, want %q", key, v, want)
+		}
+	}
+}
+
+// TestV120PlaintextWALWriteAfterMigration verifies that new writes after
+// upgrading from a v1.2.0 plaintext WAL work correctly alongside the legacy
+// data.
+func TestV120PlaintextWALWriteAfterMigration(t *testing.T) {
+	dir := newTestDir(t)
+
+	// Create a v1.2.0 plaintext WAL with 10 records.
+	var records [][]byte
+	for i := 0; i < 10; i++ {
+		records = append(records, buildPlaintextRecord(
+			fmt.Sprintf("old_%d", i),
+			[]byte(fmt.Sprintf("v%d", i)),
+			time.Time{},
+		))
+	}
+	walPath := filepath.Join(dir, "shard_000.db")
+	writeRawPlaintextWAL(t, walPath, records)
+
+	// Open with v1.3.0, load legacy data, then write new data.
+	s, err := NewStorage(true, nil, dir)
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+	defer s.CloseShard(0)
+
+	if err := s.OpenShard(0, nil); err != nil {
+		t.Fatalf("OpenShard: %v", err)
+	}
+	engine := newTestEngine(t)
+	if err := s.LoadShard(0, engine); err != nil {
+		t.Fatalf("LoadShard: %v", err)
+	}
+	if engine.KeyCount() != 10 {
+		t.Fatalf("expected 10 legacy keys, got %d", engine.KeyCount())
+	}
+
+	// Write new records through v1.3.0.
+	for i := 0; i < 10; i++ {
+		if err := s.Write(0, fmt.Sprintf("new_%d", i), []byte(fmt.Sprintf("nv%d", i)), time.Time{}); err != nil {
+			t.Fatalf("Write new_%d: %v", i, err)
+		}
+	}
+
+	// Close and reopen — both legacy and new records should survive.
+	s.CloseShard(0)
+	s2, err := NewStorage(true, nil, dir)
+	if err != nil {
+		t.Fatalf("NewStorage (reopen): %v", err)
+	}
+	defer s2.CloseShard(0)
+	if err := s2.OpenShard(0, nil); err != nil {
+		t.Fatalf("OpenShard (reopen): %v", err)
+	}
+	engine2 := newTestEngine(t)
+	if err := s2.LoadShard(0, engine2); err != nil {
+		t.Fatalf("LoadShard (reopen): %v", err)
+	}
+
+	if engine2.KeyCount() != 20 {
+		t.Fatalf("expected 20 keys (10 legacy + 10 new), got %d", engine2.KeyCount())
+	}
+
+	// Verify legacy records.
+	for i := 0; i < 10; i++ {
+		key := fmt.Sprintf("old_%d", i)
+		want := fmt.Sprintf("v%d", i)
+		v, ok := engine2.Get(key)
+		if !ok {
+			t.Fatalf("legacy key %q not found", key)
+		}
+		if string(v) != want {
+			t.Fatalf("legacy key %q: got %q, want %q", key, v, want)
+		}
+	}
+
+	// Verify new records.
+	for i := 0; i < 10; i++ {
+		key := fmt.Sprintf("new_%d", i)
+		want := fmt.Sprintf("nv%d", i)
+		v, ok := engine2.Get(key)
+		if !ok {
+			t.Fatalf("new key %q not found", key)
+		}
+		if string(v) != want {
+			t.Fatalf("new key %q: got %q, want %q", key, v, want)
+		}
 	}
 }


### PR DESCRIPTION
## Description

add the possibility to upgrade from plaintext wal to encrypted wal. 
Because when someone used encryption already with v1.2.0 or earlier the wal was not encrypted.
To ensure a upgrade works this fix is needed 

**Component:** (e.g., Networking/RESP, Storage Engine, Router/Shard, CLI, Build/CI)

Persistence

**Type of Change:**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance optimization (no change in behavior, improved speed/memory)
- [ ] Refactoring (no functional changes, code cleanup)
- [ ] Build / CI / Documentation

---

## Related Issue

none
---

## Technical Deep Dive & Context

on server start and encryption enabled any wal files which are plain are detected by the OpenShard workflow.
(checking for magic header)
the Shard will open the WAL in plaintext mode
LoadShard will replay normally (as there is no encryption) 
Afterwards a Migration will be executed, existing WAL files will be truncated, rewritten but this time encrypted



## How Has This Been Tested?

- go test
- bechmark
- manual proof

---

## Checklist

- [x] My code follows the existing code style of this project
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally (`go test ./...` and `go test -race ./...`)
- [x] I have updated the documentation (README, comments, or any relevant docs)
- [x] My changes generate no new `go vet` warnings
- [ ] Any breaking changes are documented and communicated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added transparent migration from plaintext write-ahead logs to encrypted storage.
  * Existing data is automatically re-encrypted when encryption is enabled.
  * Migration works across restarts, snapshots, and mixed legacy/new records.
  * Subsequent writes use encrypted storage after migration completes.

* **Bug Fixes**
  * Plaintext logs no longer fail to open when encryption is enabled.
  * Preserved nonce recovery and compatibility with legacy records during encrypted replay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->