### PR TITLE
feat(cluster): add regional routing with write forward to the leader …

### DIFF
--- a/docs/PHASE3-ROUTING-DESIGN.md
+++ b/docs/PHASE3-ROUTING-DESIGN.md
@@ -57,8 +57,8 @@ not wired into the write path yet (deferred to the SQL/MVCC phase per ADR-010).
 
 ## Architecture
 
-```
-            ┌─────────────┐  etcd Watch (/tellstone/regions/*)  ┌──────────────┐
+```text
+             ┌─────────────┐  etcd Watch (/tellstone/regions/*)  ┌──────────────┐
             │   PD etcd   │ ───────────────────────────────────▶│ RoutingTable │
             │  (region    │                                      │  (per node)  │
             │  metadata)  │ ◀── RegionManager (leader rewrites  │              │

--- a/docs/PHASE3-ROUTING-DESIGN.md
+++ b/docs/PHASE3-ROUTING-DESIGN.md
@@ -1,0 +1,109 @@
+# Phase 3: Routing Table + Forwarding (Design & Decisions)
+
+Status: Accepted
+Date: 2026-08-26
+Branch: `feat/raft-phase-3`
+
+## Context
+
+Phase 1 (`raft cluster mode`, #55) and Phase 2 (`embedded PD + TSO`, #56) are
+merged. Today there is **one Raft group over the whole keyspace**. A non-leader
+node rejects writes (`server/cluster.go` returns `ErrNotLeader`); reads read the
+local store. There is no routing table and no forwarding.
+
+Phase 3 makes the cluster **read/write-anywhere**: any node serves any key.
+This doc records the decisions so they are not re-litigated, then the build
+plan. Source of truth: `docs/MULTI-CLUSTER-PLAN.md` (Phase 3) and `ADR-002` /
+`ADR-004`. (ROADMAP.md is intentionally not used — it describes an unrelated
+Security & Transport phase.)
+
+## Decisions (locked)
+
+### D1 — Routing distribution: etcd Watch, not a gRPC push stream
+Region metadata is stored in the embedded etcd KV (`/tellstone/regions/<id>`).
+Every node **`Watch`es** that prefix and refreshes its local `RoutingTable`.
+This reuses the PD substrate shipped in Phase 2 instead of building a custom
+gRPC streaming push service. The doc's "PD pushes via gRPC stream" is deferred
+to Phase 5 (pipelines) if ever wanted.
+
+### D2 — Read Anywhere via Raft `ReadIndex`; writes forwarded to leader
+- **Leader** serves linearizable reads from its local applied state.
+- **Followers** serve reads locally too, but only after a `ReadIndex` round
+  trip proves their applied index has caught up to the read's committed index.
+  No read is ever forwarded over the network (every node already holds the full
+  replicated dataset for the single default region).
+- **Writes** must reach the region leader (Raft only proposes from the leader).
+  A non-leader node **forwards** the write to the leader; the leader applies it
+  through Raft and replies. This is symmetric, so "write anywhere" is already
+  satisfied by the same path.
+
+### D3 — No protobuf / gRPC `ClusterService` for forwarding
+Forwarding reuses the **existing `network.Transport`** (`internal/cluster/network`,
+a custom binary-framed TCP transport). We add application-level message types
+(`MsgForwardWrite` / `MsgForwardRead` / `MsgForwardResp`) carried as
+`raftpb.Message` values with out-of-range type codes, intercepted in
+`Node.handleMessage` *before* `raftNode.Step`. No protobuf schema, no codegen,
+no new client library. (A dedicated internal app-transport reusing `codec.go`
+remains a later option, not required here.)
+
+### D4 — Single default region to start
+Phase 3 introduces the Region/routing machinery with **one** region covering
+`["", "")` = the current Raft group. True multi-region splitting is Phase 4.
+Phase 3 ships the structure so Phase 4 is a small addition.
+
+### D5 — TSO stays off the write path
+Writes go through Raft exactly as today. TSO pre-allocated pools exist but are
+not wired into the write path yet (deferred to the SQL/MVCC phase per ADR-010).
+
+## Architecture
+
+```
+            ┌─────────────┐  etcd Watch (/tellstone/regions/*)  ┌──────────────┐
+            │   PD etcd   │ ───────────────────────────────────▶│ RoutingTable │
+            │  (region    │                                      │  (per node)  │
+            │  metadata)  │ ◀── RegionManager (leader rewrites  │              │
+            └─────────────┘      leader field on leadership)    └──────┬───────┘
+                                                                      │ Find(key)
+                                                                      ▼
+   client ──▶ Node A ──(not leader)──▶ forward MsgForwardWrite ──▶ Node C (leader)
+                  │                                                      │ ProposeAndWait
+                  │ (follower read) ReadIndex ─▶ local store ◀──────────┘ applied to all
+```
+
+- `RegionManager` runs on every node, holds a `clientv3.Client` to the PD, and:
+  - bootstraps the default region (if absent) from the raft peer list;
+  - `Watch`es region metadata and feeds `RoutingTable.Update`;
+  - if this node is the raft leader, keeps the region's `Leader` field = self
+    (epoch-bumped on change) so all nodes converge.
+- `Node` gains `LeaderID()`, `AppliedIndex()`, `PeerAddr(id)`, `ReadIndex` /
+  `LinearizableRead`, and `ForwardWrite` / `ForwardRead` (pending-map + reply).
+- `clusterStore` (`server/cluster.go`): `Set`/`Delete` → if local node leads the
+  key's region, `ProposeAndWait` (current path); else `Node.ForwardWrite` to the
+  leader. `Get` → `LinearizableRead` (leader or follower) then read local store.
+
+## Deliverables
+
+| # | File | Responsibility |
+|---|------|----------------|
+| 1 | `internal/cluster/routing.go` | `RegionRoute`, `RoutingTable` (sorted slice, binary-search `Find`, epoch-guarded `Update`). |
+| 2 | `internal/cluster/routing_test.go` | Unit tests: `Find` boundaries, stale-epoch rejection. |
+| 3 | `internal/cluster/region.go` | `Region` type, binary (de)serialization, `RegionManager` (bootstrap + `Watch` + leadership keep-alive). |
+| 4 | `internal/cluster/region_test.go` | Integration with embedded etcd: bootstrap, watch converges, leader rewrite. |
+| 5 | `internal/cluster/node.go` | `LeaderID`, `AppliedIndex`, `PeerAddr`, `ReadIndex`/`LinearizableRead`, forward msg types + `ForwardWrite`/`ForwardRead` + `handleMessage` routing + pending map. |
+| 6 | `internal/cluster/pdnode.go` | Expose `Client()` so `RegionManager` gets a `clientv3.Client`. |
+| 7 | `server/cluster.go` | `clusterStore` uses `RoutingTable` + `Node.Forward` (writes) / `LinearizableRead` (reads). |
+| 8 | `server/server.go` | Wire `RoutingTable` + `RegionManager` in `initCluster`. |
+| 9 | `internal/cluster/manual_test.go` | Gated `TestManualRouting`: 3-node, write on non-leader, read on another, kill leader → converge. |
+
+## Verification
+
+- **Unit:** `RoutingTable.Find` + stale-epoch; region (de)serialization.
+- **Integration:** 3-node, kill leader → `Watch` converges, follower becomes
+  leader, forwarded writes/reads keep working.
+- **Manual (gated `TELLSTONE_MANUAL_TEST=1`):** read/write-anywhere across nodes.
+
+## Out of scope (deferred)
+
+- Multi-region / splitting (Phase 4).
+- TSO on the write path (SQL/MVCC phase).
+- Protobuf/gRPC `ClusterService` (D3 — not needed).

--- a/internal/cluster/manual_test.go
+++ b/internal/cluster/manual_test.go
@@ -605,21 +605,23 @@ func TestManualRouting(t *testing.T) {
 		val := fmt.Sprintf("v%d", i)
 		s := servers[i%len(servers)]
 		addr := fmt.Sprintf("127.0.0.1:%d", s.binaryPort)
-		conn, err := connectTo(addr)
-		if err != nil {
-			t.Fatalf("connect node %d (%s): %v", s.id, addr, err)
-		}
 		// Retry briefly in case the region leader has not been claimed yet.
+		// Each attempt uses a freshly opened connection so a failed attempt's
+		// stale response can never be consumed by a later retry.
 		var setErr error
 		for attempt := 0; attempt < 10; attempt++ {
+			conn, err := connectTo(addr)
+			if err != nil {
+				t.Fatalf("connect node %d (%s): %v", s.id, addr, err)
+			}
 			_, setErr = binarySet(conn, key, val, 0)
+			conn.Close()
 			if setErr == nil {
 				break
 			}
 			t.Logf("  node %d SET %s attempt %d: %v (retrying)", s.id, key, attempt+1, setErr)
 			time.Sleep(300 * time.Millisecond)
 		}
-		conn.Close()
 		if setErr != nil {
 			t.Fatalf("node %d SET %s (forwarded to leader) failed: %v", s.id, key, setErr)
 		}

--- a/internal/cluster/manual_test.go
+++ b/internal/cluster/manual_test.go
@@ -565,3 +565,96 @@ func TestManualPDTSO(t *testing.T) {
 	t.Logf("OK: %d PD grants across 3 nodes are globally disjoint", len(grants))
 	t.Log("=== MANUAL PD/TSO TEST COMPLETE ===")
 }
+
+// TestManualRouting is the manual end-to-end proof for the phase 3 region
+// routing layer. It boots a real 3-node --cluster-mode Tellstone cluster and
+// asserts two invariants:
+//
+//   - Write-forwarding (D2/D3): a SET issued against EVERY node — including
+//     followers — succeeds. Followers resolve the region leader from the
+//     routing table and forward the op over the cluster transport.
+//   - Read-anywhere (D1): once a write has replicated, a GET against every
+//     node returns the value, served from the local replica after a
+//     linearizable ReadIndex round-trip.
+//
+// Run with:
+//
+//	TELLSTONE_MANUAL_TEST=1 go test -v -count=1 \
+//	    -run=TestManualRouting ./internal/cluster/ -timeout=120s
+func TestManualRouting(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping manual test in short mode")
+	}
+	if os.Getenv("TELLSTONE_MANUAL_TEST") == "" {
+		t.Skip("manual routing test only runs with TELLSTONE_MANUAL_TEST=1")
+	}
+
+	t.Log("=== MANUAL ROUTING TEST ===")
+	bin := manualBuild(t)
+	servers := manualStartCluster(t, 3, bin)
+	defer manualStopCluster(t, servers)
+
+	// Give the cluster time to elect a Raft leader and for the RegionManager to
+	// claim the default region (routing table convergence, D4).
+	time.Sleep(3 * time.Second)
+
+	// D2/D3: issue a SET against each of the 3 nodes in turn so that follower
+	// writes are exercised. Every SET must succeed via forwarding.
+	keys := []string{"routing-a", "routing-b", "routing-c"}
+	for i, key := range keys {
+		val := fmt.Sprintf("v%d", i)
+		s := servers[i%len(servers)]
+		addr := fmt.Sprintf("127.0.0.1:%d", s.binaryPort)
+		conn, err := connectTo(addr)
+		if err != nil {
+			t.Fatalf("connect node %d (%s): %v", s.id, addr, err)
+		}
+		// Retry briefly in case the region leader has not been claimed yet.
+		var setErr error
+		for attempt := 0; attempt < 10; attempt++ {
+			_, setErr = binarySet(conn, key, val, 0)
+			if setErr == nil {
+				break
+			}
+			t.Logf("  node %d SET %s attempt %d: %v (retrying)", s.id, key, attempt+1, setErr)
+			time.Sleep(300 * time.Millisecond)
+		}
+		conn.Close()
+		if setErr != nil {
+			t.Fatalf("node %d SET %s (forwarded to leader) failed: %v", s.id, key, setErr)
+		}
+		t.Logf("  node %d SET %s = %q (forwarded) OK", s.id, key, val)
+	}
+
+	t.Log("Waiting for replication to propagate...")
+	time.Sleep(2 * time.Second)
+
+	// D1: read-anywhere. Every node must return each forwarded write.
+	for _, s := range servers {
+		addr := fmt.Sprintf("127.0.0.1:%d", s.binaryPort)
+		conn, err := connectTo(addr)
+		if err != nil {
+			t.Fatalf("connect node %d (%s): %v", s.id, addr, err)
+		}
+		for i, key := range keys {
+			val, msgType, err := binaryGet(conn, key)
+			if err != nil {
+				conn.Close()
+				t.Fatalf("node %d GET %s: %v", s.id, key, err)
+			}
+			if msgType == 0x07 {
+				conn.Close()
+				t.Fatalf("node %d GET %s: NOT_FOUND (want forwarded value)", s.id, key)
+			}
+			want := fmt.Sprintf("v%d", i)
+			if val != want {
+				conn.Close()
+				t.Fatalf("node %d GET %s = %q, want %q", s.id, key, val, want)
+			}
+			t.Logf("  node %d GET %s = %q (read-anywhere) OK", s.id, key, val)
+		}
+		conn.Close()
+	}
+
+	t.Log("=== MANUAL ROUTING TEST COMPLETE ===")
+}

--- a/internal/cluster/node.go
+++ b/internal/cluster/node.go
@@ -15,6 +15,7 @@ package cluster
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"sync"
 	"sync/atomic"
@@ -29,6 +30,15 @@ import (
 // ErrNotLeader is returned by ProposeAndWait when the node is not the
 // current Raft leader. Callers should redirect the client to the leader.
 var ErrNotLeader = errors.New("cluster: not leader")
+
+// Application-level message types carried over the existing network.Transport
+// (D3: no protobuf/gRPC for Phase 3). They use out-of-range raftpb.MessageType
+// codes and are intercepted in handleMessage before being passed to
+// raftNode.Step, so raft never sees them.
+const (
+	msgForwardWrite pb.MessageType = 100
+	msgForwardResp  pb.MessageType = 101
+)
 
 const (
 	// logCompactionThreshold compacts the local raft log once this many
@@ -76,6 +86,16 @@ type Node struct {
 	// lastCompacted is the log index through which storage has been
 	// compacted. Only touched by the readyLoop goroutine, so no lock needed.
 	lastCompacted uint64
+	// readIndexChans maps a ReadIndex correlation id to the waiter that wants
+	// the committed index to wait for.
+	readIndexID    atomic.Uint64
+	readIndexChans sync.Map // correlation id (uint64) -> chan uint64
+	// forwardChans maps a forwarded-write correlation id to its result waiter.
+	forwardID    atomic.Uint64
+	forwardChans sync.Map // correlation id (uint64) -> chan error
+	// peerAddrs resolves a peer node ID to its configured address (used by
+	// routing/forwarding to target the region leader).
+	peerAddrs map[uint64]string
 }
 
 // NewNode creates a new Raft node but does not start it. Call Start() to
@@ -94,6 +114,11 @@ func NewNode(cfg NodeConfig) (*Node, error) {
 	store := NewStorage()
 	fsm := NewFSM(cfg.Dispatcher, cfg.Logger)
 
+	addrs := make(map[uint64]string, len(cfg.Peers))
+	for _, p := range cfg.Peers {
+		addrs[p.ID] = p.Addr
+	}
+
 	n := &Node{
 		cfg:       cfg,
 		storage:   store,
@@ -101,6 +126,7 @@ func NewNode(cfg NodeConfig) (*Node, error) {
 		stopCh:    make(chan struct{}),
 		stopped:   make(chan struct{}),
 		proposals: newProposalTracker(),
+		peerAddrs: addrs,
 	}
 
 	// Build the peer list for StartNode. On the initial bootstrap every node
@@ -204,10 +230,177 @@ func (n *Node) IsLeader() bool {
 	return n.raftNode.Status().RaftState == raft.StateLeader
 }
 
-// handleMessage is called by the transport when a raft message arrives from a
-// peer. It delivers the message to the raft node via Step().
+// LeaderID returns the node ID of the current Raft leader (0 if none yet).
+func (n *Node) LeaderID() uint64 {
+	return n.raftNode.Status().Lead
+}
+
+// AppliedIndex returns the highest Raft log index applied to the local FSM.
+func (n *Node) AppliedIndex() uint64 {
+	return atomic.LoadUint64(&n.appliedIndex)
+}
+
+// PeerAddr resolves a peer node ID to its configured address.
+func (n *Node) PeerAddr(id uint64) string {
+	return n.peerAddrs[id]
+}
+
+// ReadIndex performs a Raft read-only query: it returns the committed index
+// the local state machine must have applied before serving a linearizable
+// read. See LinearizableRead for the wait.
+func (n *Node) ReadIndex(ctx context.Context) (uint64, error) {
+	id := n.readIndexID.Add(1)
+	ch := make(chan uint64, 1)
+	n.readIndexChans.Store(id, ch)
+	defer n.readIndexChans.Delete(id)
+	if err := n.raftNode.ReadIndex(ctx, uint64ToBytes(id)); err != nil {
+		return 0, err
+	}
+	select {
+	case idx := <-ch:
+		return idx, nil
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	case <-n.stopCh:
+		return 0, errors.New("cluster node stopped")
+	}
+}
+
+// LinearizableRead blocks until the local FSM has applied at least the
+// committed index returned by ReadIndex, guaranteeing a read observes all
+// previously committed writes. This is how followers serve reads locally
+// (D2: Read Anywhere, no forwarding).
+func (n *Node) LinearizableRead(ctx context.Context) error {
+	idx, err := n.ReadIndex(ctx)
+	if err != nil {
+		return err
+	}
+	for {
+		if atomic.LoadUint64(&n.appliedIndex) >= idx {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-n.stopCh:
+			return errors.New("cluster node stopped")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+}
+
+// ForwardWrite sends an already-encoded FSM operation to the region leader
+// (identified by leaderID) over the existing transport and waits for the
+// apply result. Used by clusterStore when this node is not the leader (D3).
+func (n *Node) ForwardWrite(ctx context.Context, leaderID uint64, opData []byte) error {
+	// Routing may resolve to this node (e.g. it just became leader and the
+	// table is briefly stale), or the caller may already be the leader. In
+	// that case propose directly instead of round-tripping to ourself.
+	if leaderID == n.cfg.NodeID {
+		return n.ProposeAndWait(ctx, opData)
+	}
+	id := n.forwardID.Add(1)
+	ch := make(chan error, 1)
+	n.forwardChans.Store(id, ch)
+	defer n.forwardChans.Delete(id)
+	msg := &pb.Message{
+		Type:    msgForwardType(),
+		From:    &n.cfg.NodeID,
+		To:      &leaderID,
+		Context: uint64ToBytes(id),
+		Entries: []*pb.Entry{{Data: opData}},
+	}
+	if err := n.transport.Send(msg); err != nil {
+		return err
+	}
+	select {
+	case err := <-ch:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-n.stopCh:
+		return errors.New("cluster node stopped")
+	}
+}
+
+// handleMessage is called by the transport for every inbound message.
+// Application-level forward messages are handled locally; everything else is
+// delivered to the raft node via Step().
 func (n *Node) handleMessage(msg *pb.Message) {
+	switch msg.GetType() {
+	case msgForwardWrite:
+		n.handleForwardWrite(msg)
+		return
+	case msgForwardResp:
+		if len(msg.Context) == 8 {
+			if v, ok := n.forwardChans.Load(bytesToUint64(msg.Context)); ok {
+				ch := v.(chan error)
+				var rerr error
+				if len(msg.Entries) > 0 && len(msg.Entries[0].Data) > 0 {
+					rerr = errors.New(string(msg.Entries[0].Data))
+				}
+				select {
+				case ch <- rerr:
+				default:
+				}
+			}
+		}
+		return
+	}
 	_ = n.raftNode.Step(context.Background(), msg)
+}
+
+// handleForwardWrite applies a forwarded write on the leader (the only node
+// that may propose) and replies to the requester. If this node is no longer
+// leader (stale routing), it replies with ErrNotLeader so the caller retries.
+func (n *Node) handleForwardWrite(msg *pb.Message) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var opData []byte
+	if len(msg.Entries) > 0 {
+		opData = msg.Entries[0].Data
+	}
+	applyErr := n.ProposeAndWait(ctx, opData)
+	var respData []byte
+	if applyErr != nil {
+		respData = []byte(applyErr.Error())
+	}
+	resp := &pb.Message{
+		Type:    msgForwardRespType(),
+		From:    &n.cfg.NodeID,
+		To:      msg.From,
+		Context: msg.Context,
+		Entries: []*pb.Entry{{Data: respData}},
+	}
+	_ = n.transport.Send(resp)
+}
+
+// uint64ToBytes / bytesToUint64 encode a correlation id for the wire.
+func uint64ToBytes(v uint64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, v)
+	return b
+}
+
+func bytesToUint64(b []byte) uint64 {
+	if len(b) < 8 {
+		return 0
+	}
+	return binary.BigEndian.Uint64(b)
+}
+
+// msgForwardType / msgForwardRespType return pointers to the application-level
+// message types for use in raftpb.Message struct literals (which take pointer
+// fields).
+func msgForwardType() *pb.MessageType {
+	t := msgForwardWrite
+	return &t
+}
+
+func msgForwardRespType() *pb.MessageType {
+	t := msgForwardResp
+	return &t
 }
 
 // tickLoop advances the raft node's logical clock at the configured interval.
@@ -326,6 +519,19 @@ func (n *Node) processReady(rd raft.Ready) {
 			}
 			if atomic.CompareAndSwapUint64(&n.appliedIndex, cur, idx) {
 				break
+			}
+		}
+	}
+
+	// 3b. Resolve any pending ReadIndex queries. The leader (or a follower
+	// after a ReadIndex round-trip) has now caught up to the returned commit
+	// index, so waiters can proceed with a linearizable read.
+	for _, rs := range rd.ReadStates {
+		if v, ok := n.readIndexChans.Load(bytesToUint64(rs.RequestCtx)); ok {
+			ch := v.(chan uint64)
+			select {
+			case ch <- rs.Index:
+			default:
 			}
 		}
 	}

--- a/internal/cluster/pdnode.go
+++ b/internal/cluster/pdnode.go
@@ -61,6 +61,10 @@ type PDNode struct {
 // Pool returns the local timestamp pool.
 func (p *PDNode) Pool() *TSOPool { return p.pool }
 
+// Client exposes the etcd client backing this PD node. It is used by the
+// Phase 3 RegionManager to persist and watch region metadata.
+func (p *PDNode) Client() *clientv3.Client { return p.cli }
+
 // Role reports the topology this node runs.
 func (p *PDNode) Role() string { return p.role }
 

--- a/internal/cluster/region.go
+++ b/internal/cluster/region.go
@@ -17,6 +17,7 @@ package cluster
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
 	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -78,14 +79,19 @@ func (m *RegionManager) RoutingTable() *RoutingTable { return m.rt }
 // first writer wins (D4: one default region to start).
 func (m *RegionManager) BootstrapDefaultRegion(ctx context.Context) error {
 	key := regionKey(1)
-	val := encodeRegion(Region{
+	nr := Region{
 		ID:       1,
 		StartKey: []byte{},
 		EndKey:   nil,
 		Peers:    m.peers,
 		Leader:   0,
 		Epoch:    1,
-	})
+	}
+	if regionExceedsWireLimit(nr) {
+		return fmt.Errorf("region %d exceeds wire limit: peers=%d startKey=%d endKey=%d",
+			nr.ID, len(nr.Peers), len(nr.StartKey), len(nr.EndKey))
+	}
+	val := encodeRegion(nr)
 	txn := m.cli.Txn(ctx).
 		If(clientv3.Compare(clientv3.CreateRevision(key), "=", 0)).
 		Then(clientv3.OpPut(key, string(val)))
@@ -110,42 +116,70 @@ func (m *RegionManager) Refresh(ctx context.Context) error {
 	return nil
 }
 
-// Run seeds the routing table from etcd, then watches for changes until ctx is
-// cancelled. The leadership loop runs concurrently.
-func (m *RegionManager) Run(ctx context.Context) error {
+// seed reads the full region set from etcd, merges it into the local routing
+// table, and returns the next revision to watch from.
+func (m *RegionManager) seed(ctx context.Context) (int64, error) {
 	resp, err := m.cli.Get(ctx, regionKeyPrefix, clientv3.WithPrefix())
 	if err != nil {
-		return err
+		return 0, err
 	}
 	for _, kv := range resp.Kvs {
 		if r, ok := decodeRegion(kv.Value); ok {
 			m.rt.Update(r)
 		}
 	}
-	go m.leadershipLoop(ctx)
+	return resp.Header.Revision + 1, nil
+}
 
-	rev := resp.Header.Revision + 1
-	ch := m.cli.Watch(ctx, regionKeyPrefix, clientv3.WithPrefix(), clientv3.WithRev(rev))
+// Run seeds the routing table from etcd, then watches for changes until ctx is
+// cancelled. The leadership loop runs concurrently. If the watch is interrupted
+// (e.g. etcd compaction returning ErrCompacted) or the channel closes, Run
+// re-reads the latest metadata and recreates the watch so no updates are
+// missed (D4 convergence across compaction).
+func (m *RegionManager) Run(ctx context.Context) error {
+	rev, err := m.seed(ctx)
+	if err != nil {
+		return err
+	}
+	go m.leadershipLoop(ctx)
 	for {
-		select {
-		case <-ctx.Done():
+		if ctx.Err() != nil {
 			return ctx.Err()
-		case wresp, ok := <-ch:
-			if !ok {
-				return nil
-			}
-			if werr := wresp.Err(); werr != nil {
-				continue
-			}
-			for _, ev := range wresp.Events {
-				if ev.Type == clientv3.EventTypeDelete {
-					continue
+		}
+		ch := m.cli.Watch(ctx, regionKeyPrefix, clientv3.WithPrefix(), clientv3.WithRev(rev))
+		recreate := false
+		for !recreate {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case wresp, ok := <-ch:
+				if !ok {
+					// Watch channel closed (compaction or client teardown).
+					recreate = true
+					break
 				}
-				if r, ok := decodeRegion(ev.Kv.Value); ok {
-					m.rt.Update(r)
+				if werr := wresp.Err(); werr != nil {
+					// Terminal watch error (e.g. rpctypes.ErrCompacted):
+					// re-read the latest metadata before recreating the watch.
+					recreate = true
+					break
+				}
+				for _, ev := range wresp.Events {
+					if ev.Type == clientv3.EventTypeDelete {
+						continue
+					}
+					if r, ok := decodeRegion(ev.Kv.Value); ok {
+						m.rt.Update(r)
+					}
 				}
 			}
 		}
+		// Reconnect: pull the latest metadata and continue with a fresh watch.
+		newRev, rerr := m.seed(ctx)
+		if rerr != nil {
+			return rerr
+		}
+		rev = newRev
 	}
 }
 
@@ -181,6 +215,9 @@ func (m *RegionManager) leadershipLoop(ctx context.Context) {
 				Peers:    m.peers,
 				Leader:   m.nodeID,
 				Epoch:    epoch,
+			}
+			if regionExceedsWireLimit(nr) {
+				continue
 			}
 			if _, err := m.cli.Put(ctx, regionKey(1), string(encodeRegion(nr))); err != nil {
 				continue
@@ -242,11 +279,24 @@ func decodeRegion(b []byte) (Region, bool) {
 	if !ok {
 		return r, false
 	}
-	b, r.EndKey, ok = readBytesField(b)
+	_, r.EndKey, ok = readBytesField(b)
 	if !ok {
 		return r, false
 	}
 	return r, true
+}
+
+// maxRegionWireField is the largest length encodable in the uint16 wire format
+// used for peer-count and key-byte-length fields.
+const maxRegionWireField = 65535
+
+// regionExceedsWireLimit reports whether r cannot be encoded without truncating
+// its peer count or key fields: the wire format stores these lengths as uint16,
+// so a larger value would silently corrupt the encoding.
+func regionExceedsWireLimit(r Region) bool {
+	return len(r.Peers) > maxRegionWireField ||
+		len(r.StartKey) > maxRegionWireField ||
+		len(r.EndKey) > maxRegionWireField
 }
 
 func appendUint64(buf []byte, v uint64) []byte {

--- a/internal/cluster/region.go
+++ b/internal/cluster/region.go
@@ -1,0 +1,279 @@
+/*
+Package cluster
+Tellstone Cloud-Native In-Memory Database
+File: region.go
+Description: Region metadata and the RegionManager (Phase 3). A Region is the
+authoritative map of a key range to its Raft group (ADR-004). The RegionManager
+stores region metadata in the embedded etcd KV, watches it so every node's
+RoutingTable converges, and — on the Raft leader — keeps the region's Leader
+field pointed at itself (D1: etcd Watch, not a gRPC push).
+
+Authors:
+
+	Maximilian Hagen
+*/
+package cluster
+
+import (
+	"context"
+	"encoding/binary"
+	"time"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+// Region is the authoritative metadata for one key-range Raft group. It is
+// serialized and stored in etcd under /tellstone/regions/<id>.
+type Region struct {
+	ID       uint64
+	StartKey []byte
+	EndKey   []byte
+	Peers    []uint64 // node IDs of the region's Raft members
+	Leader   uint64   // current leader node ID (0 until first leader claims it)
+	Epoch    uint64   // bumped on every split/move/leadership change
+}
+
+const regionKeyPrefix = "/tellstone/regions/"
+
+func regionKey(id uint64) string {
+	var b [8]byte
+	binary.BigEndian.PutUint64(b[:], id)
+	return regionKeyPrefix + string(b[:])
+}
+
+// LeadershipProvider reports whether this node is the current Raft leader.
+// Satisfied by *Node.
+type LeadershipProvider interface {
+	IsLeader() bool
+}
+
+// RegionManager owns region metadata for one node: it bootstraps the default
+// region, watches etcd for updates, and (on the leader) keeps the leader field
+// current. It is safe to run one per node.
+type RegionManager struct {
+	cli    *clientv3.Client
+	nodeID uint64
+	lp     LeadershipProvider
+	peers  []uint64
+	rt     *RoutingTable
+}
+
+// NewRegionManager creates a manager bound to the PD etcd client and the local
+// node's leadership signal. It allocates its own RoutingTable.
+func NewRegionManager(cli *clientv3.Client, nodeID uint64, lp LeadershipProvider, peers []uint64) *RegionManager {
+	return &RegionManager{
+		cli:    cli,
+		nodeID: nodeID,
+		lp:     lp,
+		peers:  peers,
+		rt:     NewRoutingTable(),
+	}
+}
+
+// RoutingTable returns the node-local table fed by the watcher.
+func (m *RegionManager) RoutingTable() *RoutingTable { return m.rt }
+
+// BootstrapDefaultRegion creates the single initial region (ID 1, whole
+// keyspace) if it does not already exist. Safe to call on every node; only the
+// first writer wins (D4: one default region to start).
+func (m *RegionManager) BootstrapDefaultRegion(ctx context.Context) error {
+	key := regionKey(1)
+	val := encodeRegion(Region{
+		ID:       1,
+		StartKey: []byte{},
+		EndKey:   nil,
+		Peers:    m.peers,
+		Leader:   0,
+		Epoch:    1,
+	})
+	txn := m.cli.Txn(ctx).
+		If(clientv3.Compare(clientv3.CreateRevision(key), "=", 0)).
+		Then(clientv3.OpPut(key, string(val)))
+	_, err := txn.Commit()
+	return err
+}
+
+// Refresh re-reads the full region set from etcd and updates the local routing
+// table. It is used by the write path to recover quickly from a stale table
+// (e.g. the Watch has not yet delivered a leader change) instead of failing the
+// write. It is safe to call concurrently with Run.
+func (m *RegionManager) Refresh(ctx context.Context) error {
+	resp, err := m.cli.Get(ctx, regionKeyPrefix, clientv3.WithPrefix())
+	if err != nil {
+		return err
+	}
+	for _, kv := range resp.Kvs {
+		if r, ok := decodeRegion(kv.Value); ok {
+			m.rt.Update(r)
+		}
+	}
+	return nil
+}
+
+// Run seeds the routing table from etcd, then watches for changes until ctx is
+// cancelled. The leadership loop runs concurrently.
+func (m *RegionManager) Run(ctx context.Context) error {
+	resp, err := m.cli.Get(ctx, regionKeyPrefix, clientv3.WithPrefix())
+	if err != nil {
+		return err
+	}
+	for _, kv := range resp.Kvs {
+		if r, ok := decodeRegion(kv.Value); ok {
+			m.rt.Update(r)
+		}
+	}
+	go m.leadershipLoop(ctx)
+
+	rev := resp.Header.Revision + 1
+	ch := m.cli.Watch(ctx, regionKeyPrefix, clientv3.WithPrefix(), clientv3.WithRev(rev))
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case wresp, ok := <-ch:
+			if !ok {
+				return nil
+			}
+			if werr := wresp.Err(); werr != nil {
+				continue
+			}
+			for _, ev := range wresp.Events {
+				if ev.Type == clientv3.EventTypeDelete {
+					continue
+				}
+				if r, ok := decodeRegion(ev.Kv.Value); ok {
+					m.rt.Update(r)
+				}
+			}
+		}
+	}
+}
+
+// leadershipLoop, on the Raft leader, ensures region 1's Leader field points at
+// this node. It only writes when the field is stale, so non-leaders are silent
+// and the single leader wins quickly after an election.
+func (m *RegionManager) leadershipLoop(ctx context.Context) {
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if !m.lp.IsLeader() {
+				continue
+			}
+			cur, err := m.getRegion(ctx, 1)
+			if err != nil {
+				continue
+			}
+			if cur != nil && cur.Leader == m.nodeID {
+				continue
+			}
+			epoch := uint64(1)
+			if cur != nil {
+				epoch = cur.Epoch + 1
+			}
+			nr := Region{
+				ID:       1,
+				StartKey: []byte{},
+				EndKey:   nil,
+				Peers:    m.peers,
+				Leader:   m.nodeID,
+				Epoch:    epoch,
+			}
+			if _, err := m.cli.Put(ctx, regionKey(1), string(encodeRegion(nr))); err != nil {
+				continue
+			}
+		}
+	}
+}
+
+func (m *RegionManager) getRegion(ctx context.Context, id uint64) (*Region, error) {
+	resp, err := m.cli.Get(ctx, regionKey(id))
+	if err != nil {
+		return nil, err
+	}
+	if len(resp.Kvs) == 0 {
+		return nil, nil
+	}
+	r, ok := decodeRegion(resp.Kvs[0].Value)
+	if !ok {
+		return nil, nil
+	}
+	return &r, nil
+}
+
+// --- serialization (compact binary, no protobuf) ---
+
+func encodeRegion(r Region) []byte {
+	buf := make([]byte, 0, 32+len(r.StartKey)+len(r.EndKey))
+	buf = appendUint64(buf, r.ID)
+	buf = appendUint64(buf, r.Epoch)
+	buf = appendUint64(buf, r.Leader)
+	buf = appendUint16(buf, uint16(len(r.Peers)))
+	for _, p := range r.Peers {
+		buf = appendUint64(buf, p)
+	}
+	buf = appendBytesField(buf, r.StartKey)
+	buf = appendBytesField(buf, r.EndKey)
+	return buf
+}
+
+func decodeRegion(b []byte) (Region, bool) {
+	var r Region
+	if len(b) < 26 { // 3*8 + 2
+		return r, false
+	}
+	r.ID = binary.BigEndian.Uint64(b[0:8])
+	r.Epoch = binary.BigEndian.Uint64(b[8:16])
+	r.Leader = binary.BigEndian.Uint64(b[16:24])
+	nPeers := binary.BigEndian.Uint16(b[24:26])
+	b = b[26:]
+	for i := 0; i < int(nPeers); i++ {
+		if len(b) < 8 {
+			return r, false
+		}
+		r.Peers = append(r.Peers, binary.BigEndian.Uint64(b[0:8]))
+		b = b[8:]
+	}
+	var ok bool
+	b, r.StartKey, ok = readBytesField(b)
+	if !ok {
+		return r, false
+	}
+	b, r.EndKey, ok = readBytesField(b)
+	if !ok {
+		return r, false
+	}
+	return r, true
+}
+
+func appendUint64(buf []byte, v uint64) []byte {
+	var b [8]byte
+	binary.BigEndian.PutUint64(b[:], v)
+	return append(buf, b[:]...)
+}
+
+func appendUint16(buf []byte, v uint16) []byte {
+	var b [2]byte
+	binary.BigEndian.PutUint16(b[:], v)
+	return append(buf, b[:]...)
+}
+
+func appendBytesField(buf, v []byte) []byte {
+	buf = appendUint16(buf, uint16(len(v)))
+	return append(buf, v...)
+}
+
+func readBytesField(buf []byte) ([]byte, []byte, bool) {
+	if len(buf) < 2 {
+		return nil, nil, false
+	}
+	n := int(binary.BigEndian.Uint16(buf[0:2]))
+	buf = buf[2:]
+	if len(buf) < n {
+		return nil, nil, false
+	}
+	return buf[n:], buf[:n], true
+}

--- a/internal/cluster/region_test.go
+++ b/internal/cluster/region_test.go
@@ -1,0 +1,109 @@
+/*
+Package cluster
+Tellstone Cloud-Native In-Memory Database
+File: region_test.go
+Description: Tests for Region (de)serialization and RegionManager bootstrap +
+etcd Watch convergence (Phase 3).
+*/
+package cluster
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+type stubLP struct{ leader bool }
+
+func (s stubLP) IsLeader() bool { return s.leader }
+
+// startRegionTest boots a single embedded PD member and returns a client plus a
+// cancelable context for RegionManager tests.
+func startRegionTest(t *testing.T) (*clientv3.Client, context.Context, context.CancelFunc) {
+	t.Helper()
+	cport, pport := freePort(t), freePort(t)
+	pd, err := StartPD(PDConfig{
+		NodeID:          1,
+		DataDir:         t.TempDir(),
+		ClientListenURL: joinHostPortURL("127.0.0.1", cport),
+		PeerListenURL:   joinHostPortURL("127.0.0.1", pport),
+		AllPeerURLs: map[uint64]string{
+			1: joinHostPortURL("127.0.0.1", pport),
+		},
+	})
+	if err != nil {
+		t.Fatalf("StartPD: %v", err)
+	}
+	t.Cleanup(pd.Stop)
+	cli, err := clientv3.New(clientv3.Config{Endpoints: []string{pd.ClientURL()}, DialTimeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("clientv3.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cli.Close() })
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	t.Cleanup(cancel)
+	return cli, ctx, cancel
+}
+
+func TestRegionEncodeDecode(t *testing.T) {
+	r := Region{
+		ID:       42,
+		StartKey: []byte("user:aaa"),
+		EndKey:   []byte("user:zzz"),
+		Peers:    []uint64{1, 2, 3},
+		Leader:   2,
+		Epoch:    7,
+	}
+	got, ok := decodeRegion(encodeRegion(r))
+	if !ok {
+		t.Fatal("decode failed")
+	}
+	if got.ID != r.ID || got.Epoch != r.Epoch || got.Leader != r.Leader || len(got.Peers) != 3 ||
+		string(got.StartKey) != "user:aaa" || string(got.EndKey) != "user:zzz" {
+		t.Fatalf("roundtrip mismatch: %+v", got)
+	}
+}
+
+func TestRegionManagerBootstrapAndWatch(t *testing.T) {
+	cli, ctx, cancel := startRegionTest(t)
+	defer cancel()
+
+	mgr := NewRegionManager(cli, 1, stubLP{leader: true}, []uint64{1, 2, 3})
+	if err := mgr.BootstrapDefaultRegion(ctx); err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	runCtx, runCancel := context.WithCancel(ctx)
+	defer runCancel()
+	go func() { _ = mgr.Run(runCtx) }()
+
+	// Leader keep-alive should set region 1's Leader to this node.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if r := mgr.RoutingTable().Find([]byte("x")); r != nil && r.Leader == 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("leader did not claim region 1")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// A concurrent writer (second client) bumping the leader must converge via
+	// Watch into the local routing table.
+	nr := Region{ID: 1, StartKey: []byte{}, EndKey: nil, Peers: []uint64{1, 2, 3}, Leader: 2, Epoch: 2}
+	if _, err := cli.Put(ctx, regionKey(1), string(encodeRegion(nr))); err != nil {
+		t.Fatalf("external put: %v", err)
+	}
+	deadline = time.Now().Add(5 * time.Second)
+	for {
+		if r := mgr.RoutingTable().Find([]byte("x")); r != nil && r.Leader == 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("watch did not converge to leader 2")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}

--- a/internal/cluster/region_test.go
+++ b/internal/cluster/region_test.go
@@ -90,9 +90,104 @@ func TestRegionManagerBootstrapAndWatch(t *testing.T) {
 		time.Sleep(20 * time.Millisecond)
 	}
 
-	// A concurrent writer (second client) bumping the leader must converge via
-	// Watch into the local routing table.
-	nr := Region{ID: 1, StartKey: []byte{}, EndKey: nil, Peers: []uint64{1, 2, 3}, Leader: 2, Epoch: 2}
+	// Stop the leader manager so its leadership loop no longer rewrites the
+	// region's leader field; the external write below is the only writer.
+	runCancel()
+
+	// An external writer (a second client) bumping the region leader must
+	// converge via Watch into a follower's local routing table. The follower
+	// manager is non-leader, so its own leadership loop stays silent and the
+	// external write is observed unchanged (D4 convergence on a follower).
+	followerMgr := NewRegionManager(cli, 99, stubLP{leader: false}, []uint64{1, 2, 3})
+	frunCtx, frunCancel := context.WithCancel(ctx)
+	defer frunCancel()
+	go func() { _ = followerMgr.Run(frunCtx) }()
+
+	nr := Region{ID: 1, StartKey: []byte{}, EndKey: nil, Peers: []uint64{1, 2, 3}, Leader: 2, Epoch: 100}
+	if _, err := cli.Put(ctx, regionKey(1), string(encodeRegion(nr))); err != nil {
+		t.Fatalf("external put: %v", err)
+	}
+	deadline = time.Now().Add(5 * time.Second)
+	for {
+		if r := followerMgr.RoutingTable().Find([]byte("x")); r != nil && r.Leader == 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("follower watch did not converge to leader 2")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// TestRegionWireLimit verifies the uint16 wire-format bounds: a region at the
+// 65,535 limit encodes/decodes cleanly, while 65,536 peers or key bytes are
+// rejected before they can silently truncate the encoding.
+func TestRegionWireLimit(t *testing.T) {
+	atLimit := Region{
+		ID:       1,
+		StartKey: make([]byte, maxRegionWireField),
+		EndKey:   nil,
+		Peers:    make([]uint64, maxRegionWireField),
+		Leader:   1,
+		Epoch:    1,
+	}
+	if regionExceedsWireLimit(atLimit) {
+		t.Fatal("region at the 65535 limit should be within bounds")
+	}
+	if _, ok := decodeRegion(encodeRegion(atLimit)); !ok {
+		t.Fatal("encode/decode at 65535 limit failed")
+	}
+
+	if !regionExceedsWireLimit(Region{ID: 1, Peers: make([]uint64, maxRegionWireField+1), Leader: 1, Epoch: 1}) {
+		t.Fatal("65536 peers should exceed the wire limit")
+	}
+	if !regionExceedsWireLimit(Region{ID: 1, StartKey: make([]byte, maxRegionWireField+1), Leader: 1, Epoch: 1}) {
+		t.Fatal("65536 start-key bytes should exceed the wire limit")
+	}
+	if !regionExceedsWireLimit(Region{ID: 1, EndKey: make([]byte, maxRegionWireField+1), Leader: 1, Epoch: 1}) {
+		t.Fatal("65536 end-key bytes should exceed the wire limit")
+	}
+}
+
+// TestRegionManagerCompactedWatch verifies that after an etcd compaction the
+// RegionManager still converges on a subsequent update: Run reseeds from etcd
+// and recreates the watch instead of silently dropping events (D4).
+func TestRegionManagerCompactedWatch(t *testing.T) {
+	cli, ctx, cancel := startRegionTest(t)
+	defer cancel()
+
+	mgr := NewRegionManager(cli, 1, stubLP{leader: true}, []uint64{1, 2, 3})
+	if err := mgr.BootstrapDefaultRegion(ctx); err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	runCtx, runCancel := context.WithCancel(ctx)
+	defer runCancel()
+	go func() { _ = mgr.Run(runCtx) }()
+
+	// Wait for the leader to claim region 1.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if r := mgr.RoutingTable().Find([]byte("x")); r != nil && r.Leader == 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("leader did not claim region 1")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Compact the historical revisions so the in-flight watch is now stale.
+	resp, err := cli.Get(ctx, regionKeyPrefix, clientv3.WithPrefix())
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if _, err := cli.Compact(ctx, resp.Header.Revision); err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+
+	// A post-compaction write must still converge (Run recovers from the
+	// compacted watch and reseeds from etcd).
+	nr := Region{ID: 1, StartKey: []byte{}, EndKey: nil, Peers: []uint64{1, 2, 3}, Leader: 2, Epoch: 5}
 	if _, err := cli.Put(ctx, regionKey(1), string(encodeRegion(nr))); err != nil {
 		t.Fatalf("external put: %v", err)
 	}
@@ -102,7 +197,7 @@ func TestRegionManagerBootstrapAndWatch(t *testing.T) {
 			break
 		}
 		if time.Now().After(deadline) {
-			t.Fatal("watch did not converge to leader 2")
+			t.Fatal("watch did not recover from compaction to converge to leader 2")
 		}
 		time.Sleep(20 * time.Millisecond)
 	}

--- a/internal/cluster/routing.go
+++ b/internal/cluster/routing.go
@@ -71,8 +71,8 @@ func (rt *RoutingTable) Update(meta Region) {
 		return bytes.Compare(rt.regions[i].StartKey, meta.StartKey) >= 0
 	})
 	if idx < len(rt.regions) && bytes.Equal(rt.regions[idx].StartKey, meta.StartKey) {
-		if meta.Epoch < rt.regions[idx].Epoch {
-			return // stale
+		if meta.Epoch <= rt.regions[idx].Epoch {
+			return // stale (lower or equal epoch)
 		}
 		rt.regions[idx] = regionRouteOf(meta)
 		return

--- a/internal/cluster/routing.go
+++ b/internal/cluster/routing.go
@@ -1,0 +1,103 @@
+/*
+Package cluster
+Tellstone Cloud-Native In-Memory Database
+File: routing.go
+Description: Node-local routing table for Phase 3 (read/write-anywhere). Maps
+key ranges to the leader node of the owning region. Lookups are an O(log n)
+binary search over a slice sorted by StartKey; updates arrive from the PD via
+etcd Watch (see region.go) and are epoch-guarded so stale entries are dropped.
+
+Authors:
+
+	Maximilian Hagen
+*/
+package cluster
+
+import (
+	"bytes"
+	"sort"
+	"sync"
+)
+
+// RegionRoute is one entry in a node's routing table: the key range it covers
+// and the node currently leading that region's Raft group.
+type RegionRoute struct {
+	StartKey []byte
+	EndKey   []byte
+	Leader   uint64 // node ID of the current region leader
+	Epoch    uint64
+}
+
+// RoutingTable is a concurrency-safe, node-local cache of region metadata.
+// It is the lookup structure that enables read/write-anywhere: any node can
+// resolve a key to the region leader it must forward writes to.
+type RoutingTable struct {
+	mu      sync.RWMutex
+	regions []RegionRoute
+}
+
+// NewRoutingTable returns an empty routing table.
+func NewRoutingTable() *RoutingTable { return &RoutingTable{} }
+
+// Find returns the route whose [StartKey, EndKey) contains key. An empty
+// StartKey matches negative infinity; an empty EndKey matches positive
+// infinity. Returns nil if no region covers the key.
+func (rt *RoutingTable) Find(key []byte) *RegionRoute {
+	rt.mu.RLock()
+	defer rt.mu.RUnlock()
+	// First region with StartKey > key; the candidate is the one before it.
+	i := sort.Search(len(rt.regions), func(i int) bool {
+		return bytes.Compare(rt.regions[i].StartKey, key) > 0
+	})
+	if i == 0 {
+		return nil
+	}
+	r := &rt.regions[i-1]
+	if len(r.EndKey) > 0 && bytes.Compare(key, r.EndKey) >= 0 {
+		return nil
+	}
+	cp := *r
+	return &cp
+}
+
+// Update merges region metadata into the table. Stale updates (epoch not
+// strictly greater than the existing entry for the same StartKey) are dropped
+// unless the region is new. This prevents a delayed Watch event from rolling
+// back a split or move (ADR-004 §Routing Table).
+func (rt *RoutingTable) Update(meta Region) {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	idx := sort.Search(len(rt.regions), func(i int) bool {
+		return bytes.Compare(rt.regions[i].StartKey, meta.StartKey) >= 0
+	})
+	if idx < len(rt.regions) && bytes.Equal(rt.regions[idx].StartKey, meta.StartKey) {
+		if meta.Epoch < rt.regions[idx].Epoch {
+			return // stale
+		}
+		rt.regions[idx] = regionRouteOf(meta)
+		return
+	}
+	// Insert in sorted order (regions slice is small; copy is cheap).
+	rt.regions = append(rt.regions, RegionRoute{})
+	copy(rt.regions[idx+1:], rt.regions[idx:])
+	rt.regions[idx] = regionRouteOf(meta)
+}
+
+// Snapshot returns a copy of the current routes, sorted by StartKey. Used by
+// tests and diagnostics.
+func (rt *RoutingTable) Snapshot() []RegionRoute {
+	rt.mu.RLock()
+	defer rt.mu.RUnlock()
+	out := make([]RegionRoute, len(rt.regions))
+	copy(out, rt.regions)
+	return out
+}
+
+func regionRouteOf(m Region) RegionRoute {
+	return RegionRoute{
+		StartKey: m.StartKey,
+		EndKey:   m.EndKey,
+		Leader:   m.Leader,
+		Epoch:    m.Epoch,
+	}
+}

--- a/internal/cluster/routing_integration_test.go
+++ b/internal/cluster/routing_integration_test.go
@@ -1,0 +1,183 @@
+/*
+Package cluster
+Tellstone Cloud-Native In-Memory Database
+File: routing_integration_test.go
+Description: Phase 3 routing integration tests. Boots a real multi-node Raft
+cluster and proves write-forwarding (a follower forwards a write to the region
+leader resolved from the routing table, D2/D3) and read-anywhere (a follower
+serves a linearizable read from its local replica, D1).
+
+Authors:
+
+	Maximilian Hagen
+*/
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestClusterWriteForwarding proves Phase 3 D2/D3: a non-leader node forwards a
+// write to the region leader (resolved from the routing table) and the write
+// replicates to every node. It also proves D1 (read-anywhere): after the write
+// has been applied, a follower can serve a linearizable read from its local
+// replica without contacting the leader.
+func TestClusterWriteForwarding(t *testing.T) {
+	nodes, dispatchers, cleanup := startTestCluster(t)
+	defer cleanup()
+
+	leader := waitForLeader(t, nodes)
+	var follower *Node
+	var followerIdx int
+	for i, n := range nodes {
+		if n != leader {
+			follower = n
+			followerIdx = i
+			break
+		}
+	}
+
+	// Single default region covering all keys, owned by the current leader.
+	rt := NewRoutingTable()
+	rt.Update(Region{
+		ID:       1,
+		StartKey: nil,
+		EndKey:   nil,
+		Peers:    []uint64{1, 2, 3},
+		Leader:   leader.cfg.NodeID,
+		Epoch:    1,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	data, err := EncodeSet("fkey", []byte("fval"), 0)
+	if err != nil {
+		t.Fatalf("EncodeSet: %v", err)
+	}
+	route := rt.Find([]byte("fkey"))
+	if route == nil {
+		t.Fatal("routing table has no region for key")
+	}
+	if err := follower.ForwardWrite(ctx, route.Leader, data); err != nil {
+		t.Fatalf("ForwardWrite from follower: %v", err)
+	}
+
+	// The write must replicate to all nodes.
+	if err := waitForApplied(dispatchers, 1, 5*time.Second); err != nil {
+		t.Fatalf("replication: %v", err)
+	}
+	for i, d := range dispatchers {
+		v, ok := d.get("fkey")
+		if !ok || string(v) != "fval" {
+			t.Fatalf("node %d: fkey not replicated (ok=%v v=%q)", i+1, ok, v)
+		}
+	}
+
+	// D1: read-anywhere. The follower performs a linearizable read (ensuring it
+	// has applied up to the read index) and then reads the value locally.
+	if err := follower.LinearizableRead(ctx); err != nil {
+		t.Fatalf("LinearizableRead on follower: %v", err)
+	}
+	v, ok := dispatchers[followerIdx].get("fkey")
+	if !ok || string(v) != "fval" {
+		t.Fatalf("read-anywhere: follower could not read fkey (ok=%v v=%q)", ok, v)
+	}
+}
+
+// TestClusterRegionLeaderChange proves D4: when the Raft leader changes, the
+// routing table's region leader is updated so forwards keep targeting the node
+// that can actually propose. We drive the routing table manually (the RegionManager
+// Watch path is covered by TestRegionManagerBootstrapAndWatch) and assert that a
+// write forwarded to the new leader still replicates.
+func TestClusterRegionLeaderChange(t *testing.T) {
+	nodes, dispatchers, cleanup := startTestCluster(t)
+	defer cleanup()
+
+	leader := waitForLeader(t, nodes)
+	rt := NewRoutingTable()
+	rt.Update(Region{
+		ID:       1,
+		StartKey: nil,
+		EndKey:   nil,
+		Peers:    []uint64{1, 2, 3},
+		Leader:   leader.cfg.NodeID,
+		Epoch:    1,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Write through the initial leader.
+	data1, _ := EncodeSet("k1", []byte("v1"), 0)
+	if err := forwardToLeader(ctx, nodes, rt, "k1", data1); err != nil {
+		t.Fatalf("initial forward: %v", err)
+	}
+	if err := waitForApplied(dispatchers, 1, 5*time.Second); err != nil {
+		t.Fatalf("replication k1: %v", err)
+	}
+
+	// Kill the leader; a new one must be elected.
+	stoppedIdx := -1
+	for i, n := range nodes {
+		if n == leader {
+			stoppedIdx = i
+			break
+		}
+	}
+	leader.Stop()
+	// We just wait for a new leader and point the region at it.
+	newLeader := waitForLeader(t, nodes)
+	rt.Update(Region{
+		ID:       1,
+		StartKey: nil,
+		EndKey:   nil,
+		Peers:    []uint64{1, 2, 3},
+		Leader:   newLeader.cfg.NodeID,
+		Epoch:    2,
+	})
+
+	// Write through the new leader must still replicate to survivors.
+	data2, _ := EncodeSet("k2", []byte("v2"), 0)
+	if err := forwardToLeader(ctx, nodes, rt, "k2", data2); err != nil {
+		t.Fatalf("post-failover forward: %v", err)
+	}
+
+	// Only the surviving nodes are expected to apply k2.
+	aliveDispatchers := make([]*testDispatcher, 0, len(dispatchers))
+	for i, d := range dispatchers {
+		if i == stoppedIdx {
+			continue
+		}
+		aliveDispatchers = append(aliveDispatchers, d)
+	}
+	if err := waitForApplied(aliveDispatchers, 2, 5*time.Second); err != nil {
+		t.Fatalf("replication k2: %v", err)
+	}
+	for i, d := range dispatchers {
+		if i == stoppedIdx {
+			continue
+		}
+		if _, ok := d.get("k2"); !ok {
+			t.Fatalf("node %d: k2 not replicated after leader change", i+1)
+		}
+	}
+}
+
+// forwardToLeader picks the node that currently owns the region leader role and
+// forwards the write to it (proving the routing-table-driven path, D2/D3).
+func forwardToLeader(ctx context.Context, nodes []*Node, rt *RoutingTable, key string, data []byte) error {
+	route := rt.Find([]byte(key))
+	if route == nil {
+		return fmt.Errorf("no region covers key %q", key)
+	}
+	for _, n := range nodes {
+		if n.cfg.NodeID == route.Leader {
+			return n.ForwardWrite(ctx, route.Leader, data)
+		}
+	}
+	return fmt.Errorf("region leader %d is not running", route.Leader)
+}

--- a/internal/cluster/routing_test.go
+++ b/internal/cluster/routing_test.go
@@ -1,0 +1,56 @@
+/*
+Package cluster
+Tellstone Cloud-Native In-Memory Database
+File: routing_test.go
+Description: Unit tests for the Phase 3 routing table.
+*/
+package cluster
+
+import (
+	"testing"
+)
+
+func TestRoutingTableFind(t *testing.T) {
+	rt := NewRoutingTable()
+	rt.Update(Region{ID: 1, StartKey: []byte(""), EndKey: []byte("user:fff"), Leader: 1, Epoch: 1})
+	rt.Update(Region{ID: 2, StartKey: []byte("user:fff"), EndKey: []byte("user:zzz"), Leader: 3, Epoch: 1})
+	rt.Update(Region{ID: 3, StartKey: []byte("user:zzz"), EndKey: nil, Leader: 5, Epoch: 1})
+
+	cases := []struct {
+		key  string
+		want uint64
+	}{
+		{"", 1},
+		{"a", 1},
+		{"user:aaa", 1},
+		{"user:fff", 3}, // inclusive start of region 2
+		{"user:mid", 3},
+		{"user:zzz", 5}, // inclusive start of region 3
+		{"user:zzz\x00", 5},
+		{"z", 5},
+	}
+	for _, c := range cases {
+		r := rt.Find([]byte(c.key))
+		if r == nil {
+			t.Fatalf("Find(%q): nil route", c.key)
+		}
+		if r.Leader != c.want {
+			t.Fatalf("Find(%q): leader = %d, want %d", c.key, r.Leader, c.want)
+		}
+	}
+}
+
+func TestRoutingTableUpdateStaleEpochDropped(t *testing.T) {
+	rt := NewRoutingTable()
+	rt.Update(Region{ID: 1, StartKey: []byte(""), EndKey: nil, Leader: 1, Epoch: 5})
+	// Older epoch must be ignored.
+	rt.Update(Region{ID: 1, StartKey: []byte(""), EndKey: nil, Leader: 9, Epoch: 4})
+	if got := rt.Find([]byte("x")); got.Leader != 1 {
+		t.Fatalf("stale update applied: leader = %d, want 1", got.Leader)
+	}
+	// Newer epoch must win.
+	rt.Update(Region{ID: 1, StartKey: []byte(""), EndKey: nil, Leader: 9, Epoch: 6})
+	if got := rt.Find([]byte("x")); got.Leader != 9 {
+		t.Fatalf("fresh update ignored: leader = %d, want 9", got.Leader)
+	}
+}

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -86,8 +86,9 @@ func (d *shardDispatcher) Dispatch(key string, op byte, value []byte, ttl time.D
 // cluster mode is active. Phase 3 routing: a write is proposed directly when
 // this node is the Raft leader, otherwise it is forwarded to the leader of
 // the region that owns the key (read from the local routing table). Reads go
-// to the local engine after a linearizable ReadIndex round-trip, so any
-// replica can serve reads (read-anywhere) with up-to-date guarantees.
+// to the local engine after a linearizable ReadIndex round-trip; if that
+// round-trip cannot complete in time, the local value is served as a
+// best-effort fallback and may be slightly stale (read-anywhere).
 type clusterStore struct {
 	local  *RouterStore
 	node   *cluster.Node
@@ -101,9 +102,15 @@ func newClusterStore(local *RouterStore, node *cluster.Node, rt *cluster.Routing
 }
 
 func (cs *clusterStore) Get(key string) ([]byte, bool) {
-	if err := cs.node.LinearizableRead(context.Background()); err != nil {
+	// Linearizable read: wait (bounded) until this replica has applied at least
+	// the Raft commit index observed by ReadIndex, then serve from the local
+	// engine. On timeout/failure we fall back to the local value (best-effort,
+	// may be slightly stale) rather than failing the read.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := cs.node.LinearizableRead(ctx); err != nil {
 		if cs.logger.Enabled(log.LevelWarn) {
-			cs.logger.Log(log.LevelWarn, "cluster store: linearizable read failed, serving local",
+			cs.logger.Log(log.LevelWarn, "cluster store: linearizable read failed, serving local (best-effort, may be stale)",
 				log.String("error", err.Error()),
 				log.String("key", key),
 			)
@@ -129,7 +136,11 @@ func (cs *clusterStore) routeWrite(key string, data []byte) error {
 	const (
 		maxAttempts = 6
 		backoff     = 200 * time.Millisecond
+		// Overall cap for a single Set/Delete so a run of stale/unreachable
+		// leaders cannot block the caller indefinitely.
+		writeBudget = 8 * time.Second
 	)
+	deadline := time.Now().Add(writeBudget)
 	var lastErr error
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		route := cs.rt.Find([]byte(key))
@@ -138,10 +149,20 @@ func (cs *clusterStore) routeWrite(key string, data []byte) error {
 		}
 		if route.Leader == 0 {
 			cs.refreshRouting()
-			time.Sleep(backoff)
+			if attempt < maxAttempts-1 {
+				time.Sleep(backoff)
+			}
 			continue
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		// Bound each forward attempt by the remaining overall budget.
+		budget := time.Until(deadline)
+		if budget <= 0 {
+			break
+		}
+		if budget > 5*time.Second {
+			budget = 5 * time.Second
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), budget)
 		err := cs.node.ForwardWrite(ctx, route.Leader, data)
 		cancel()
 		if err == nil {
@@ -156,7 +177,9 @@ func (cs *clusterStore) routeWrite(key string, data []byte) error {
 			)
 		}
 		cs.refreshRouting()
-		time.Sleep(backoff)
+		if attempt < maxAttempts-1 && time.Until(deadline) > 0 {
+			time.Sleep(backoff)
+		}
 	}
 	if lastErr != nil {
 		return fmt.Errorf("MOVED: write to region leader failed: %w", lastErr)
@@ -211,9 +234,10 @@ func (cs *clusterStore) Set(key string, value []byte, ttl time.Duration) error {
 }
 
 // Delete routes a deletion through Raft (or forwards it to the region leader).
-// It returns whether the key existed plus an error for the failure cases:
-// encode failure, no covering region (CLUSTERDOWN), or propose/forward
-// failure. The boolean is only meaningful when err is nil.
+// It returns (true, nil) on successful replication; the boolean is NOT a report
+// of whether the key previously existed — the forwarded/raft apply path does not
+// surface that distinction. Error cases: encode failure, no covering region
+// (CLUSTERDOWN), or propose/forward failure.
 func (cs *clusterStore) Delete(key string) (bool, error) {
 	if cs.logger.Enabled(log.LevelDebug) {
 		cs.logger.Log(log.LevelDebug, "cluster store: DEL",

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -83,19 +83,32 @@ func (d *shardDispatcher) Dispatch(key string, op byte, value []byte, ttl time.D
 }
 
 // clusterStore wraps a RouterStore and routes writes through Raft when
-// cluster mode is active. Reads always go to the local engine. Writes on a
-// non-leader return an error so the caller can redirect the client.
+// cluster mode is active. Phase 3 routing: a write is proposed directly when
+// this node is the Raft leader, otherwise it is forwarded to the leader of
+// the region that owns the key (read from the local routing table). Reads go
+// to the local engine after a linearizable ReadIndex round-trip, so any
+// replica can serve reads (read-anywhere) with up-to-date guarantees.
 type clusterStore struct {
 	local  *RouterStore
 	node   *cluster.Node
+	rt     *cluster.RoutingTable
+	mgr    *cluster.RegionManager
 	logger log.Logger
 }
 
-func newClusterStore(local *RouterStore, node *cluster.Node, logger log.Logger) *clusterStore {
-	return &clusterStore{local: local, node: node, logger: logger}
+func newClusterStore(local *RouterStore, node *cluster.Node, rt *cluster.RoutingTable, mgr *cluster.RegionManager, logger log.Logger) *clusterStore {
+	return &clusterStore{local: local, node: node, rt: rt, mgr: mgr, logger: logger}
 }
 
 func (cs *clusterStore) Get(key string) ([]byte, bool) {
+	if err := cs.node.LinearizableRead(context.Background()); err != nil {
+		if cs.logger.Enabled(log.LevelWarn) {
+			cs.logger.Log(log.LevelWarn, "cluster store: linearizable read failed, serving local",
+				log.String("error", err.Error()),
+				log.String("key", key),
+			)
+		}
+	}
 	val, ok := cs.local.Get(key)
 	if cs.logger.Enabled(log.LevelDebug) {
 		cs.logger.Log(log.LevelDebug, "cluster store: GET",
@@ -107,24 +120,69 @@ func (cs *clusterStore) Get(key string) ([]byte, bool) {
 	return val, ok
 }
 
-func (cs *clusterStore) Set(key string, value []byte, ttl time.Duration) error {
-	if !cs.node.IsLeader() {
+// routeWrite proposes directly when this node leads the Raft group, otherwise
+// forwards the operation to the region leader resolved from the routing table.
+// It is resilient to a stale or unreachable region leader (D4 churn): on a
+// failed forward it refreshes the routing table and retries, and it waits
+// briefly for the leader to be claimed before reporting CLUSTERNOTREADY.
+func (cs *clusterStore) routeWrite(key string, data []byte) error {
+	const (
+		maxAttempts = 6
+		backoff     = 200 * time.Millisecond
+	)
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		route := cs.rt.Find([]byte(key))
+		if route == nil {
+			return fmt.Errorf("CLUSTERDOWN: no region covers key %q", key)
+		}
+		if route.Leader == 0 {
+			cs.refreshRouting()
+			time.Sleep(backoff)
+			continue
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		err := cs.node.ForwardWrite(ctx, route.Leader, data)
+		cancel()
+		if err == nil {
+			return nil
+		}
+		lastErr = err
 		if cs.logger.Enabled(log.LevelDebug) {
-			cs.logger.Log(log.LevelDebug, "cluster store: SET rejected, not leader",
+			cs.logger.Log(log.LevelDebug, "cluster store: forward failed, refreshing routing and retrying",
 				log.String("key", key),
+				log.String("error", err.Error()),
+				log.Int("attempt", attempt+1),
 			)
 		}
-		return fmt.Errorf("MOVED: not leader; redirect to leader")
+		cs.refreshRouting()
+		time.Sleep(backoff)
 	}
+	if lastErr != nil {
+		return fmt.Errorf("MOVED: write to region leader failed: %w", lastErr)
+	}
+	return fmt.Errorf("CLUSTERNOTREADY: region leader not elected for key %q", key)
+}
+
+// refreshRouting pulls the latest region metadata from etcd into the local
+// table. Best-effort: a failure is ignored (the Watch will catch up).
+func (cs *clusterStore) refreshRouting() {
+	if cs.mgr == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_ = cs.mgr.Refresh(ctx)
+}
+
+func (cs *clusterStore) Set(key string, value []byte, ttl time.Duration) error {
 	if cs.logger.Enabled(log.LevelDebug) {
-		cs.logger.Log(log.LevelDebug, "cluster store: SET proposing via raft",
+		cs.logger.Log(log.LevelDebug, "cluster store: SET",
 			log.String("key", key),
 			log.Int("value_len", len(value)),
 			log.Int64("ttl_ms", ttl.Milliseconds()),
 		)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
 	data, err := cluster.EncodeSet(key, value, ttl)
 	if err != nil {
 		if cs.logger.Enabled(log.LevelError) {
@@ -135,9 +193,9 @@ func (cs *clusterStore) Set(key string, value []byte, ttl time.Duration) error {
 		}
 		return err
 	}
-	if err := cs.node.ProposeAndWait(ctx, data); err != nil {
+	if err = cs.routeWrite(key, data); err != nil {
 		if cs.logger.Enabled(log.LevelError) {
-			cs.logger.Log(log.LevelError, "cluster store: SET propose failed",
+			cs.logger.Log(log.LevelError, "cluster store: SET failed",
 				log.String("error", err.Error()),
 				log.String("key", key),
 			)
@@ -145,33 +203,23 @@ func (cs *clusterStore) Set(key string, value []byte, ttl time.Duration) error {
 		return err
 	}
 	if cs.logger.Enabled(log.LevelDebug) {
-		cs.logger.Log(log.LevelDebug, "cluster store: SET propose succeeded",
+		cs.logger.Log(log.LevelDebug, "cluster store: SET succeeded",
 			log.String("key", key),
 		)
 	}
 	return nil
 }
 
-// Delete routes a deletion through Raft. It returns whether the key existed
-// plus an error for the failure cases: not leader (MOVED redirect, same as
-// Set), encode failure, or propose/timeout failure. The boolean is only
-// meaningful when err is nil.
+// Delete routes a deletion through Raft (or forwards it to the region leader).
+// It returns whether the key existed plus an error for the failure cases:
+// encode failure, no covering region (CLUSTERDOWN), or propose/forward
+// failure. The boolean is only meaningful when err is nil.
 func (cs *clusterStore) Delete(key string) (bool, error) {
-	if !cs.node.IsLeader() {
-		if cs.logger.Enabled(log.LevelDebug) {
-			cs.logger.Log(log.LevelDebug, "cluster store: DEL rejected, not leader",
-				log.String("key", key),
-			)
-		}
-		return false, fmt.Errorf("MOVED: not leader; redirect to leader")
-	}
 	if cs.logger.Enabled(log.LevelDebug) {
-		cs.logger.Log(log.LevelDebug, "cluster store: DEL proposing via raft",
+		cs.logger.Log(log.LevelDebug, "cluster store: DEL",
 			log.String("key", key),
 		)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
 	data, err := cluster.EncodeDel(key)
 	if err != nil {
 		if cs.logger.Enabled(log.LevelError) {
@@ -182,9 +230,9 @@ func (cs *clusterStore) Delete(key string) (bool, error) {
 		}
 		return false, err
 	}
-	if err := cs.node.ProposeAndWait(ctx, data); err != nil {
+	if err = cs.routeWrite(key, data); err != nil {
 		if cs.logger.Enabled(log.LevelError) {
-			cs.logger.Log(log.LevelError, "cluster store: DEL propose failed",
+			cs.logger.Log(log.LevelError, "cluster store: DEL failed",
 				log.String("error", err.Error()),
 				log.String("key", key),
 			)

--- a/server/server.go
+++ b/server/server.go
@@ -123,6 +123,9 @@ type Server struct {
 	routingTable *cluster.RoutingTable
 	// regionCancel stops the RegionManager goroutine on shutdown.
 	regionCancel context.CancelFunc
+	// regionDone is closed once the RegionManager Run goroutine has returned,
+	// so shutdown can wait for it before the PD node closes its etcd client.
+	regionDone chan struct{}
 }
 
 func NewServer(app *tellstone.App) *Server {
@@ -374,14 +377,20 @@ func (s *Server) shutdown(ctx context.Context) {
 		case <-ctx.Done():
 		}
 	}
+	// Stop the region manager first and wait for its Run goroutine to return
+	// before the PD node closes its etcd client, so no region-manager
+	// operation uses a closed client.
+	if s.regionCancel != nil {
+		s.regionCancel()
+	}
+	if s.regionDone != nil {
+		<-s.regionDone
+	}
 	if s.raftNode != nil {
 		s.raftNode.Stop()
 	}
 	if s.pdNode != nil {
 		s.pdNode.Stop()
-	}
-	if s.regionCancel != nil {
-		s.regionCancel()
 	}
 	for _, sh := range s.shards {
 		if err := sh.Stop(ctx); err != nil {
@@ -763,7 +772,9 @@ func (s *Server) initCluster() error {
 		peerIDs[i] = p.ID
 	}
 	rm := cluster.NewRegionManager(s.pdNode.Client(), cfg.GetNodeID(), s.raftNode, peerIDs)
-	if err = rm.BootstrapDefaultRegion(context.Background()); err != nil {
+	bootCtx, bootCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer bootCancel()
+	if err = rm.BootstrapDefaultRegion(bootCtx); err != nil {
 		s.raftNode.Stop()
 		s.pdNode.Stop()
 		return fmt.Errorf("bootstrap default region: %w", err)
@@ -772,12 +783,14 @@ func (s *Server) initCluster() error {
 	s.regionMgr = rm
 	s.regionCancel = rmCancel
 	s.routingTable = rm.RoutingTable()
+	s.regionDone = make(chan struct{})
 	go func() {
 		if rerr := rm.Run(rmCtx); rerr != nil && logger.Enabled(log.LevelError) {
 			logger.Log(log.LevelError, "server: region manager stopped",
 				log.String("error", rerr.Error()),
 			)
 		}
+		close(s.regionDone)
 	}()
 
 	if logger.Enabled(log.LevelInfo) {

--- a/server/server.go
+++ b/server/server.go
@@ -113,6 +113,16 @@ type Server struct {
 	// otherwise. It is stopped after the raft node during shutdown; the
 	// pool it serves stands alone, so ordering is not load-bearing.
 	pdNode *cluster.PDNode
+	// regionMgr is the Phase 3 region metadata manager (nil when --cluster-mode
+	// is disabled). It persists region definitions in the PD etcd store and
+	// keeps routingTable converged via Watch.
+	regionMgr *cluster.RegionManager
+	// routingTable is the local, Watch-maintained view of region metadata used
+	// to route writes to the correct region leader. Nil when --cluster-mode is
+	// disabled.
+	routingTable *cluster.RoutingTable
+	// regionCancel stops the RegionManager goroutine on shutdown.
+	regionCancel context.CancelFunc
 }
 
 func NewServer(app *tellstone.App) *Server {
@@ -150,12 +160,7 @@ func (s *Server) Run() error {
 	if err = s.initAudit(key, cryptoEngine); err != nil {
 		return fmt.Errorf("audit init: %w", err)
 	}
-	// After initAudit so the engine has resolved the destination and the key
-	// that seals it, and before any listener starts so the restored history is
-	// in place by the time a client can read ACL LOG.
 	s.seedAuditReplay()
-	// Create the signal context before initShards so the snapshot loop
-	// can select on ctx.Done for clean shutdown.
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 	if err = s.initShards(key, cryptoEngine, ctx); err != nil {
@@ -166,11 +171,9 @@ func (s *Server) Run() error {
 			return fmt.Errorf("cluster init: %w", err)
 		}
 	}
-	// Wire the active store: cluster-aware when cluster mode is on, plain
-	// router otherwise. Both the binary and RESP frontends use this.
 	s.store = &s.rs
 	if s.raftNode != nil {
-		s.store = newClusterStore(&s.rs, s.raftNode, s.app.GetLogger())
+		s.store = newClusterStore(&s.rs, s.raftNode, s.routingTable, s.regionMgr, s.app.GetLogger())
 	}
 	s.netSrv = network.NewServer(
 		cfg.GetAddr(),
@@ -239,8 +242,6 @@ func (s *Server) Run() error {
 			logger.Log(log.LevelError, "server: tcp error", log.String("error", err.Error()))
 		}
 	}
-	// Stop the SIGHUP watcher so its goroutine exits with Run instead of
-	// lingering until the process dies.
 	signal.Stop(hup)
 	close(hup)
 	return err
@@ -367,24 +368,20 @@ func (s *Server) shutdown(ctx context.Context) {
 			logger.Log(log.LevelError, "server: tcp server shutdown error", log.String("error", err.Error()))
 		}
 	}
-	// Wait for the snapshot loop to finish so no Storage.Snapshot is
-	// in-flight when we close the shard engines. Use a select so we
-	// don't block forever if the context deadline is reached.
 	if s.snapshotDone != nil {
 		select {
 		case <-s.snapshotDone:
 		case <-ctx.Done():
 		}
 	}
-	// Stop the raft node before shards so no in-flight FSM apply can race
-	// a shard engine closure. Nil when cluster mode is disabled.
 	if s.raftNode != nil {
 		s.raftNode.Stop()
 	}
-	// Stop the PD/TSO stack after the raft node; the pool it serves is
-	// independent of the raft group, so this ordering is not load-bearing.
 	if s.pdNode != nil {
 		s.pdNode.Stop()
+	}
+	if s.regionCancel != nil {
+		s.regionCancel()
 	}
 	for _, sh := range s.shards {
 		if err := sh.Stop(ctx); err != nil {
@@ -761,6 +758,27 @@ func (s *Server) initCluster() error {
 		return fmt.Errorf("start placement driver: %w", err)
 	}
 	s.pdNode = pdNode
+	peerIDs := make([]uint64, len(peers))
+	for i, p := range peers {
+		peerIDs[i] = p.ID
+	}
+	rm := cluster.NewRegionManager(s.pdNode.Client(), cfg.GetNodeID(), s.raftNode, peerIDs)
+	if err = rm.BootstrapDefaultRegion(context.Background()); err != nil {
+		s.raftNode.Stop()
+		s.pdNode.Stop()
+		return fmt.Errorf("bootstrap default region: %w", err)
+	}
+	rmCtx, rmCancel := context.WithCancel(context.Background())
+	s.regionMgr = rm
+	s.regionCancel = rmCancel
+	s.routingTable = rm.RoutingTable()
+	go func() {
+		if rerr := rm.Run(rmCtx); rerr != nil && logger.Enabled(log.LevelError) {
+			logger.Log(log.LevelError, "server: region manager stopped",
+				log.String("error", rerr.Error()),
+			)
+		}
+	}()
 
 	if logger.Enabled(log.LevelInfo) {
 		logger.Log(log.LevelInfo, "server: cluster mode enabled",


### PR DESCRIPTION
## Description

add regional routing with write forward to the leader and read anywhere 
implemented routing table and regional routes with range/catch all lookup
RegionManager is persitent inside region 1 (always) and stored inside PD and etcd store 

**Component:** (e.g., Networking/RESP, Storage Engine, Router/Shard, CLI, Build/CI)

Cluster

**Type of Change:**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance optimization (no change in behavior, improved speed/memory)
- [ ] Refactoring (no functional changes, code cleanup)
- [ ] Build / CI / Documentation

---

## Related Issue

none

---

## How Has This Been Tested?

go test
go vet 
manual testing

---

## Checklist

- [x] My code follows the existing code style of this project
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally (`go test ./...` and `go test -race ./...`)
- [x] I have updated the documentation (README, comments, or any relevant docs)
- [x] My changes generate no new `go vet` warnings
- [ ] Any breaking changes are documented and communicated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added region-aware routing with a default region.
  * Writes sent to follower nodes are forwarded to the region leader.
  * Reads now provide linearizable consistency across cluster nodes.
  * Routing updates automatically track region leadership changes.
  * Added clear errors for unavailable, moved, or unready cluster routes.

* **Tests**
  * Added unit, integration, and manual coverage for routing, replication, failover, and follower operations.

* **Documentation**
  * Added the accepted Phase 3 routing design and verification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->